### PR TITLE
Bluesky replies as the site's comment section (+ interaction backfeed)

### DIFF
--- a/Resources/Template/src/lib/interactions.test.ts
+++ b/Resources/Template/src/lib/interactions.test.ts
@@ -95,6 +95,12 @@ test("author and content are optional", () => {
   assert.equal(all[0].content, undefined);
 });
 
+test("accepts type: bluesky", () => {
+  const all = parseInteractions(mods(raw({ id: "bsky-abc123", type: "bluesky" })));
+  assert.equal(all.length, 1);
+  assert.equal(all[0].type, "bluesky");
+});
+
 test("interactionsFor matches targets regardless of trailing slash", () => {
   const all = parseInteractions(
     mods(

--- a/Resources/Template/src/lib/interactions.ts
+++ b/Resources/Template/src/lib/interactions.ts
@@ -34,7 +34,7 @@ const httpUrl = z.string().url().refine(
 const interactionSchema = z.object({
   /// Path-traversal guard: same rule as ReceivedInteraction.swift's init.
   id: z.string().regex(/^[A-Za-z0-9_-]+$/),
-  type: z.enum(["webmention", "activitypub", "micropub"]),
+  type: z.enum(["webmention", "activitypub", "micropub", "bluesky"]),
   source: httpUrl,
   target: httpUrl,
   interactionType: z.enum(["reply", "like", "repost", "bookmark", "mention"]),

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -276,6 +276,12 @@ final class PreviewModel {
             // (SiteSettings.provisionedWorkerResources.d1DatabaseID unset).
             _ = await ReceivedInteractionSync.pullAndCommitIfConfigured(
                 siteDirectory: siteDirectory, configDirectory: configDirectory)
+            // #1236: pull replies/likes/reposts on every Bluesky-POSSE'd post from the public
+            // AppView and snapshot them alongside the webmention/AP interactions above. No-ops
+            // for sites that have never syndicated to Bluesky (no "bluesky" entry in the local
+            // POSSE ledger) — no Cloudflare token or provisioned Worker resource needed.
+            _ = await BlueskyBackfeedSync.pullAndCommitIfConfigured(
+                siteDirectory: siteDirectory, configDirectory: configDirectory)
             // #912: pull Micropub-created posts from MICROPUB_DB and sync each into a typed
             // content file under src/content/. No-ops for sites without a provisioned D1
             // database (same gate as ReceivedInteractionSync — Micropub shares the database).

--- a/Sources/AnglesiteCore/BlueskyBackfeedSync.swift
+++ b/Sources/AnglesiteCore/BlueskyBackfeedSync.swift
@@ -26,17 +26,26 @@ public enum BlueskyBackfeedSync {
         return ("at://\(components[2])/app.bsky.feed.post/\(components[4])", components[4])
     }
 
-    /// Maps one flattened reply to the git-canonical schema. `nil` only when
-    /// `ReceivedInteraction`'s own path-traversal guard rejects the derived id — not expected for
-    /// a real AT-proto rkey, but mirrors `ReceivedInteractionSync.makeInteraction`'s `try?` rather
-    /// than trusting the upstream shape unconditionally.
-    static func makeInteraction(from reply: BlueskyThreadClient.RawReply, target: URL, now: Date) -> ReceivedInteraction? {
-        try? ReceivedInteraction(
+    /// Maps one flattened reply to the git-canonical schema. `nil` when `ReceivedInteraction`'s
+    /// own path-traversal guard rejects the derived id (not expected for a real AT-proto rkey,
+    /// but mirrors `ReceivedInteractionSync.makeInteraction`'s `try?` rather than trusting the
+    /// upstream shape unconditionally), or when `urlBuilder` can't turn `authorHandle`/`rkey`
+    /// (untrusted AppView JSON) into a `URL` — skip this one reply rather than trap the process
+    /// on a force-unwrap, matching `BlueskyPOSSEClient.publicURL`'s guarded sibling in
+    /// `POSSEClients.swift`. `urlBuilder` defaults to `URL.init(string:)`; tests inject a
+    /// failing builder to exercise the guard without depending on Foundation ever actually
+    /// rejecting a given string.
+    static func makeInteraction(
+        from reply: BlueskyThreadClient.RawReply, target: URL, now: Date,
+        urlBuilder: (String) -> URL? = { URL(string: $0) }
+    ) -> ReceivedInteraction? {
+        guard let source = urlBuilder("https://bsky.app/profile/\(reply.authorHandle)/post/\(reply.rkey)") else { return nil }
+        return try? ReceivedInteraction(
             id: "bsky-\(reply.rkey)", type: .bluesky,
-            source: URL(string: "https://bsky.app/profile/\(reply.authorHandle)/post/\(reply.rkey)")!,
+            source: source,
             target: target, interactionType: .reply,
             author: .init(
-                name: reply.authorName, url: URL(string: "https://bsky.app/profile/\(reply.authorHandle)"),
+                name: reply.authorName, url: urlBuilder("https://bsky.app/profile/\(reply.authorHandle)"),
                 photo: reply.authorPhoto),
             content: String(reply.text.prefix(500)),
             published: reply.createdAt, verified: now, verificationStatus: .verified)
@@ -47,13 +56,15 @@ public enum BlueskyBackfeedSync {
     /// the target post, so `source` and `author.url` both fall back to the actor's own profile.
     /// `id` folds in `targetRkey` so the same actor liking two different tracked posts can't
     /// collide (`POSSEStableKey.make` already produces a `[0-9a-f]+` hash, a safe subset of the id
-    /// charset).
+    /// charset). `nil` when `urlBuilder` can't turn `actorHandle` into a `URL` — see the reply
+    /// overload's doc for why this guards instead of force-unwrapping.
     static func makeInteraction(
         from event: BlueskyThreadClient.RawActorEvent, interactionType: ReceivedInteraction.InteractionType,
-        targetRkey: String, target: URL, now: Date
+        targetRkey: String, target: URL, now: Date,
+        urlBuilder: (String) -> URL? = { URL(string: $0) }
     ) -> ReceivedInteraction? {
         let kind = interactionType == .like ? "like" : "repost"
-        let profileURL = URL(string: "https://bsky.app/profile/\(event.actorHandle)")!
+        guard let profileURL = urlBuilder("https://bsky.app/profile/\(event.actorHandle)") else { return nil }
         return try? ReceivedInteraction(
             id: "bsky-\(kind)-" + POSSEStableKey.make("\(targetRkey)\n\(event.actorDID)"), type: .bluesky,
             source: profileURL, target: target, interactionType: interactionType,
@@ -83,23 +94,76 @@ public enum BlueskyBackfeedSync {
         return out
     }
 
+    /// Carries `existing`'s `verified` (and, for reposts with no upstream timestamp, `published`)
+    /// forward onto `interaction` when nothing else about it changed, so a sync that finds no
+    /// real upstream change writes nothing. Without this, `verified: now` (stamped fresh on every
+    /// `makeInteraction` call, per site-open) would make every snapshot byte-different from what's
+    /// on disk every time, defeating `ReceivedInteractionCommitter.commit`'s byte-identical no-op
+    /// check and producing a spurious commit on every site-open forever (#1236 review finding 1).
+    /// Reads `siteDirectory/data/interactions/<id>.json` directly — the reuse decision has to
+    /// happen before `commit`'s own byte-identical check ever sees the candidate data, since that
+    /// check compares against what THIS call is about to write, not what varies within it.
+    private static func stabilized(_ interaction: ReceivedInteraction, siteDirectory: URL, fileManager: FileManager) -> ReceivedInteraction {
+        guard let data = fileManager.contents(atPath: siteDirectory.appendingPathComponent(interaction.gitPath).path)
+        else { return interaction }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let existing = try? decoder.decode(ReceivedInteraction.self, from: data),
+              let reusingExistingTimestamps = try? ReceivedInteraction(
+                  id: interaction.id, type: interaction.type, source: interaction.source, target: interaction.target,
+                  interactionType: interaction.interactionType, author: interaction.author, content: interaction.content,
+                  published: existing.published, verified: existing.verified, verificationStatus: interaction.verificationStatus),
+              reusingExistingTimestamps == existing
+        else { return interaction }
+        return reusingExistingTimestamps
+    }
+
+    /// Reads whatever bluesky-sourced snapshots already exist on disk for `entry`'s target.
+    /// `pullAndCommit` calls this only for an entry whose fetch hard-failed this round, so the
+    /// committer's scoped reconcile still sees these ids as "current" and doesn't delete them —
+    /// without this, a post whose fetch failed would drop out of the fresh set entirely and the
+    /// scoped reconcile would read that absence as "no longer present, delete" (#1236 review
+    /// finding 3).
+    private static func existingSnapshots(
+        for entry: POSSESyndicationLog.Entry, siteDirectory: URL, fileManager: FileManager
+    ) -> [ReceivedInteraction] {
+        let dir = siteDirectory.appendingPathComponent("data/interactions", isDirectory: true)
+        guard let files = try? fileManager.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil) else { return [] }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return files.compactMap { file -> ReceivedInteraction? in
+            guard file.pathExtension == "json", let data = fileManager.contents(atPath: file.path),
+                  let interaction = try? decoder.decode(ReceivedInteraction.self, from: data),
+                  interaction.type == .bluesky, interaction.target == entry.canonicalURL
+            else { return nil }
+            return interaction
+        }
+    }
+
     /// Pulls every Bluesky-syndicated entry's replies/likes/reposts and reconciles them into
-    /// `siteDirectory`. Returns 0 (never throws, never partially reconciles) if `ledger` has no
-    /// `"bluesky"` entries, or if *any* tracked post's fetch hard-fails — a transient failure on
-    /// one post must not be misread as "this post now has zero replies" and wipe its real,
-    /// previously-fetched snapshots (see the design doc's failure-handling section).
+    /// `siteDirectory`. Returns 0 (never throws) if `ledger` has no `"bluesky"` entries. A
+    /// transient failure on one tracked post's fetch no longer aborts the whole pass (#1236
+    /// review finding 3): that entry is skipped for this round — contributing no new
+    /// interactions, but also not losing whatever snapshots it already has on disk (see
+    /// `existingSnapshots`) — while every other entry still fetches and commits normally. The
+    /// return value is the number of ids actually written or deleted this round (from entries
+    /// that succeeded); an entry whose fetch failed contributes nothing to that count either way,
+    /// since its on-disk files are carried forward unchanged.
     public static func pullAndCommit(
         ledger: POSSESyndicationLog, siteDirectory: URL,
         transport: BlueskyThreadClient.Transport = BlueskyThreadClient.defaultTransport,
-        now: Date = Date()
+        now: Date = Date(), fileManager: FileManager = .default
     ) async -> Int {
         let entries = ledger.entries.filter { $0.platform == "bluesky" }
         guard !entries.isEmpty else { return 0 }
 
         var all: [ReceivedInteraction] = []
         for entry in entries {
-            guard let interactions = await Self.interactions(for: entry, transport: transport, now: now) else { return 0 }
-            all.append(contentsOf: interactions)
+            if let interactions = await Self.interactions(for: entry, transport: transport, now: now) {
+                all.append(contentsOf: interactions.map { Self.stabilized($0, siteDirectory: siteDirectory, fileManager: fileManager) })
+            } else {
+                all.append(contentsOf: Self.existingSnapshots(for: entry, siteDirectory: siteDirectory, fileManager: fileManager))
+            }
         }
         let committedIDs = await ReceivedInteractionCommitter.commit(interactions: all, scopedTo: [.bluesky], into: siteDirectory)
         return committedIDs.count

--- a/Sources/AnglesiteCore/BlueskyBackfeedSync.swift
+++ b/Sources/AnglesiteCore/BlueskyBackfeedSync.swift
@@ -1,0 +1,119 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Orchestrates #1236's "pull the Bluesky replies/likes/reposts of every POSSE'd post and snapshot
+/// them into the site's git working copy" step, mirroring `ReceivedInteractionSync`'s shape but
+/// reading `POSSESyndicationLog` (the local POSSE ledger) instead of a Worker's D1 database — no
+/// Cloudflare token or provisioned Worker resource is needed, since Bluesky's `getPostThread`/
+/// `getLikes`/`getRepostedBy` are public, unauthenticated AppView endpoints (same trust posture as
+/// `AnnouncedPostSync`'s outbox fetch). Designed to be called once per site-open
+/// (`PreviewModel.open(site:)`), alongside the other per-site syncs.
+///
+/// See `docs/superpowers/specs/2026-08-17-bluesky-replies-comment-section-design.md` for the full
+/// design, including why `ReceivedInteractionCommitter.commit` needed a `scopedTo` parameter for
+/// this to share `data/interactions/` safely with `ReceivedInteractionSync`.
+public enum BlueskyBackfeedSync {
+    /// Derives the `at://` URI (and the post's own rkey) `BlueskyThreadClient` needs from a
+    /// `POSSESyndicationLog.Entry.syndicationURL` — the Bluesky permalink
+    /// `https://bsky.app/profile/<handle>/post/<rkey>` `BlueskyPOSSEClient.publicURL` produces
+    /// (`Sources/AnglesiteCore/POSSEClients.swift`). `nil` for anything not shaped like that
+    /// permalink — the entry is simply skipped rather than guessed at.
+    static func atURI(from syndicationURL: URL) -> (uri: String, rkey: String)? {
+        let components = syndicationURL.pathComponents
+        guard components.count == 5, components[1] == "profile", components[3] == "post" else { return nil }
+        return ("at://\(components[2])/app.bsky.feed.post/\(components[4])", components[4])
+    }
+
+    /// Maps one flattened reply to the git-canonical schema. `nil` only when
+    /// `ReceivedInteraction`'s own path-traversal guard rejects the derived id — not expected for
+    /// a real AT-proto rkey, but mirrors `ReceivedInteractionSync.makeInteraction`'s `try?` rather
+    /// than trusting the upstream shape unconditionally.
+    static func makeInteraction(from reply: BlueskyThreadClient.RawReply, target: URL, now: Date) -> ReceivedInteraction? {
+        try? ReceivedInteraction(
+            id: "bsky-\(reply.rkey)", type: .bluesky,
+            source: URL(string: "https://bsky.app/profile/\(reply.authorHandle)/post/\(reply.rkey)")!,
+            target: target, interactionType: .reply,
+            author: .init(
+                name: reply.authorName, url: URL(string: "https://bsky.app/profile/\(reply.authorHandle)"),
+                photo: reply.authorPhoto),
+            content: String(reply.text.prefix(500)),
+            published: reply.createdAt, verified: now, verificationStatus: .verified)
+    }
+
+    /// Maps one like/repost. Bluesky has no distinct per-like/-repost resource URL (unlike a
+    /// webmention `like-of`/`repost-of` post) — the interaction *is* the actor's relationship to
+    /// the target post, so `source` and `author.url` both fall back to the actor's own profile.
+    /// `id` folds in `targetRkey` so the same actor liking two different tracked posts can't
+    /// collide (`POSSEStableKey.make` already produces a `[0-9a-f]+` hash, a safe subset of the id
+    /// charset).
+    static func makeInteraction(
+        from event: BlueskyThreadClient.RawActorEvent, interactionType: ReceivedInteraction.InteractionType,
+        targetRkey: String, target: URL, now: Date
+    ) -> ReceivedInteraction? {
+        let kind = interactionType == .like ? "like" : "repost"
+        let profileURL = URL(string: "https://bsky.app/profile/\(event.actorHandle)")!
+        return try? ReceivedInteraction(
+            id: "bsky-\(kind)-" + POSSEStableKey.make("\(targetRkey)\n\(event.actorDID)"), type: .bluesky,
+            source: profileURL, target: target, interactionType: interactionType,
+            author: .init(name: event.actorName, url: profileURL, photo: event.actorPhoto),
+            content: nil, published: event.createdAt ?? now, verified: now, verificationStatus: .verified)
+    }
+
+    /// One tracked post's full result set, or `nil` if any of its three fetches hard-failed.
+    private static func interactions(
+        for entry: POSSESyndicationLog.Entry, transport: BlueskyThreadClient.Transport, now: Date
+    ) async -> [ReceivedInteraction]? {
+        guard let (atURI, rkey) = Self.atURI(from: entry.syndicationURL) else { return [] }
+        async let repliesTask = BlueskyThreadClient.fetchReplies(atURI: atURI, transport: transport)
+        async let likesTask = BlueskyThreadClient.fetchLikes(atURI: atURI, transport: transport)
+        async let repostsTask = BlueskyThreadClient.fetchReposts(atURI: atURI, transport: transport)
+        guard let replies = await repliesTask, let likes = await likesTask, let reposts = await repostsTask
+        else { return nil }
+
+        var out: [ReceivedInteraction] = []
+        out.append(contentsOf: replies.compactMap { Self.makeInteraction(from: $0, target: entry.canonicalURL, now: now) })
+        out.append(contentsOf: likes.compactMap {
+            Self.makeInteraction(from: $0, interactionType: .like, targetRkey: rkey, target: entry.canonicalURL, now: now)
+        })
+        out.append(contentsOf: reposts.compactMap {
+            Self.makeInteraction(from: $0, interactionType: .repost, targetRkey: rkey, target: entry.canonicalURL, now: now)
+        })
+        return out
+    }
+
+    /// Pulls every Bluesky-syndicated entry's replies/likes/reposts and reconciles them into
+    /// `siteDirectory`. Returns 0 (never throws, never partially reconciles) if `ledger` has no
+    /// `"bluesky"` entries, or if *any* tracked post's fetch hard-fails — a transient failure on
+    /// one post must not be misread as "this post now has zero replies" and wipe its real,
+    /// previously-fetched snapshots (see the design doc's failure-handling section).
+    public static func pullAndCommit(
+        ledger: POSSESyndicationLog, siteDirectory: URL,
+        transport: BlueskyThreadClient.Transport = BlueskyThreadClient.defaultTransport,
+        now: Date = Date()
+    ) async -> Int {
+        let entries = ledger.entries.filter { $0.platform == "bluesky" }
+        guard !entries.isEmpty else { return 0 }
+
+        var all: [ReceivedInteraction] = []
+        for entry in entries {
+            guard let interactions = await Self.interactions(for: entry, transport: transport, now: now) else { return 0 }
+            all.append(contentsOf: interactions)
+        }
+        let committedIDs = await ReceivedInteractionCommitter.commit(interactions: all, scopedTo: [.bluesky], into: siteDirectory)
+        return committedIDs.count
+    }
+
+    /// Reads the site's POSSE ledger from `configDirectory`; no-ops (returns 0, no network call)
+    /// when the site has never syndicated to Bluesky. `configDirectory` is the package's `Config/`
+    /// directory (`AnglesitePackage.configURL`), a sibling of `siteDirectory`
+    /// (`AnglesitePackage.sourceURL`).
+    public static func pullAndCommitIfConfigured(
+        siteDirectory: URL, configDirectory: URL,
+        transport: BlueskyThreadClient.Transport = BlueskyThreadClient.defaultTransport
+    ) async -> Int {
+        guard let ledger = POSSESyndicationLog.load(from: configDirectory) else { return 0 }
+        return await pullAndCommit(ledger: ledger, siteDirectory: siteDirectory, transport: transport)
+    }
+}

--- a/Sources/AnglesiteCore/BlueskyThreadClient.swift
+++ b/Sources/AnglesiteCore/BlueskyThreadClient.swift
@@ -25,6 +25,12 @@ public enum BlueskyThreadClient {
     /// API gives no truncation marker past this depth to detect and log against.
     static let threadDepth = 100
 
+    /// Likes/reposts are paginated 100 at a time, up to this many pages — a generous, fixed cap
+    /// rather than trusting a peer-controlled `cursor` chain to terminate, matching
+    /// `AnnouncedPostSync.OutboxClient`'s own paging cap.
+    static let maximumPages = 20
+    static let pageSize = 100
+
     private static let session = CappedHTTPTransport.session(requestTimeout: timeout, resourceTimeout: resourceTimeout)
 
     /// Production transport — public so callers (`BlueskyBackfeedSync`, tests) can inject a fake,
@@ -44,6 +50,18 @@ public enum BlueskyThreadClient {
         let authorPhoto: URL?
         let text: String
         let createdAt: Date
+    }
+
+    /// One like or repost, before mapping to `ReceivedInteraction`.
+    struct RawActorEvent: Sendable, Equatable {
+        let actorDID: String
+        let actorHandle: String
+        let actorName: String?
+        let actorPhoto: URL?
+        /// `nil` when the endpoint exposes no per-item timestamp — observed on `getRepostedBy`,
+        /// whose items are bare actor profiles with no `createdAt` of their own. The caller falls
+        /// back to sync time rather than inventing a value.
+        let createdAt: Date?
     }
 
     private static let iso8601 = ISO8601DateFormatter()
@@ -105,6 +123,58 @@ public enum BlueskyThreadClient {
         for child in (node["replies"] as? [[String: Any]]) ?? [] {
             flattenReplies(child, into: &results)
         }
+    }
+
+    /// Extracts one page of actor events from a `getLikes`/`getRepostedBy` response. `itemsKey` is
+    /// `"likes"` (each item wraps `{actor, createdAt}`) or `"repostedBy"` (each item *is* the
+    /// actor profile directly) — `item["actor"] ?? item` handles both shapes with one function.
+    static func makeActorEvents(from json: [String: Any], itemsKey: String) -> [RawActorEvent] {
+        let items = (json[itemsKey] as? [[String: Any]]) ?? []
+        return items.compactMap { item -> RawActorEvent? in
+            let actor = (item["actor"] as? [String: Any]) ?? item
+            guard let did = actor["did"] as? String, let handle = actor["handle"] as? String else { return nil }
+            return RawActorEvent(
+                actorDID: did, actorHandle: handle, actorName: actor["displayName"] as? String,
+                actorPhoto: (actor["avatar"] as? String).flatMap(URL.init(string:)),
+                createdAt: parseDate(item["createdAt"]))
+        }
+    }
+
+    /// Shared paging loop for `fetchLikes`/`fetchReposts`: follows `cursor` up to `maximumPages`,
+    /// stopping early once a page returns no cursor. Returns `nil` only on the *first* page's hard
+    /// failure — once at least one page has been read successfully, a later page failing mid-walk
+    /// still returns what was gathered so far, since a partial-but-real list is more useful than
+    /// discarding it, and a missed later page just means an undercount until the next site-open
+    /// retries (unlike `fetchReplies`'s all-or-nothing failure, this never has to decide "zero or
+    /// retry" for the whole post — see `BlueskyBackfeedSync`'s own all-or-nothing gate for that).
+    private static func paginate(
+        endpoint: String, atURI: String, itemsKey: String, transport: Transport
+    ) async -> [RawActorEvent]? {
+        var results: [RawActorEvent] = []
+        var cursor: String?
+        var page = 0
+        var fetchedAnyPage = false
+        repeat {
+            var items = [URLQueryItem(name: "uri", value: atURI), URLQueryItem(name: "limit", value: String(pageSize))]
+            if let cursor { items.append(URLQueryItem(name: "cursor", value: cursor)) }
+            guard let url = Self.url(path: endpoint, queryItems: items),
+                  let (data, http) = try? await transport(URLRequest(url: url)), (200..<300).contains(http.statusCode),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return fetchedAnyPage ? results : nil }
+            fetchedAnyPage = true
+            results.append(contentsOf: makeActorEvents(from: json, itemsKey: itemsKey))
+            cursor = json["cursor"] as? String
+            page += 1
+        } while cursor != nil && page < maximumPages
+        return results
+    }
+
+    static func fetchLikes(atURI: String, transport: Transport) async -> [RawActorEvent]? {
+        await paginate(endpoint: "app.bsky.feed.getLikes", atURI: atURI, itemsKey: "likes", transport: transport)
+    }
+
+    static func fetchReposts(atURI: String, transport: Transport) async -> [RawActorEvent]? {
+        await paginate(endpoint: "app.bsky.feed.getRepostedBy", atURI: atURI, itemsKey: "repostedBy", transport: transport)
     }
 
     private static func url(path: String, queryItems: [URLQueryItem]) -> URL? {

--- a/Sources/AnglesiteCore/BlueskyThreadClient.swift
+++ b/Sources/AnglesiteCore/BlueskyThreadClient.swift
@@ -1,0 +1,145 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Unauthenticated reader for Bluesky's public AppView (#1236): pulls the reply thread, likes,
+/// and reposts of a POSSE'd post so `BlueskyBackfeedSync` can snapshot them into
+/// `data/interactions/` per the received-interaction canonicality design
+/// (`docs/specs/2026-06-29-c3-received-interaction-canonicality.md`). No app password or session
+/// is needed — `public.api.bsky.app` serves `getPostThread`/`getLikes`/`getRepostedBy` to anyone,
+/// the same trust posture the inline-embed fetch in
+/// `Resources/Template/scripts/embeds/adapters.ts` already relies on for Bluesky link cards.
+/// See `docs/superpowers/specs/2026-08-17-bluesky-replies-comment-section-design.md`.
+public enum BlueskyThreadClient {
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    static let timeout: TimeInterval = 10
+    static let resourceTimeout: TimeInterval = 20
+    /// A thread with many replies (or a heavily-liked post) can be sizeable; generous but bounded
+    /// — the same "cap a third-party response, don't trust it blindly" posture
+    /// `CappedHTTPTransport`'s other callers (`ActorProfileFetcher`, `AnnouncedPostSync.OutboxClient`) use.
+    static let maximumResponseBytes = 4 * 1024 * 1024
+    /// How deep into nested replies-to-replies `getPostThread` is asked to walk. Comfortably
+    /// beyond any realistic blog-comment thread; deeper nesting is a documented limitation — the
+    /// API gives no truncation marker past this depth to detect and log against.
+    static let threadDepth = 100
+
+    private static let session = CappedHTTPTransport.session(requestTimeout: timeout, resourceTimeout: resourceTimeout)
+
+    /// Production transport — public so callers (`BlueskyBackfeedSync`, tests) can inject a fake,
+    /// matching `AnnouncedPostSync.defaultTransport`'s own rationale.
+    public static let defaultTransport: Transport = { request in
+        try await CappedHTTPTransport.fetch(
+            request, session: session, cap: maximumResponseBytes,
+            tooLarge: { _ in URLError(.dataLengthExceedsMaximum) })
+    }
+
+    /// One reply flattened out of a `getPostThread` tree, before mapping to `ReceivedInteraction`
+    /// (which needs a `target` this client has no reason to know about).
+    struct RawReply: Sendable, Equatable {
+        let rkey: String
+        let authorHandle: String
+        let authorName: String?
+        let authorPhoto: URL?
+        let text: String
+        let createdAt: Date
+    }
+
+    private static let iso8601 = ISO8601DateFormatter()
+    private static let iso8601Fractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    /// Bluesky timestamps are ISO 8601 with fractional seconds (`...000Z`); tries the fractional
+    /// formatter first and falls back to the plain one rather than assuming either shape.
+    private static func parseDate(_ raw: Any?) -> Date? {
+        guard let string = raw as? String else { return nil }
+        return iso8601Fractional.date(from: string) ?? iso8601.date(from: string)
+    }
+
+    private static let adultLabels: Set<String> = ["porn", "sexual", "nudity", "graphic-media"]
+
+    /// Whether `post` (a `getPostThread` node's `post` object) carries any label — AppView-applied
+    /// or self-applied — this codebase treats as adult content. `Interactions.astro` has no
+    /// content-warning UI to gate display on, so such a reply is excluded entirely rather than
+    /// rendered.
+    static func isAdultLabeled(_ post: [String: Any]) -> Bool {
+        let appViewLabels = (post["labels"] as? [[String: Any]]) ?? []
+        if appViewLabels.contains(where: { adultLabels.contains(($0["val"] as? String) ?? "") }) {
+            return true
+        }
+        let record = post["record"] as? [String: Any]
+        let selfLabels = (record?["labels"] as? [String: Any])?["values"] as? [[String: Any]] ?? []
+        return selfLabels.contains { adultLabels.contains(($0["val"] as? String) ?? "") }
+    }
+
+    /// Extracts a `RawReply` from a `getPostThread` node's `post` object, or `nil` if it's missing
+    /// a field this schema requires — a malformed/unexpected AppView response shouldn't crash the
+    /// whole sync, just skip this one reply.
+    static func makeRawReply(from post: [String: Any]) -> RawReply? {
+        guard let uri = post["uri"] as? String, let rkey = uri.split(separator: "/").last,
+              let author = post["author"] as? [String: Any], let handle = author["handle"] as? String,
+              let record = post["record"] as? [String: Any], let text = record["text"] as? String,
+              let createdAt = parseDate(record["createdAt"])
+        else { return nil }
+        return RawReply(
+            rkey: String(rkey), authorHandle: handle, authorName: author["displayName"] as? String,
+            authorPhoto: (author["avatar"] as? String).flatMap(URL.init(string:)),
+            text: text, createdAt: createdAt)
+    }
+
+    /// Recursively flattens every reply under `node` (a `getPostThread` thread or reply object)
+    /// into `results`, depth-first. Skips `#blockedPost`/`#notFoundPost` branches (Bluesky-side
+    /// moderation/deletion — see the design doc) and adult-labeled posts, but still walks an
+    /// adult-labeled post's own children (their labels are independent of their parent's).
+    static func flattenReplies(_ node: [String: Any], into results: inout [RawReply]) {
+        guard (node["$type"] as? String) == "app.bsky.feed.defs#threadViewPost",
+              let post = node["post"] as? [String: Any]
+        else { return }
+        if !isAdultLabeled(post), let reply = makeRawReply(from: post) {
+            results.append(reply)
+        }
+        for child in (node["replies"] as? [[String: Any]]) ?? [] {
+            flattenReplies(child, into: &results)
+        }
+    }
+
+    private static func url(path: String, queryItems: [URLQueryItem]) -> URL? {
+        var components = URLComponents(string: "https://public.api.bsky.app/xrpc/\(path)")
+        components?.queryItems = queryItems
+        return components?.url
+    }
+
+    /// Fetches and flattens every reply under `atURI`'s thread, at any depth. Returns `nil` on any
+    /// hard failure (network error, non-2xx, undecodable body) — callers must treat `nil` as
+    /// "retry next time," never as "zero replies," since a root post that's genuinely gone comes
+    /// back as a *successful* response whose `thread` is `#notFoundPost`/`#blockedPost` (handled
+    /// here as an empty result, not a `nil` one).
+    ///
+    /// **Important:** this walks `thread["replies"]`, not `thread` itself. `thread["post"]` is the
+    /// *tracked post's own copy* (the same post `atURI` names) — `flattenReplies` on `thread`
+    /// directly would append the owner's own post as if it were a reply to itself. Each element of
+    /// `thread["replies"]`, by contrast, genuinely is a reply — that's where `flattenReplies`
+    /// (append this node's post, recurse into its own nested `replies`) is the correct walk.
+    static func fetchReplies(atURI: String, transport: Transport) async -> [RawReply]? {
+        guard let url = Self.url(path: "app.bsky.feed.getPostThread", queryItems: [
+            URLQueryItem(name: "uri", value: atURI),
+            URLQueryItem(name: "depth", value: String(threadDepth)),
+            URLQueryItem(name: "parentHeight", value: "0"),
+        ]) else { return nil }
+        guard let (data, http) = try? await transport(URLRequest(url: url)), (200..<300).contains(http.statusCode)
+        else { return nil }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let thread = json["thread"] as? [String: Any]
+        else { return nil }
+        guard (thread["$type"] as? String) == "app.bsky.feed.defs#threadViewPost" else { return [] }
+        var results: [RawReply] = []
+        for child in (thread["replies"] as? [[String: Any]]) ?? [] {
+            flattenReplies(child, into: &results)
+        }
+        return results
+    }
+}

--- a/Sources/AnglesiteCore/BlueskyThreadClient.swift
+++ b/Sources/AnglesiteCore/BlueskyThreadClient.swift
@@ -104,7 +104,8 @@ public enum BlueskyThreadClient {
               let createdAt = parseDate(record["createdAt"])
         else { return nil }
         return RawReply(
-            rkey: String(rkey), authorHandle: handle, authorName: author["displayName"] as? String,
+            rkey: String(rkey), authorHandle: handle,
+            authorName: (author["displayName"] as? String) ?? handle,
             authorPhoto: (author["avatar"] as? String).flatMap(URL.init(string:)),
             text: text, createdAt: createdAt)
     }
@@ -134,34 +135,33 @@ public enum BlueskyThreadClient {
             let actor = (item["actor"] as? [String: Any]) ?? item
             guard let did = actor["did"] as? String, let handle = actor["handle"] as? String else { return nil }
             return RawActorEvent(
-                actorDID: did, actorHandle: handle, actorName: actor["displayName"] as? String,
+                actorDID: did, actorHandle: handle,
+                actorName: (actor["displayName"] as? String) ?? handle,
                 actorPhoto: (actor["avatar"] as? String).flatMap(URL.init(string:)),
                 createdAt: parseDate(item["createdAt"]))
         }
     }
 
     /// Shared paging loop for `fetchLikes`/`fetchReposts`: follows `cursor` up to `maximumPages`,
-    /// stopping early once a page returns no cursor. Returns `nil` only on the *first* page's hard
-    /// failure — once at least one page has been read successfully, a later page failing mid-walk
-    /// still returns what was gathered so far, since a partial-but-real list is more useful than
-    /// discarding it, and a missed later page just means an undercount until the next site-open
-    /// retries (unlike `fetchReplies`'s all-or-nothing failure, this never has to decide "zero or
-    /// retry" for the whole post — see `BlueskyBackfeedSync`'s own all-or-nothing gate for that).
+    /// stopping early once a page returns no cursor. Returns `nil` on *any* page's hard failure,
+    /// first or later — a later-page failure must not return the partial results gathered so far,
+    /// since `BlueskyBackfeedSync` treats a non-`nil` result as "this is the complete, current
+    /// set" and hands it straight to the committer's scoped reconcile: a partial set there would
+    /// read the unfetched remainder as "no longer present" and delete real, still-current
+    /// likes/reposts. All-or-nothing here matches `fetchReplies`'s own failure contract.
     private static func paginate(
         endpoint: String, atURI: String, itemsKey: String, transport: Transport
     ) async -> [RawActorEvent]? {
         var results: [RawActorEvent] = []
         var cursor: String?
         var page = 0
-        var fetchedAnyPage = false
         repeat {
             var items = [URLQueryItem(name: "uri", value: atURI), URLQueryItem(name: "limit", value: String(pageSize))]
             if let cursor { items.append(URLQueryItem(name: "cursor", value: cursor)) }
             guard let url = Self.url(path: endpoint, queryItems: items),
                   let (data, http) = try? await transport(URLRequest(url: url)), (200..<300).contains(http.statusCode),
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else { return fetchedAnyPage ? results : nil }
-            fetchedAnyPage = true
+            else { return nil }
             results.append(contentsOf: makeActorEvents(from: json, itemsKey: itemsKey))
             cursor = json["cursor"] as? String
             page += 1

--- a/Sources/AnglesiteCore/ReceivedInteraction.swift
+++ b/Sources/AnglesiteCore/ReceivedInteraction.swift
@@ -20,6 +20,9 @@ public struct ReceivedInteraction: Codable, Sendable, Equatable, Identifiable {
         case activitypub
         /// Created through the site's Micropub endpoint.
         case micropub
+        /// Pulled from Bluesky's public AppView — a reply, like, or repost on the owner's POSSE'd
+        /// copy of this post (#1236), not delivered to any endpoint of ours.
+        case bluesky
     }
 
     /// What kind of interaction this represents.

--- a/Sources/AnglesiteCore/ReceivedInteractionCommitter.swift
+++ b/Sources/AnglesiteCore/ReceivedInteractionCommitter.swift
@@ -8,6 +8,8 @@ import Foundation
 /// operational store (there's nothing to delete from it after a successful commit), so a stale
 /// snapshot file — one whose interaction was later unverified or its source deleted — must be
 /// removed on the next reconcile too, per the design doc's "sender-side delete" behavior.
+/// Two independent sources can share this directory safely via `commit`'s `scopedTo` parameter —
+/// see `docs/superpowers/specs/2026-08-17-bluesky-replies-comment-section-design.md`.
 public enum ReceivedInteractionCommitter {
     /// JSON encoding for one interaction's snapshot file: sorted keys (stable, clean diffs) and
     /// ISO 8601 dates, matching the Astro template's zod schema
@@ -18,6 +20,22 @@ public enum ReceivedInteractionCommitter {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
         return try encoder.encode(interaction)
+    }
+
+    /// Whether an existing snapshot file's own decoded `type` is in `protocolTypes` — scopes
+    /// staleness deletion so two independent sources sharing `data/interactions/` (#1236 adds a
+    /// second one, the Bluesky backfeed, alongside the existing webmention/AP sync) don't delete
+    /// each other's files. A file that fails to decode (malformed, or hand-authored without a
+    /// recognized `type`) is treated as out of scope — never deleted by a source that can't
+    /// identify it as its own.
+    private static func isInScope(
+        _ file: URL, protocolTypes: Set<ReceivedInteraction.ProtocolType>, fileManager: FileManager
+    ) -> Bool {
+        struct TypeOnly: Decodable { let type: ReceivedInteraction.ProtocolType }
+        guard let data = fileManager.contents(atPath: file.path),
+              let decoded = try? JSONDecoder().decode(TypeOnly.self, from: data)
+        else { return false }
+        return protocolTypes.contains(decoded.type)
     }
 
     /// Reconciles `data/interactions/` under `siteDirectory` against `interactions` (the full,
@@ -35,6 +53,7 @@ public enum ReceivedInteractionCommitter {
     @discardableResult
     public static func commit(
         interactions: [ReceivedInteraction],
+        scopedTo protocolTypes: Set<ReceivedInteraction.ProtocolType>? = nil,
         into siteDirectory: URL,
         fileManager: FileManager = .default,
         gitCommitBatch: @Sendable (URL, [String], String) async -> String? = InboxSubmissionCommitter.processGitCommitBatch
@@ -50,6 +69,7 @@ public enum ReceivedInteractionCommitter {
         for file in existingFiles where file.pathExtension == "json" {
             let id = file.deletingPathExtension().lastPathComponent
             guard !currentIDs.contains(id) else { continue }
+            if let protocolTypes, !Self.isInScope(file, protocolTypes: protocolTypes, fileManager: fileManager) { continue }
             guard (try? fileManager.removeItem(at: file)) != nil else { continue }
             relPaths.append("data/interactions/\(id).json")
             deletedIDs.append(id)

--- a/Sources/AnglesiteCore/ReceivedInteractionSync.swift
+++ b/Sources/AnglesiteCore/ReceivedInteractionSync.swift
@@ -46,7 +46,8 @@ public enum ReceivedInteractionSync {
     public static func pullAndCommit(client: WebmentionInboxD1Client, siteDirectory: URL) async -> Int {
         guard let mentions = try? await client.listVerifiedMentions() else { return 0 }
         let interactions = mentions.compactMap(Self.makeInteraction(from:))
-        let committedIDs = await ReceivedInteractionCommitter.commit(interactions: interactions, into: siteDirectory)
+        let committedIDs = await ReceivedInteractionCommitter.commit(
+            interactions: interactions, scopedTo: [.webmention], into: siteDirectory)
         return committedIDs.count
     }
 

--- a/Tests/AnglesiteCoreTests/BlueskyBackfeedSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/BlueskyBackfeedSyncTests.swift
@@ -137,6 +137,114 @@ struct BlueskyBackfeedSyncTests {
         #expect(FileManager.default.fileExists(atPath: siteDirectory.appendingPathComponent("data/interactions/wm-abc123.json").path))
     }
 
+    @Test("pullAndCommit still commits a different post's fresh replies when one tracked post's fetch hard-fails")
+    func partialFailureStillCommitsOtherPosts() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let ledger = POSSESyndicationLog(entries: [
+            .init(sourceFile: "src/content/blog/broken.md", canonicalURL: URL(string: "https://me.example/blog/broken")!,
+                  platform: "bluesky", syndicationURL: URL(string: "https://bsky.app/profile/me.example/post/3broken")!, postedAt: Date()),
+            .init(sourceFile: "src/content/blog/ok.md", canonicalURL: URL(string: "https://me.example/blog/ok")!,
+                  platform: "bluesky", syndicationURL: URL(string: "https://bsky.app/profile/me.example/post/3ok")!, postedAt: Date()),
+        ])
+
+        let okThreadBody = Data("""
+        {"thread": {"$type": "app.bsky.feed.defs#threadViewPost",
+          "post": {"uri": "at://me.example/app.bsky.feed.post/3ok", "author": {"did": "did:plc:me", "handle": "me.example"},
+                    "record": {"text": "my other post", "createdAt": "2026-08-01T09:00:00.000Z"}},
+          "replies": [{"$type": "app.bsky.feed.defs#threadViewPost",
+            "post": {"uri": "at://bob.bsky.social/app.bsky.feed.post/3bbb",
+                      "author": {"did": "did:plc:bob", "handle": "bob.bsky.social"},
+                      "record": {"text": "nice!", "createdAt": "2026-08-01T10:00:00.000Z"}}, "replies": []}]}}
+        """.utf8)
+
+        let count = await BlueskyBackfeedSync.pullAndCommit(ledger: ledger, siteDirectory: siteDirectory, transport: { request in
+            let query = request.url?.query ?? ""
+            let path = request.url?.path ?? ""
+            if query.contains("3broken") { return (Data(), Self.response(500)) }
+            if path.hasSuffix("getPostThread") { return (okThreadBody, Self.response(200)) }
+            if path.hasSuffix("getLikes") { return (Self.emptyLikesBody(), Self.response(200)) }
+            if path.hasSuffix("getRepostedBy") { return (Self.emptyRepostsBody(), Self.response(200)) }
+            return (Data(), Self.response(404))
+        })
+        #expect(count == 1)
+        #expect(FileManager.default.fileExists(atPath: siteDirectory.appendingPathComponent("data/interactions/bsky-3bbb.json").path))
+    }
+
+    @Test("pullAndCommit is a true no-op on a second call with unchanged upstream data, even as verified/published sync time advances")
+    func secondSyncWithUnchangedDataIsNoOp() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let ledger = POSSESyndicationLog(entries: [.init(
+            sourceFile: "src/content/blog/hi.md", canonicalURL: URL(string: "https://me.example/blog/hi")!,
+            platform: "bluesky", syndicationURL: URL(string: "https://bsky.app/profile/me.example/post/3root")!, postedAt: Date())])
+
+        let threadBody = Data("""
+        {"thread": {"$type": "app.bsky.feed.defs#threadViewPost",
+          "post": {"uri": "at://me.example/app.bsky.feed.post/3root", "author": {"did": "did:plc:me", "handle": "me.example"},
+                    "record": {"text": "my post", "createdAt": "2026-08-01T09:00:00.000Z"}},
+          "replies": [{"$type": "app.bsky.feed.defs#threadViewPost",
+            "post": {"uri": "at://alice.bsky.social/app.bsky.feed.post/3abc",
+                      "author": {"did": "did:plc:alice", "handle": "alice.bsky.social", "displayName": "Alice"},
+                      "record": {"text": "great post!", "createdAt": "2026-08-01T10:00:00.000Z"}}, "replies": []}]}}
+        """.utf8)
+        // A repost has no per-item createdAt, so `published` is stamped from `now` too — this
+        // exercises both halves of finding 1's fix (verified always stamped from `now`, and
+        // published additionally stamped from `now` for reposts).
+        let repostsBody = Data(#"{"uri": "x", "repostedBy": [{"did": "did:plc:erin", "handle": "erin.bsky.social"}]}"#.utf8)
+
+        let transport: BlueskyThreadClient.Transport = { request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("getPostThread") { return (threadBody, Self.response(200)) }
+            if path.hasSuffix("getLikes") { return (Self.emptyLikesBody(), Self.response(200)) }
+            if path.hasSuffix("getRepostedBy") { return (repostsBody, Self.response(200)) }
+            return (Data(), Self.response(404))
+        }
+
+        let firstCount = await BlueskyBackfeedSync.pullAndCommit(
+            ledger: ledger, siteDirectory: siteDirectory, transport: transport, now: Date(timeIntervalSince1970: 1_000_000))
+        #expect(firstCount == 2)
+
+        let replyFile = siteDirectory.appendingPathComponent("data/interactions/bsky-3abc.json")
+        let repostFiles = try FileManager.default.contentsOfDirectory(atPath: siteDirectory.appendingPathComponent("data/interactions").path)
+            .filter { $0.hasPrefix("bsky-repost-") }
+        #expect(repostFiles.count == 1)
+        let repostFile = siteDirectory.appendingPathComponent("data/interactions/\(repostFiles[0])")
+        let replyBytesBeforeSecondSync = try Data(contentsOf: replyFile)
+        let repostBytesBeforeSecondSync = try Data(contentsOf: repostFile)
+
+        let secondCount = await BlueskyBackfeedSync.pullAndCommit(
+            ledger: ledger, siteDirectory: siteDirectory, transport: transport, now: Date(timeIntervalSince1970: 2_000_000))
+        #expect(secondCount == 0)
+        #expect(try Data(contentsOf: replyFile) == replyBytesBeforeSecondSync)
+        #expect(try Data(contentsOf: repostFile) == repostBytesBeforeSecondSync)
+    }
+
+    // MARK: - makeInteraction URL guards
+
+    @Test("makeInteraction(from reply:) skips the reply rather than crashing when urlBuilder can't produce a URL")
+    func makeInteractionSkipsReplyWithUnbuildableURL() {
+        let reply = BlueskyThreadClient.RawReply(
+            rkey: "3abc", authorHandle: "alice.bsky.social", authorName: "Alice", authorPhoto: nil,
+            text: "hi", createdAt: Date())
+        let interaction = BlueskyBackfeedSync.makeInteraction(
+            from: reply, target: URL(string: "https://me.example/blog/hi")!, now: Date(),
+            urlBuilder: { _ in nil })
+        #expect(interaction == nil)
+    }
+
+    @Test("makeInteraction(from event:) skips the like/repost rather than crashing when urlBuilder can't produce a URL")
+    func makeInteractionSkipsEventWithUnbuildableURL() {
+        let event = BlueskyThreadClient.RawActorEvent(
+            actorDID: "did:plc:dave", actorHandle: "dave.bsky.social", actorName: "Dave", actorPhoto: nil, createdAt: nil)
+        let interaction = BlueskyBackfeedSync.makeInteraction(
+            from: event, interactionType: .like, targetRkey: "3root", target: URL(string: "https://me.example/blog/hi")!,
+            now: Date(), urlBuilder: { _ in nil })
+        #expect(interaction == nil)
+    }
+
     // MARK: - pullAndCommitIfConfigured
 
     @Test("pullAndCommitIfConfigured no-ops when there is no ledger file")

--- a/Tests/AnglesiteCoreTests/BlueskyBackfeedSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/BlueskyBackfeedSyncTests.swift
@@ -1,0 +1,187 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite(.serialized)
+struct BlueskyBackfeedSyncTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://public.api.bsky.app/")!, statusCode: status, httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func emptyThreadBody(rkey: String) -> Data {
+        Data("""
+        {"thread": {"$type": "app.bsky.feed.defs#threadViewPost",
+          "post": {"uri": "at://me.example/app.bsky.feed.post/\(rkey)", "author": {"did": "did:plc:me", "handle": "me.example"},
+                    "record": {"text": "my post", "createdAt": "2026-08-01T09:00:00.000Z"}}, "replies": []}}
+        """.utf8)
+    }
+    private static func emptyLikesBody() -> Data { Data(#"{"uri": "x", "likes": []}"#.utf8) }
+    private static func emptyRepostsBody() -> Data { Data(#"{"uri": "x", "repostedBy": []}"#.utf8) }
+
+    // MARK: - atURI
+
+    @Test("atURI derives the at:// URI and rkey from a bsky.app permalink")
+    func atURIParses() throws {
+        let parsed = try #require(BlueskyBackfeedSync.atURI(from: URL(string: "https://bsky.app/profile/alice.bsky.social/post/3abc")!))
+        #expect(parsed.uri == "at://alice.bsky.social/app.bsky.feed.post/3abc")
+        #expect(parsed.rkey == "3abc")
+    }
+
+    @Test("atURI returns nil for a URL that isn't a bsky.app post permalink")
+    func atURIRejectsUnrecognizedURL() {
+        #expect(BlueskyBackfeedSync.atURI(from: URL(string: "https://example.com/other")!) == nil)
+    }
+
+    // MARK: - pullAndCommit
+
+    @Test("pullAndCommit no-ops when the ledger has no bluesky entries")
+    func noOpsWithoutBlueskyEntries() async {
+        let ledger = POSSESyndicationLog(entries: [.init(
+            sourceFile: "src/content/blog/hi.md", canonicalURL: URL(string: "https://me.example/blog/hi")!,
+            platform: "mastodon", syndicationURL: URL(string: "https://mastodon.example/@me/1")!, postedAt: Date())])
+        let count = await BlueskyBackfeedSync.pullAndCommit(
+            ledger: ledger, siteDirectory: URL(fileURLWithPath: "/nonexistent"),
+            transport: { _ in
+                Issue.record("transport must not be called with no bluesky entries")
+                struct Unexpected: Error {}
+                throw Unexpected()
+            })
+        #expect(count == 0)
+    }
+
+    @Test("pullAndCommit fetches replies/likes/reposts for a tracked post and commits them")
+    func happyPath() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let ledger = POSSESyndicationLog(entries: [.init(
+            sourceFile: "src/content/blog/hi.md", canonicalURL: URL(string: "https://me.example/blog/hi")!,
+            platform: "bluesky", syndicationURL: URL(string: "https://bsky.app/profile/me.example/post/3root")!, postedAt: Date())])
+
+        let threadBody = Data("""
+        {"thread": {"$type": "app.bsky.feed.defs#threadViewPost",
+          "post": {"uri": "at://me.example/app.bsky.feed.post/3root", "author": {"did": "did:plc:me", "handle": "me.example"},
+                    "record": {"text": "my post", "createdAt": "2026-08-01T09:00:00.000Z"}},
+          "replies": [{"$type": "app.bsky.feed.defs#threadViewPost",
+            "post": {"uri": "at://alice.bsky.social/app.bsky.feed.post/3abc",
+                      "author": {"did": "did:plc:alice", "handle": "alice.bsky.social", "displayName": "Alice"},
+                      "record": {"text": "great post!", "createdAt": "2026-08-01T10:00:00.000Z"}}, "replies": []}]}}
+        """.utf8)
+        let likesBody = Data("""
+        {"uri": "x", "likes": [{"createdAt": "2026-08-01T11:00:00.000Z", "actor": {"did": "did:plc:dave", "handle": "dave.bsky.social"}}]}
+        """.utf8)
+
+        let count = await BlueskyBackfeedSync.pullAndCommit(ledger: ledger, siteDirectory: siteDirectory, transport: { request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("getPostThread") { return (threadBody, Self.response(200)) }
+            if path.hasSuffix("getLikes") { return (likesBody, Self.response(200)) }
+            if path.hasSuffix("getRepostedBy") { return (Self.emptyRepostsBody(), Self.response(200)) }
+            return (Data(), Self.response(404))
+        })
+        #expect(count == 2)
+        #expect(FileManager.default.fileExists(atPath: siteDirectory.appendingPathComponent("data/interactions/bsky-3abc.json").path))
+        let likeFiles = try FileManager.default.contentsOfDirectory(atPath: siteDirectory.appendingPathComponent("data/interactions").path)
+            .filter { $0.hasPrefix("bsky-like-") }
+        #expect(likeFiles.count == 1)
+    }
+
+    @Test("pullAndCommit skips the whole commit when one tracked post's fetch hard-fails, leaving prior snapshots untouched")
+    func hardFailureSkipsCommit() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let existing = try ReceivedInteraction(
+            id: "bsky-existing", type: .bluesky,
+            source: URL(string: "https://bsky.app/profile/alice.bsky.social/post/existing")!,
+            target: URL(string: "https://me.example/blog/hi")!, interactionType: .reply,
+            author: nil, content: "hi", published: Date(), verified: Date(), verificationStatus: .verified)
+        _ = await ReceivedInteractionCommitter.commit(interactions: [existing], scopedTo: [.bluesky], into: siteDirectory)
+
+        let ledger = POSSESyndicationLog(entries: [.init(
+            sourceFile: "src/content/blog/hi.md", canonicalURL: URL(string: "https://me.example/blog/hi")!,
+            platform: "bluesky", syndicationURL: URL(string: "https://bsky.app/profile/me.example/post/3root")!, postedAt: Date())])
+
+        let count = await BlueskyBackfeedSync.pullAndCommit(ledger: ledger, siteDirectory: siteDirectory, transport: { request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("getPostThread") { return (Self.emptyThreadBody(rkey: "3root"), Self.response(200)) }
+            if path.hasSuffix("getLikes") { return (Data(), Self.response(500)) }
+            if path.hasSuffix("getRepostedBy") { return (Self.emptyRepostsBody(), Self.response(200)) }
+            return (Data(), Self.response(404))
+        })
+        #expect(count == 0)
+        #expect(FileManager.default.fileExists(atPath: siteDirectory.appendingPathComponent("data/interactions/bsky-existing.json").path))
+    }
+
+    @Test("pullAndCommit's bluesky-scoped reconcile leaves an existing webmention-sourced snapshot untouched")
+    func doesNotDeleteWebmentionFiles() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let webmentionInteraction = try ReceivedInteraction(
+            id: "wm-abc123", type: .webmention,
+            source: URL(string: "https://alice.example/post")!, target: URL(string: "https://me.example/blog/hi")!,
+            interactionType: .reply, author: nil, content: "hi", published: Date(), verified: Date(), verificationStatus: .verified)
+        _ = await ReceivedInteractionCommitter.commit(interactions: [webmentionInteraction], scopedTo: [.webmention], into: siteDirectory)
+
+        let ledger = POSSESyndicationLog(entries: [.init(
+            sourceFile: "src/content/blog/hi.md", canonicalURL: URL(string: "https://me.example/blog/hi")!,
+            platform: "bluesky", syndicationURL: URL(string: "https://bsky.app/profile/me.example/post/3root")!, postedAt: Date())])
+
+        _ = await BlueskyBackfeedSync.pullAndCommit(ledger: ledger, siteDirectory: siteDirectory, transport: { request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("getPostThread") { return (Self.emptyThreadBody(rkey: "3root"), Self.response(200)) }
+            if path.hasSuffix("getLikes") { return (Self.emptyLikesBody(), Self.response(200)) }
+            if path.hasSuffix("getRepostedBy") { return (Self.emptyRepostsBody(), Self.response(200)) }
+            return (Data(), Self.response(404))
+        })
+        #expect(FileManager.default.fileExists(atPath: siteDirectory.appendingPathComponent("data/interactions/wm-abc123.json").path))
+    }
+
+    // MARK: - pullAndCommitIfConfigured
+
+    @Test("pullAndCommitIfConfigured no-ops when there is no ledger file")
+    func noOpsWithoutLedger() async {
+        let fm = FileManager.default
+        let configDir = fm.temporaryDirectory.appendingPathComponent("bluesky-backfeed-config-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: configDir) }
+
+        let count = await BlueskyBackfeedSync.pullAndCommitIfConfigured(
+            siteDirectory: URL(fileURLWithPath: "/nonexistent"), configDirectory: configDir,
+            transport: { _ in
+                Issue.record("transport must not be called with no ledger")
+                struct Unexpected: Error {}
+                throw Unexpected()
+            })
+        #expect(count == 0)
+    }
+
+    private static func makeThrowawayGitRepo() throws -> URL {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("bluesky-backfeed-repo-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "placeholder\n".write(to: dir.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+
+        func git(_ args: [String]) throws {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = args
+            p.currentDirectoryURL = dir
+            p.environment = ProcessInfo.processInfo.environment.merging([
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "test@anglesite.test",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "test@anglesite.test",
+            ]) { _, new in new }
+            try p.run()
+            p.waitUntilExit()
+            guard p.terminationStatus == 0 else {
+                struct GitFailed: Error {}
+                throw GitFailed()
+            }
+        }
+        try git(["init", "-q"])
+        try git(["config", "user.email", "test@anglesite.test"])
+        try git(["config", "user.name", "test"])
+        try git(["add", "-A"])
+        try git(["commit", "-q", "-m", "initial"])
+        return dir
+    }
+}

--- a/Tests/AnglesiteCoreTests/BlueskyThreadClientTests.swift
+++ b/Tests/AnglesiteCoreTests/BlueskyThreadClientTests.swift
@@ -209,8 +209,12 @@ struct BlueskyThreadClientTests {
         #expect(likes == nil)
     }
 
-    @Test("fetchLikes returns pages already gathered when a later page fails, rather than discarding them")
-    func fetchLikesLaterPageFailureReturnsPartial() async throws {
+    @Test("fetchLikes returns nil when a later page fails, rather than returning an incomplete partial set")
+    func fetchLikesLaterPageFailureIsNil() async throws {
+        // A partial set here would flow straight into BlueskyBackfeedSync's scoped reconcile as
+        // "the complete, current set" and cause it to delete the still-real likes/reposts that
+        // were on the page that failed (#1236 review finding 4) — so any page failing, not just
+        // the first, must propagate as a hard nil.
         let requestCount = Counter()
         let likes = await BlueskyThreadClient.fetchLikes(atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in
             let n = await requestCount.increment()
@@ -222,8 +226,25 @@ struct BlueskyThreadClientTests {
             }
             return (Data(), Self.response(500))
         })
-        let unwrapped = try #require(likes)
-        #expect(unwrapped.map(\.actorHandle) == ["one.bsky.social"])
+        #expect(likes == nil)
+    }
+
+    // MARK: - author name fallback (displayName ?? handle)
+
+    @Test("makeRawReply falls back to the handle when the author has no displayName")
+    func makeRawReplyFallsBackToHandleWhenNoDisplayName() {
+        let reply = BlueskyThreadClient.makeRawReply(from: Self.post(handle: "alice.bsky.social", displayName: nil))
+        #expect(reply?.authorName == "alice.bsky.social")
+    }
+
+    @Test("makeActorEvents falls back to the handle when the actor has no displayName")
+    func makeActorEventsFallsBackToHandleWhenNoDisplayName() {
+        let json: [String: Any] = ["likes": [
+            ["createdAt": "2026-08-01T11:00:00.000Z", "actor": ["did": "did:plc:dave", "handle": "dave.bsky.social"]],
+        ]]
+        let events = BlueskyThreadClient.makeActorEvents(from: json, itemsKey: "likes")
+        #expect(events.count == 1)
+        #expect(events[0].actorName == "dave.bsky.social")
     }
 }
 

--- a/Tests/AnglesiteCoreTests/BlueskyThreadClientTests.swift
+++ b/Tests/AnglesiteCoreTests/BlueskyThreadClientTests.swift
@@ -137,4 +137,101 @@ struct BlueskyThreadClientTests {
             atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in (Data(), Self.response(500)) })
         #expect(replies == nil)
     }
+
+    // MARK: - fetchLikes / fetchReposts
+
+    @Test("fetchLikes parses a getLikes response including each like's createdAt")
+    func fetchLikesHappyPath() async throws {
+        let body = Data("""
+        {"uri": "at://root.example/app.bsky.feed.post/3root", "likes": [
+          {"createdAt": "2026-08-01T11:00:00.000Z", "indexedAt": "2026-08-01T11:00:01.000Z",
+           "actor": {"did": "did:plc:dave", "handle": "dave.bsky.social", "displayName": "Dave"}}
+        ]}
+        """.utf8)
+        let likes = await BlueskyThreadClient.fetchLikes(
+            atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in (body, Self.response(200)) })
+        let unwrapped = try #require(likes)
+        #expect(unwrapped.count == 1)
+        #expect(unwrapped[0].actorHandle == "dave.bsky.social")
+        #expect(unwrapped[0].createdAt != nil)
+    }
+
+    @Test("fetchReposts parses a getRepostedBy response whose items are bare actor profiles with no createdAt")
+    func fetchRepostsHappyPath() async throws {
+        let body = Data("""
+        {"uri": "at://root.example/app.bsky.feed.post/3root", "repostedBy": [
+          {"did": "did:plc:erin", "handle": "erin.bsky.social", "displayName": "Erin"}
+        ]}
+        """.utf8)
+        let reposts = await BlueskyThreadClient.fetchReposts(
+            atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in (body, Self.response(200)) })
+        let unwrapped = try #require(reposts)
+        #expect(unwrapped.count == 1)
+        #expect(unwrapped[0].actorHandle == "erin.bsky.social")
+        #expect(unwrapped[0].createdAt == nil)
+    }
+
+    @Test("fetchLikes follows cursor across multiple pages")
+    func fetchLikesPaginates() async throws {
+        let page1 = Data("""
+        {"uri": "x", "cursor": "page2", "likes": [{"createdAt": "2026-08-01T11:00:00.000Z", "actor": {"did": "did:plc:1", "handle": "one.bsky.social"}}]}
+        """.utf8)
+        let page2 = Data("""
+        {"uri": "x", "likes": [{"createdAt": "2026-08-01T12:00:00.000Z", "actor": {"did": "did:plc:2", "handle": "two.bsky.social"}}]}
+        """.utf8)
+        let likes = await BlueskyThreadClient.fetchLikes(atURI: "at://root.example/app.bsky.feed.post/3root", transport: { request in
+            let sawCursor = request.url?.query?.contains("cursor=page2") ?? false
+            return (sawCursor ? page2 : page1, Self.response(200))
+        })
+        let unwrapped = try #require(likes)
+        #expect(unwrapped.map(\.actorHandle) == ["one.bsky.social", "two.bsky.social"])
+    }
+
+    @Test("fetchLikes stops paginating at the page cap rather than trusting an endless cursor chain")
+    func fetchLikesStopsAtPageCap() async throws {
+        let requestCount = Counter()
+        let likes = await BlueskyThreadClient.fetchLikes(atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in
+            let n = await requestCount.increment()
+            let body = Data("""
+            {"uri": "x", "cursor": "more", "likes": [{"createdAt": "2026-08-01T11:00:00.000Z", "actor": {"did": "did:plc:\(n)", "handle": "user\(n).bsky.social"}}]}
+            """.utf8)
+            return (body, Self.response(200))
+        })
+        let unwrapped = try #require(likes)
+        #expect(await requestCount.value == BlueskyThreadClient.maximumPages)
+        #expect(unwrapped.count == BlueskyThreadClient.maximumPages)
+    }
+
+    @Test("fetchLikes returns nil when the first page hard-fails")
+    func fetchLikesFirstPageFailureIsNil() async throws {
+        let likes = await BlueskyThreadClient.fetchLikes(
+            atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in (Data(), Self.response(500)) })
+        #expect(likes == nil)
+    }
+
+    @Test("fetchLikes returns pages already gathered when a later page fails, rather than discarding them")
+    func fetchLikesLaterPageFailureReturnsPartial() async throws {
+        let requestCount = Counter()
+        let likes = await BlueskyThreadClient.fetchLikes(atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in
+            let n = await requestCount.increment()
+            if n == 1 {
+                let body = Data("""
+                {"uri": "x", "cursor": "page2", "likes": [{"createdAt": "2026-08-01T11:00:00.000Z", "actor": {"did": "did:plc:1", "handle": "one.bsky.social"}}]}
+                """.utf8)
+                return (body, Self.response(200))
+            }
+            return (Data(), Self.response(500))
+        })
+        let unwrapped = try #require(likes)
+        #expect(unwrapped.map(\.actorHandle) == ["one.bsky.social"])
+    }
+}
+
+private actor Counter {
+    private(set) var value = 0
+    @discardableResult
+    func increment() -> Int {
+        value += 1
+        return value
+    }
 }

--- a/Tests/AnglesiteCoreTests/BlueskyThreadClientTests.swift
+++ b/Tests/AnglesiteCoreTests/BlueskyThreadClientTests.swift
@@ -1,0 +1,140 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("BlueskyThreadClient")
+struct BlueskyThreadClientTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://public.api.bsky.app/")!, statusCode: status, httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func post(
+        uri: String = "at://alice.bsky.social/app.bsky.feed.post/3abc",
+        handle: String = "alice.bsky.social", displayName: String? = "Alice", avatar: String? = "https://cdn.example/alice.jpg",
+        text: String = "great post!", createdAt: String = "2026-08-01T10:00:00.000Z",
+        labels: [[String: Any]]? = nil, selfLabels: [String]? = nil
+    ) -> [String: Any] {
+        var record: [String: Any] = ["text": text, "createdAt": createdAt]
+        if let selfLabels {
+            record["labels"] = ["$type": "com.atproto.label.defs#selfLabels", "values": selfLabels.map { ["val": $0] }]
+        }
+        var author: [String: Any] = ["did": "did:plc:alice", "handle": handle]
+        if let displayName { author["displayName"] = displayName }
+        if let avatar { author["avatar"] = avatar }
+        var dict: [String: Any] = ["uri": uri, "author": author, "record": record]
+        if let labels { dict["labels"] = labels }
+        return dict
+    }
+
+    private static func threadNode(post: [String: Any], replies: [[String: Any]] = []) -> [String: Any] {
+        ["$type": "app.bsky.feed.defs#threadViewPost", "post": post, "replies": replies]
+    }
+
+    // MARK: - flattenReplies
+
+    @Test("flattenReplies collects a single reply with no children")
+    func flattenSingleReply() {
+        var results: [BlueskyThreadClient.RawReply] = []
+        BlueskyThreadClient.flattenReplies(Self.threadNode(post: Self.post()), into: &results)
+        #expect(results.count == 1)
+        #expect(results[0].rkey == "3abc")
+        #expect(results[0].authorHandle == "alice.bsky.social")
+        #expect(results[0].authorName == "Alice")
+        #expect(results[0].text == "great post!")
+    }
+
+    @Test("flattenReplies walks nested replies-to-replies depth-first")
+    func flattenNestedReplies() {
+        let grandchild = Self.threadNode(post: Self.post(uri: "at://carol.bsky.social/app.bsky.feed.post/3ggg", handle: "carol.bsky.social"))
+        let child = Self.threadNode(
+            post: Self.post(uri: "at://bob.bsky.social/app.bsky.feed.post/3bbb", handle: "bob.bsky.social"),
+            replies: [grandchild])
+        var results: [BlueskyThreadClient.RawReply] = []
+        BlueskyThreadClient.flattenReplies(Self.threadNode(post: Self.post(), replies: [child]), into: &results)
+        #expect(results.map(\.rkey) == ["3abc", "3bbb", "3ggg"])
+    }
+
+    @Test("flattenReplies skips a blockedPost branch")
+    func flattenSkipsBlockedPost() {
+        let blocked: [String: Any] = ["$type": "app.bsky.feed.defs#blockedPost", "uri": "at://evil.example/app.bsky.feed.post/3xxx"]
+        var results: [BlueskyThreadClient.RawReply] = []
+        BlueskyThreadClient.flattenReplies(Self.threadNode(post: Self.post(), replies: [blocked]), into: &results)
+        #expect(results.count == 1)
+    }
+
+    @Test("flattenReplies skips a notFoundPost branch")
+    func flattenSkipsNotFoundPost() {
+        let notFound: [String: Any] = ["$type": "app.bsky.feed.defs#notFoundPost", "uri": "at://gone.example/app.bsky.feed.post/3xxx"]
+        var results: [BlueskyThreadClient.RawReply] = []
+        BlueskyThreadClient.flattenReplies(Self.threadNode(post: Self.post(), replies: [notFound]), into: &results)
+        #expect(results.count == 1)
+    }
+
+    @Test("flattenReplies excludes an AppView-labeled adult-content reply but still walks its own children")
+    func flattenExcludesAppViewLabeledPost() {
+        let labeledPost = Self.post(
+            uri: "at://bob.bsky.social/app.bsky.feed.post/3bbb", handle: "bob.bsky.social",
+            labels: [["val": "porn", "src": "did:plc:labeler"]])
+        let child = Self.threadNode(post: Self.post(uri: "at://carol.bsky.social/app.bsky.feed.post/3ggg", handle: "carol.bsky.social"))
+        var results: [BlueskyThreadClient.RawReply] = []
+        BlueskyThreadClient.flattenReplies(
+            Self.threadNode(post: Self.post(), replies: [Self.threadNode(post: labeledPost, replies: [child])]),
+            into: &results)
+        #expect(results.map(\.rkey) == ["3abc", "3ggg"])
+    }
+
+    @Test("flattenReplies excludes a self-labeled adult-content reply")
+    func flattenExcludesSelfLabeledPost() {
+        let labeledPost = Self.post(
+            uri: "at://bob.bsky.social/app.bsky.feed.post/3bbb", handle: "bob.bsky.social", selfLabels: ["sexual"])
+        var results: [BlueskyThreadClient.RawReply] = []
+        BlueskyThreadClient.flattenReplies(Self.threadNode(post: Self.post(), replies: [Self.threadNode(post: labeledPost)]), into: &results)
+        #expect(results.map(\.rkey) == ["3abc"])
+    }
+
+    @Test("flattenReplies skips a reply missing a required field rather than crashing")
+    func flattenSkipsMalformedPost() {
+        let malformed: [String: Any] = ["uri": "at://bob.bsky.social/app.bsky.feed.post/3bbb"]
+        var results: [BlueskyThreadClient.RawReply] = []
+        BlueskyThreadClient.flattenReplies(Self.threadNode(post: Self.post(), replies: [Self.threadNode(post: malformed)]), into: &results)
+        #expect(results.map(\.rkey) == ["3abc"])
+    }
+
+    // MARK: - fetchReplies
+
+    @Test("fetchReplies parses a getPostThread response into flattened replies")
+    func fetchRepliesHappyPath() async throws {
+        let body = Data("""
+        {"thread": {"$type": "app.bsky.feed.defs#threadViewPost",
+          "post": {"uri": "at://root.example/app.bsky.feed.post/3root", "author": {"did": "did:plc:root", "handle": "root.example"},
+                    "record": {"text": "the original post", "createdAt": "2026-08-01T09:00:00.000Z"}},
+          "replies": [{"$type": "app.bsky.feed.defs#threadViewPost",
+            "post": {"uri": "at://alice.bsky.social/app.bsky.feed.post/3abc",
+                      "author": {"did": "did:plc:alice", "handle": "alice.bsky.social", "displayName": "Alice"},
+                      "record": {"text": "great post!", "createdAt": "2026-08-01T10:00:00.000Z"}},
+            "replies": []}]}}
+        """.utf8)
+        let replies = await BlueskyThreadClient.fetchReplies(
+            atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in (body, Self.response(200)) })
+        let unwrapped = try #require(replies)
+        #expect(unwrapped.count == 1)
+        #expect(unwrapped[0].rkey == "3abc")
+    }
+
+    @Test("fetchReplies returns an empty (not nil) list when the root post is gone")
+    func fetchRepliesRootNotFound() async throws {
+        let body = Data("""
+        {"thread": {"$type": "app.bsky.feed.defs#notFoundPost", "uri": "at://root.example/app.bsky.feed.post/3root"}}
+        """.utf8)
+        let replies = await BlueskyThreadClient.fetchReplies(
+            atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in (body, Self.response(200)) })
+        #expect(replies == [])
+    }
+
+    @Test("fetchReplies returns nil (hard failure) on a non-2xx response")
+    func fetchRepliesHardFailure() async throws {
+        let replies = await BlueskyThreadClient.fetchReplies(
+            atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in (Data(), Self.response(500)) })
+        #expect(replies == nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/ReceivedInteractionCommitterTests.swift
+++ b/Tests/AnglesiteCoreTests/ReceivedInteractionCommitterTests.swift
@@ -7,9 +7,11 @@ import Foundation
 // concurrently with the rest of the subprocess-heavy suite.
 @Suite(.serialized)
 struct ReceivedInteractionCommitterTests {
-    private static func interaction(id: String, content: String = "Great post!") -> ReceivedInteraction {
+    private static func interaction(
+        id: String, type: ReceivedInteraction.ProtocolType = .webmention, content: String = "Great post!"
+    ) -> ReceivedInteraction {
         try! ReceivedInteraction(
-            id: id, type: .webmention,
+            id: id, type: type,
             source: URL(string: "https://alice.example/post")!,
             target: URL(string: "https://me.example/blog/hi")!,
             interactionType: .reply,
@@ -58,6 +60,31 @@ struct ReceivedInteractionCommitterTests {
             interactions: [Self.interaction(id: "wm-abc123")], into: siteDirectory)
         #expect(ids == ["wm-def456"])
         #expect(!FileManager.default.fileExists(atPath: staleFile.path))
+    }
+
+    @Test("commit with scopedTo only reconciles staleness within its own scope, leaving other sources' files untouched")
+    func commitScopedToLeavesOtherSourcesAlone() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        _ = await ReceivedInteractionCommitter.commit(
+            interactions: [Self.interaction(id: "wm-abc123", type: .webmention)], into: siteDirectory)
+        _ = await ReceivedInteractionCommitter.commit(
+            interactions: [Self.interaction(id: "bsky-def456", type: .bluesky)],
+            scopedTo: [.bluesky], into: siteDirectory)
+
+        let webmentionFile = siteDirectory.appendingPathComponent("data/interactions/wm-abc123.json")
+        let blueskyFile = siteDirectory.appendingPathComponent("data/interactions/bsky-def456.json")
+        #expect(FileManager.default.fileExists(atPath: webmentionFile.path))
+        #expect(FileManager.default.fileExists(atPath: blueskyFile.path))
+
+        // A bluesky-scoped reconcile with zero current bluesky interactions deletes bsky-def456
+        // (stale within its own scope) but must leave wm-abc123 alone (out of scope entirely).
+        let ids = await ReceivedInteractionCommitter.commit(
+            interactions: [], scopedTo: [.bluesky], into: siteDirectory)
+        #expect(ids == ["bsky-def456"])
+        #expect(FileManager.default.fileExists(atPath: webmentionFile.path))
+        #expect(!FileManager.default.fileExists(atPath: blueskyFile.path))
     }
 
     @Test("commit is a no-op when every interaction already matches what's on disk and nothing needs deleting")

--- a/Tests/AnglesiteCoreTests/ReceivedInteractionSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/ReceivedInteractionSyncTests.swift
@@ -103,7 +103,7 @@ struct ReceivedInteractionSyncTests {
 
         let interactionsDir = siteDirectory.appendingPathComponent("data/interactions", isDirectory: true)
         try FileManager.default.createDirectory(at: interactionsDir, withIntermediateDirectories: true)
-        try Data("{}".utf8).write(to: interactionsDir.appendingPathComponent("wm-stale.json"))
+        try Data(#"{"type":"webmention"}"#.utf8).write(to: interactionsDir.appendingPathComponent("wm-stale.json"))
 
         let body = Self.d1Body("")
         let client = WebmentionInboxD1Client(
@@ -113,6 +113,28 @@ struct ReceivedInteractionSyncTests {
         #expect(count == 1)
         #expect(!FileManager.default.fileExists(
             atPath: interactionsDir.appendingPathComponent("wm-stale.json").path))
+    }
+
+    @Test("pullAndCommit's webmention-scoped reconcile leaves an existing bluesky-sourced snapshot untouched")
+    func webmentionReconcileLeavesBlueskyFilesAlone() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let blueskyInteraction = try ReceivedInteraction(
+            id: "bsky-xyz", type: .bluesky,
+            source: URL(string: "https://bsky.app/profile/alice.bsky.social/post/xyz")!,
+            target: URL(string: "https://me.example/blog/hi")!, interactionType: .reply,
+            author: nil, content: "hi", published: Date(), verified: Date(), verificationStatus: .verified)
+        _ = await ReceivedInteractionCommitter.commit(
+            interactions: [blueskyInteraction], scopedTo: [.bluesky], into: siteDirectory)
+
+        let body = Self.d1Body("")
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token", transport: { _ in (body, Self.response(200)) })
+        _ = await ReceivedInteractionSync.pullAndCommit(client: client, siteDirectory: siteDirectory)
+
+        #expect(FileManager.default.fileExists(
+            atPath: siteDirectory.appendingPathComponent("data/interactions/bsky-xyz.json").path))
     }
 
     @Test("returns 0 without touching git when the D1 query fails")

--- a/Tests/AnglesiteCoreTests/ReceivedInteractionTests.swift
+++ b/Tests/AnglesiteCoreTests/ReceivedInteractionTests.swift
@@ -43,6 +43,30 @@ struct ReceivedInteractionTests {
         #expect(!ReceivedInteraction.InteractionType.mention.isFacepile)
     }
 
+    @Test("bluesky is a valid protocol type and round-trips through JSON")
+    func blueskyProtocolTypeRoundTrips() throws {
+        let interaction = try ReceivedInteraction(
+            id: "bsky-abc123",
+            type: .bluesky,
+            source: URL(string: "https://bsky.app/profile/alice.bsky.social/post/abc123")!,
+            target: URL(string: "https://my.site/articles/hello-world")!,
+            interactionType: .reply,
+            author: nil,
+            content: "hello",
+            published: Date(),
+            verified: Date(),
+            verificationStatus: .verified
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(interaction)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(ReceivedInteraction.self, from: data)
+        #expect(decoded.type == .bluesky)
+    }
+
     @Test("gitPath produces the expected file path")
     func gitPath() throws {
         let interaction = try ReceivedInteraction(

--- a/docs/superpowers/plans/2026-08-17-bluesky-replies-comment-section.md
+++ b/docs/superpowers/plans/2026-08-17-bluesky-replies-comment-section.md
@@ -284,7 +284,7 @@ Expected: PASS — including every pre-existing test in the file (the `type` par
 
 ```bash
 git add Sources/AnglesiteCore/ReceivedInteractionCommitter.swift Tests/AnglesiteCoreTests/ReceivedInteractionCommitterTests.swift
-git commit -m "feat(#1236): scope received-interaction staleness deletion by protocol type"
+git commit -m "feat(#1236): scope interaction reconcile by protocol type"
 ```
 
 ---
@@ -355,7 +355,7 @@ Expected: PASS — including all pre-existing tests in the file.
 
 ```bash
 git add Sources/AnglesiteCore/ReceivedInteractionSync.swift Tests/AnglesiteCoreTests/ReceivedInteractionSyncTests.swift
-git commit -m "fix(#1236): scope webmention interaction reconcile to its own protocol type"
+git commit -m "fix(#1236): scope webmention reconcile to its own protocol type"
 ```
 
 ---
@@ -1250,7 +1250,7 @@ Expected: PASS
 
 ```bash
 git add Sources/AnglesiteCore/BlueskyBackfeedSync.swift Tests/AnglesiteCoreTests/BlueskyBackfeedSyncTests.swift
-git commit -m "feat(#1236): orchestrate Bluesky backfeed into received-interaction snapshots"
+git commit -m "feat(#1236): orchestrate Bluesky interaction backfeed"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-08-17-bluesky-replies-comment-section.md
+++ b/docs/superpowers/plans/2026-08-17-bluesky-replies-comment-section.md
@@ -1,0 +1,1350 @@
+# Bluesky Replies as the Site's Comment Section Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pull the replies, likes, and reposts a POSSE'd Bluesky post receives back into the site's own `data/interactions/` git-canonical snapshot, so they render in the existing comment/facepile UI with zero render-side changes.
+
+**Architecture:** A new unauthenticated AT-proto reader (`BlueskyThreadClient`) fetches `getPostThread`/`getLikes`/`getRepostedBy` from Bluesky's public AppView for every post the local POSSE ledger (`POSSESyndicationLog`) already knows was cross-posted. A new orchestrator (`BlueskyBackfeedSync`), mirroring the existing `ReceivedInteractionSync`/`AnnouncedPostSync` "pull on site-open" shape, maps the results into the existing `ReceivedInteraction` schema and commits them via `ReceivedInteractionCommitter`, which gains a `scopedTo` parameter so this new writer can share `data/interactions/` with the existing webmention/ActivityPub writer without either deleting the other's files.
+
+**Tech Stack:** Swift 6.4 (`AnglesiteCore`, portable SwiftPM target — no Darwin-only APIs), Swift Testing (`@Suite`/`@Test`), TypeScript + `node:test` (Astro template `src/lib`).
+
+**Full design:** [`docs/superpowers/specs/2026-08-17-bluesky-replies-comment-section-design.md`](../specs/2026-08-17-bluesky-replies-comment-section-design.md)
+
+## Global Constraints
+
+- Swift/SwiftUI + Apple frameworks only, no new third-party dependencies (`CONTRIBUTING.md` ▸ "Code guidelines"). This plan adds no dependency.
+- `AnglesiteCore` is a portable SwiftPM target (Linux + Darwin) — no `CryptoKit`/Darwin-only APIs without a `#if canImport` fallback. This plan uses only `Foundation`/`FoundationNetworking`.
+- Run `swift test --package-path .` and, from `JS/edit-overlay/`-adjacent template code, `npx tsx --test` before opening the PR (`CONTRIBUTING.md` ▸ "Testing"; template lib tests use `node:test`, not vitest, per existing convention in `Resources/Template/src/lib/interactions.test.ts`).
+- Conventional commits, subject ≤72 characters, reference `#1236` (`CONTRIBUTING.md` ▸ "Commits and pull requests").
+- This is app-only — no MCP schema change, so no paired `anglesite-skills` PR.
+- Issue `#1236` is already claimed (`🛠️ In Progress` label set).
+
+---
+
+### Task 1: `ReceivedInteraction.ProtocolType` and the template zod schema gain `bluesky`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ReceivedInteraction.swift:16-23`
+- Modify: `Resources/Template/src/lib/interactions.ts` (the `interactionSchema`'s `type` field)
+- Test: `Tests/AnglesiteCoreTests/ReceivedInteractionTests.swift`
+- Test: `Resources/Template/src/lib/interactions.test.ts`
+
+**Interfaces:**
+- Produces: `ReceivedInteraction.ProtocolType.bluesky` — every later Swift task constructs `ReceivedInteraction`s with `type: .bluesky`.
+- Produces: the template's `ReceivedInteraction["type"]` zod type now includes `"bluesky"` — without this, every Bluesky-sourced snapshot file fails validation and is silently dropped with a console warning (`parseInteractions`'s existing behavior for any unrecognized `type`).
+
+- [ ] **Step 1: Write the failing Swift test**
+
+Add to `Tests/AnglesiteCoreTests/ReceivedInteractionTests.swift` (after the existing `jsonRoundTrip` test):
+
+```swift
+    @Test("bluesky is a valid protocol type and round-trips through JSON")
+    func blueskyProtocolTypeRoundTrips() throws {
+        let interaction = try ReceivedInteraction(
+            id: "bsky-abc123",
+            type: .bluesky,
+            source: URL(string: "https://bsky.app/profile/alice.bsky.social/post/abc123")!,
+            target: URL(string: "https://my.site/articles/hello-world")!,
+            interactionType: .reply,
+            author: nil,
+            content: "hello",
+            published: Date(),
+            verified: Date(),
+            verificationStatus: .verified
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(interaction)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(ReceivedInteraction.self, from: data)
+        #expect(decoded.type == .bluesky)
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --package-path . --filter ReceivedInteractionTests`
+Expected: FAIL to compile — `type 'ReceivedInteraction.ProtocolType' has no member 'bluesky'`.
+
+- [ ] **Step 3: Add the `.bluesky` case**
+
+In `Sources/AnglesiteCore/ReceivedInteraction.swift`, change:
+
+```swift
+    public enum ProtocolType: String, Codable, Sendable, Equatable {
+        /// Delivered to the site's Webmention endpoint (IndieWeb).
+        case webmention
+        /// Delivered via ActivityPub (fediverse) federation.
+        case activitypub
+        /// Created through the site's Micropub endpoint.
+        case micropub
+    }
+```
+
+to:
+
+```swift
+    public enum ProtocolType: String, Codable, Sendable, Equatable {
+        /// Delivered to the site's Webmention endpoint (IndieWeb).
+        case webmention
+        /// Delivered via ActivityPub (fediverse) federation.
+        case activitypub
+        /// Created through the site's Micropub endpoint.
+        case micropub
+        /// Pulled from Bluesky's public AppView — a reply, like, or repost on the owner's POSSE'd
+        /// copy of this post (#1236), not delivered to any endpoint of ours.
+        case bluesky
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `swift test --package-path . --filter ReceivedInteractionTests`
+Expected: PASS
+
+- [ ] **Step 5: Write the failing template test**
+
+Add to `Resources/Template/src/lib/interactions.test.ts` (after the `"author and content are optional"` test):
+
+```ts
+test("accepts type: bluesky", () => {
+  const all = parseInteractions(mods(raw({ id: "bsky-abc123", type: "bluesky" })));
+  assert.equal(all.length, 1);
+  assert.equal(all[0].type, "bluesky");
+});
+```
+
+- [ ] **Step 6: Run the template test to verify it fails**
+
+Run (from `Resources/Template/`): `npx tsx --test src/lib/interactions.test.ts`
+Expected: FAIL — the new case's `raw({ type: "bluesky" })` fails `z.enum(["webmention", "activitypub", "micropub"])`, so `parseInteractions` returns `0` results, not `1`.
+
+- [ ] **Step 7: Widen the zod schema**
+
+In `Resources/Template/src/lib/interactions.ts`, change:
+
+```ts
+  type: z.enum(["webmention", "activitypub", "micropub"]),
+```
+
+to:
+
+```ts
+  type: z.enum(["webmention", "activitypub", "micropub", "bluesky"]),
+```
+
+- [ ] **Step 8: Run the template test to verify it passes**
+
+Run (from `Resources/Template/`): `npx tsx --test src/lib/interactions.test.ts`
+Expected: PASS (all tests in the file, not just the new one — this file has no other pending changes yet).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ReceivedInteraction.swift Tests/AnglesiteCoreTests/ReceivedInteractionTests.swift \
+  Resources/Template/src/lib/interactions.ts Resources/Template/src/lib/interactions.test.ts
+git commit -m "feat(#1236): add bluesky received-interaction protocol type"
+```
+
+---
+
+### Task 2: `ReceivedInteractionCommitter.commit` gains `scopedTo` for multi-source reconciliation
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ReceivedInteractionCommitter.swift`
+- Test: `Tests/AnglesiteCoreTests/ReceivedInteractionCommitterTests.swift`
+
+**Interfaces:**
+- Consumes: `ReceivedInteraction.ProtocolType` (Task 1).
+- Produces: `ReceivedInteractionCommitter.commit(interactions:scopedTo:into:fileManager:gitCommitBatch:) async -> [String]` — `scopedTo` is `Set<ReceivedInteraction.ProtocolType>?`, defaulting to `nil` (today's whole-directory behavior, unchanged for every existing caller). Task 3 and Task 6 are the two callers that pass an explicit scope.
+
+- [ ] **Step 1: Write the failing test**
+
+In `Tests/AnglesiteCoreTests/ReceivedInteractionCommitterTests.swift`, change the existing `interaction` helper to accept a `type`, defaulting to `.webmention` so every existing call site is unaffected:
+
+```swift
+    private static func interaction(
+        id: String, type: ReceivedInteraction.ProtocolType = .webmention, content: String = "Great post!"
+    ) -> ReceivedInteraction {
+        try! ReceivedInteraction(
+            id: id, type: type,
+            source: URL(string: "https://alice.example/post")!,
+            target: URL(string: "https://me.example/blog/hi")!,
+            interactionType: .reply,
+            author: .init(name: "Alice", url: URL(string: "https://alice.example"), photo: nil),
+            content: content,
+            published: Date(timeIntervalSince1970: 1_753_299_000),
+            verified: Date(timeIntervalSince1970: 1_753_300_000),
+            verificationStatus: .verified)
+    }
+```
+
+Then add a new test (after `commitDeletesStaleFiles`):
+
+```swift
+    @Test("commit with scopedTo only reconciles staleness within its own scope, leaving other sources' files untouched")
+    func commitScopedToLeavesOtherSourcesAlone() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        _ = await ReceivedInteractionCommitter.commit(
+            interactions: [Self.interaction(id: "wm-abc123", type: .webmention)], into: siteDirectory)
+        _ = await ReceivedInteractionCommitter.commit(
+            interactions: [Self.interaction(id: "bsky-def456", type: .bluesky)],
+            scopedTo: [.bluesky], into: siteDirectory)
+
+        let webmentionFile = siteDirectory.appendingPathComponent("data/interactions/wm-abc123.json")
+        let blueskyFile = siteDirectory.appendingPathComponent("data/interactions/bsky-def456.json")
+        #expect(FileManager.default.fileExists(atPath: webmentionFile.path))
+        #expect(FileManager.default.fileExists(atPath: blueskyFile.path))
+
+        // A bluesky-scoped reconcile with zero current bluesky interactions deletes bsky-def456
+        // (stale within its own scope) but must leave wm-abc123 alone (out of scope entirely).
+        let ids = await ReceivedInteractionCommitter.commit(
+            interactions: [], scopedTo: [.bluesky], into: siteDirectory)
+        #expect(ids == ["bsky-def456"])
+        #expect(FileManager.default.fileExists(atPath: webmentionFile.path))
+        #expect(!FileManager.default.fileExists(atPath: blueskyFile.path))
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --package-path . --filter ReceivedInteractionCommitterTests`
+Expected: FAIL to compile — `commit(interactions:scopedTo:into:)` doesn't exist yet.
+
+- [ ] **Step 3: Add `scopedTo` and the scope-check helper**
+
+In `Sources/AnglesiteCore/ReceivedInteractionCommitter.swift`, change the `commit` signature and its stale-deletion loop:
+
+```swift
+    @discardableResult
+    public static func commit(
+        interactions: [ReceivedInteraction],
+        scopedTo protocolTypes: Set<ReceivedInteraction.ProtocolType>? = nil,
+        into siteDirectory: URL,
+        fileManager: FileManager = .default,
+        gitCommitBatch: @Sendable (URL, [String], String) async -> String? = InboxSubmissionCommitter.processGitCommitBatch
+    ) async -> [String] {
+        let interactionsDir = siteDirectory.appendingPathComponent("data/interactions", isDirectory: true)
+        let currentIDs = Set(interactions.map(\.id))
+
+        var relPaths: [String] = []
+        var writtenIDs: [String] = []
+        var deletedIDs: [String] = []
+
+        let existingFiles = (try? fileManager.contentsOfDirectory(at: interactionsDir, includingPropertiesForKeys: nil)) ?? []
+        for file in existingFiles where file.pathExtension == "json" {
+            let id = file.deletingPathExtension().lastPathComponent
+            guard !currentIDs.contains(id) else { continue }
+            if let protocolTypes, !Self.isInScope(file, protocolTypes: protocolTypes, fileManager: fileManager) { continue }
+            guard (try? fileManager.removeItem(at: file)) != nil else { continue }
+            relPaths.append("data/interactions/\(id).json")
+            deletedIDs.append(id)
+        }
+```
+
+(The rest of the function body — writing new/changed files, the commit call — is unchanged.)
+
+Then add the helper, right after `jsonData(for:)`:
+
+```swift
+    /// Whether an existing snapshot file's own decoded `type` is in `protocolTypes` — scopes
+    /// staleness deletion so two independent sources sharing `data/interactions/` (#1236 adds a
+    /// second one, the Bluesky backfeed, alongside the existing webmention/AP sync) don't delete
+    /// each other's files. A file that fails to decode (malformed, or hand-authored without a
+    /// recognized `type`) is treated as out of scope — never deleted by a source that can't
+    /// identify it as its own.
+    private static func isInScope(
+        _ file: URL, protocolTypes: Set<ReceivedInteraction.ProtocolType>, fileManager: FileManager
+    ) -> Bool {
+        struct TypeOnly: Decodable { let type: ReceivedInteraction.ProtocolType }
+        guard let data = fileManager.contents(atPath: file.path),
+              let decoded = try? JSONDecoder().decode(TypeOnly.self, from: data)
+        else { return false }
+        return protocolTypes.contains(decoded.type)
+    }
+```
+
+Also update the type-level doc comment (above `public enum ReceivedInteractionCommitter`) to mention scoping — append this sentence to the existing comment block:
+
+```swift
+/// Two independent sources can share this directory safely via `commit`'s `scopedTo` parameter —
+/// see `docs/superpowers/specs/2026-08-17-bluesky-replies-comment-section-design.md`.
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `swift test --package-path . --filter ReceivedInteractionCommitterTests`
+Expected: PASS — including every pre-existing test in the file (the `type` param default preserves their behavior exactly).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ReceivedInteractionCommitter.swift Tests/AnglesiteCoreTests/ReceivedInteractionCommitterTests.swift
+git commit -m "feat(#1236): scope received-interaction staleness deletion by protocol type"
+```
+
+---
+
+### Task 3: `ReceivedInteractionSync` scopes its production commit to `.webmention`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ReceivedInteractionSync.swift:49`
+- Test: `Tests/AnglesiteCoreTests/ReceivedInteractionSyncTests.swift`
+
+**Interfaces:**
+- Consumes: `ReceivedInteractionCommitter.commit(interactions:scopedTo:into:)` (Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/ReceivedInteractionSyncTests.swift` (after `reconcilesAwayStaleFiles`):
+
+```swift
+    @Test("pullAndCommit's webmention-scoped reconcile leaves an existing bluesky-sourced snapshot untouched")
+    func webmentionReconcileLeavesBlueskyFilesAlone() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let blueskyInteraction = try ReceivedInteraction(
+            id: "bsky-xyz", type: .bluesky,
+            source: URL(string: "https://bsky.app/profile/alice.bsky.social/post/xyz")!,
+            target: URL(string: "https://me.example/blog/hi")!, interactionType: .reply,
+            author: nil, content: "hi", published: Date(), verified: Date(), verificationStatus: .verified)
+        _ = await ReceivedInteractionCommitter.commit(
+            interactions: [blueskyInteraction], scopedTo: [.bluesky], into: siteDirectory)
+
+        let body = Self.d1Body("")
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token", transport: { _ in (body, Self.response(200)) })
+        _ = await ReceivedInteractionSync.pullAndCommit(client: client, siteDirectory: siteDirectory)
+
+        #expect(FileManager.default.fileExists(
+            atPath: siteDirectory.appendingPathComponent("data/interactions/bsky-xyz.json").path))
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --package-path . --filter ReceivedInteractionSyncTests`
+Expected: FAIL — `pullAndCommit`'s D1-empty reconcile currently deletes every file it doesn't recognize, including `bsky-xyz.json`.
+
+- [ ] **Step 3: Pass the scope**
+
+In `Sources/AnglesiteCore/ReceivedInteractionSync.swift`, change:
+
+```swift
+        let committedIDs = await ReceivedInteractionCommitter.commit(interactions: interactions, into: siteDirectory)
+```
+
+to:
+
+```swift
+        let committedIDs = await ReceivedInteractionCommitter.commit(
+            interactions: interactions, scopedTo: [.webmention], into: siteDirectory)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `swift test --package-path . --filter ReceivedInteractionSyncTests`
+Expected: PASS — including all pre-existing tests in the file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ReceivedInteractionSync.swift Tests/AnglesiteCoreTests/ReceivedInteractionSyncTests.swift
+git commit -m "fix(#1236): scope webmention interaction reconcile to its own protocol type"
+```
+
+---
+
+### Task 4: `BlueskyThreadClient` — fetch and flatten a reply thread
+
+**Files:**
+- Create: `Sources/AnglesiteCore/BlueskyThreadClient.swift`
+- Test: `Tests/AnglesiteCoreTests/BlueskyThreadClientTests.swift`
+
+**Interfaces:**
+- Consumes: `CappedHTTPTransport.session(requestTimeout:resourceTimeout:)` / `.fetch(_:session:cap:tooLarge:)` (existing, `Sources/AnglesiteCore/CappedHTTPTransport.swift`).
+- Produces: `BlueskyThreadClient.Transport` (public typealias `@Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)`), `BlueskyThreadClient.defaultTransport` (public), `BlueskyThreadClient.RawReply` (internal struct: `rkey`, `authorHandle`, `authorName: String?`, `authorPhoto: URL?`, `text`, `createdAt: Date`), `BlueskyThreadClient.fetchReplies(atURI:transport:) async -> [RawReply]?` (internal — `nil` means hard failure, `[]` means a successful fetch that found no replies). Task 6 (`BlueskyBackfeedSync`) is the consumer.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/BlueskyThreadClientTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("BlueskyThreadClient")
+struct BlueskyThreadClientTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://public.api.bsky.app/")!, statusCode: status, httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func post(
+        uri: String = "at://alice.bsky.social/app.bsky.feed.post/3abc",
+        handle: String = "alice.bsky.social", displayName: String? = "Alice", avatar: String? = "https://cdn.example/alice.jpg",
+        text: String = "great post!", createdAt: String = "2026-08-01T10:00:00.000Z",
+        labels: [[String: Any]]? = nil, selfLabels: [String]? = nil
+    ) -> [String: Any] {
+        var record: [String: Any] = ["text": text, "createdAt": createdAt]
+        if let selfLabels {
+            record["labels"] = ["$type": "com.atproto.label.defs#selfLabels", "values": selfLabels.map { ["val": $0] }]
+        }
+        var author: [String: Any] = ["did": "did:plc:alice", "handle": handle]
+        if let displayName { author["displayName"] = displayName }
+        if let avatar { author["avatar"] = avatar }
+        var dict: [String: Any] = ["uri": uri, "author": author, "record": record]
+        if let labels { dict["labels"] = labels }
+        return dict
+    }
+
+    private static func threadNode(post: [String: Any], replies: [[String: Any]] = []) -> [String: Any] {
+        ["$type": "app.bsky.feed.defs#threadViewPost", "post": post, "replies": replies]
+    }
+
+    // MARK: - flattenReplies
+
+    @Test("flattenReplies collects a single reply with no children")
+    func flattenSingleReply() {
+        var results: [BlueskyThreadClient.RawReply] = []
+        BlueskyThreadClient.flattenReplies(Self.threadNode(post: Self.post()), into: &results)
+        #expect(results.count == 1)
+        #expect(results[0].rkey == "3abc")
+        #expect(results[0].authorHandle == "alice.bsky.social")
+        #expect(results[0].authorName == "Alice")
+        #expect(results[0].text == "great post!")
+    }
+
+    @Test("flattenReplies walks nested replies-to-replies depth-first")
+    func flattenNestedReplies() {
+        let grandchild = Self.threadNode(post: Self.post(uri: "at://carol.bsky.social/app.bsky.feed.post/3ggg", handle: "carol.bsky.social"))
+        let child = Self.threadNode(
+            post: Self.post(uri: "at://bob.bsky.social/app.bsky.feed.post/3bbb", handle: "bob.bsky.social"),
+            replies: [grandchild])
+        var results: [BlueskyThreadClient.RawReply] = []
+        BlueskyThreadClient.flattenReplies(Self.threadNode(post: Self.post(), replies: [child]), into: &results)
+        #expect(results.map(\.rkey) == ["3abc", "3bbb", "3ggg"])
+    }
+
+    @Test("flattenReplies skips a blockedPost branch")
+    func flattenSkipsBlockedPost() {
+        let blocked: [String: Any] = ["$type": "app.bsky.feed.defs#blockedPost", "uri": "at://evil.example/app.bsky.feed.post/3xxx"]
+        var results: [BlueskyThreadClient.RawReply] = []
+        BlueskyThreadClient.flattenReplies(Self.threadNode(post: Self.post(), replies: [blocked]), into: &results)
+        #expect(results.count == 1)
+    }
+
+    @Test("flattenReplies skips a notFoundPost branch")
+    func flattenSkipsNotFoundPost() {
+        let notFound: [String: Any] = ["$type": "app.bsky.feed.defs#notFoundPost", "uri": "at://gone.example/app.bsky.feed.post/3xxx"]
+        var results: [BlueskyThreadClient.RawReply] = []
+        BlueskyThreadClient.flattenReplies(Self.threadNode(post: Self.post(), replies: [notFound]), into: &results)
+        #expect(results.count == 1)
+    }
+
+    @Test("flattenReplies excludes an AppView-labeled adult-content reply but still walks its own children")
+    func flattenExcludesAppViewLabeledPost() {
+        let labeledPost = Self.post(
+            uri: "at://bob.bsky.social/app.bsky.feed.post/3bbb", handle: "bob.bsky.social",
+            labels: [["val": "porn", "src": "did:plc:labeler"]])
+        let child = Self.threadNode(post: Self.post(uri: "at://carol.bsky.social/app.bsky.feed.post/3ggg", handle: "carol.bsky.social"))
+        var results: [BlueskyThreadClient.RawReply] = []
+        BlueskyThreadClient.flattenReplies(
+            Self.threadNode(post: Self.post(), replies: [Self.threadNode(post: labeledPost, replies: [child])]),
+            into: &results)
+        #expect(results.map(\.rkey) == ["3abc", "3ggg"])
+    }
+
+    @Test("flattenReplies excludes a self-labeled adult-content reply")
+    func flattenExcludesSelfLabeledPost() {
+        let labeledPost = Self.post(
+            uri: "at://bob.bsky.social/app.bsky.feed.post/3bbb", handle: "bob.bsky.social", selfLabels: ["sexual"])
+        var results: [BlueskyThreadClient.RawReply] = []
+        BlueskyThreadClient.flattenReplies(Self.threadNode(post: Self.post(), replies: [Self.threadNode(post: labeledPost)]), into: &results)
+        #expect(results.map(\.rkey) == ["3abc"])
+    }
+
+    @Test("flattenReplies skips a reply missing a required field rather than crashing")
+    func flattenSkipsMalformedPost() {
+        let malformed: [String: Any] = ["uri": "at://bob.bsky.social/app.bsky.feed.post/3bbb"]
+        var results: [BlueskyThreadClient.RawReply] = []
+        BlueskyThreadClient.flattenReplies(Self.threadNode(post: Self.post(), replies: [Self.threadNode(post: malformed)]), into: &results)
+        #expect(results.map(\.rkey) == ["3abc"])
+    }
+
+    // MARK: - fetchReplies
+
+    @Test("fetchReplies parses a getPostThread response into flattened replies")
+    func fetchRepliesHappyPath() async throws {
+        let body = Data("""
+        {"thread": {"$type": "app.bsky.feed.defs#threadViewPost",
+          "post": {"uri": "at://root.example/app.bsky.feed.post/3root", "author": {"did": "did:plc:root", "handle": "root.example"},
+                    "record": {"text": "the original post", "createdAt": "2026-08-01T09:00:00.000Z"}},
+          "replies": [{"$type": "app.bsky.feed.defs#threadViewPost",
+            "post": {"uri": "at://alice.bsky.social/app.bsky.feed.post/3abc",
+                      "author": {"did": "did:plc:alice", "handle": "alice.bsky.social", "displayName": "Alice"},
+                      "record": {"text": "great post!", "createdAt": "2026-08-01T10:00:00.000Z"}},
+            "replies": []}]}}
+        """.utf8)
+        let replies = await BlueskyThreadClient.fetchReplies(
+            atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in (body, Self.response(200)) })
+        let unwrapped = try #require(replies)
+        #expect(unwrapped.count == 1)
+        #expect(unwrapped[0].rkey == "3abc")
+    }
+
+    @Test("fetchReplies returns an empty (not nil) list when the root post is gone")
+    func fetchRepliesRootNotFound() async throws {
+        let body = Data("""
+        {"thread": {"$type": "app.bsky.feed.defs#notFoundPost", "uri": "at://root.example/app.bsky.feed.post/3root"}}
+        """.utf8)
+        let replies = await BlueskyThreadClient.fetchReplies(
+            atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in (body, Self.response(200)) })
+        #expect(replies == [])
+    }
+
+    @Test("fetchReplies returns nil (hard failure) on a non-2xx response")
+    func fetchRepliesHardFailure() async throws {
+        let replies = await BlueskyThreadClient.fetchReplies(
+            atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in (Data(), Self.response(500)) })
+        #expect(replies == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter BlueskyThreadClientTests`
+Expected: FAIL to compile — `BlueskyThreadClient` doesn't exist yet.
+
+- [ ] **Step 3: Create `BlueskyThreadClient.swift` with the reply-fetching half**
+
+Create `Sources/AnglesiteCore/BlueskyThreadClient.swift`:
+
+```swift
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Unauthenticated reader for Bluesky's public AppView (#1236): pulls the reply thread, likes,
+/// and reposts of a POSSE'd post so `BlueskyBackfeedSync` can snapshot them into
+/// `data/interactions/` per the received-interaction canonicality design
+/// (`docs/specs/2026-06-29-c3-received-interaction-canonicality.md`). No app password or session
+/// is needed — `public.api.bsky.app` serves `getPostThread`/`getLikes`/`getRepostedBy` to anyone,
+/// the same trust posture the inline-embed fetch in
+/// `Resources/Template/scripts/embeds/adapters.ts` already relies on for Bluesky link cards.
+/// See `docs/superpowers/specs/2026-08-17-bluesky-replies-comment-section-design.md`.
+public enum BlueskyThreadClient {
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    static let timeout: TimeInterval = 10
+    static let resourceTimeout: TimeInterval = 20
+    /// A thread with many replies (or a heavily-liked post) can be sizeable; generous but bounded
+    /// — the same "cap a third-party response, don't trust it blindly" posture
+    /// `CappedHTTPTransport`'s other callers (`ActorProfileFetcher`, `AnnouncedPostSync.OutboxClient`) use.
+    static let maximumResponseBytes = 4 * 1024 * 1024
+    /// How deep into nested replies-to-replies `getPostThread` is asked to walk. Comfortably
+    /// beyond any realistic blog-comment thread; deeper nesting is a documented limitation — the
+    /// API gives no truncation marker past this depth to detect and log against.
+    static let threadDepth = 100
+
+    private static let session = CappedHTTPTransport.session(requestTimeout: timeout, resourceTimeout: resourceTimeout)
+
+    /// Production transport — public so callers (`BlueskyBackfeedSync`, tests) can inject a fake,
+    /// matching `AnnouncedPostSync.defaultTransport`'s own rationale.
+    public static let defaultTransport: Transport = { request in
+        try await CappedHTTPTransport.fetch(
+            request, session: session, cap: maximumResponseBytes,
+            tooLarge: { _ in URLError(.dataLengthExceedsMaximum) })
+    }
+
+    /// One reply flattened out of a `getPostThread` tree, before mapping to `ReceivedInteraction`
+    /// (which needs a `target` this client has no reason to know about).
+    struct RawReply: Sendable, Equatable {
+        let rkey: String
+        let authorHandle: String
+        let authorName: String?
+        let authorPhoto: URL?
+        let text: String
+        let createdAt: Date
+    }
+
+    private static let iso8601 = ISO8601DateFormatter()
+    private static let iso8601Fractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    /// Bluesky timestamps are ISO 8601 with fractional seconds (`...000Z`); tries the fractional
+    /// formatter first and falls back to the plain one rather than assuming either shape.
+    private static func parseDate(_ raw: Any?) -> Date? {
+        guard let string = raw as? String else { return nil }
+        return iso8601Fractional.date(from: string) ?? iso8601.date(from: string)
+    }
+
+    private static let adultLabels: Set<String> = ["porn", "sexual", "nudity", "graphic-media"]
+
+    /// Whether `post` (a `getPostThread` node's `post` object) carries any label — AppView-applied
+    /// or self-applied — this codebase treats as adult content. `Interactions.astro` has no
+    /// content-warning UI to gate display on, so such a reply is excluded entirely rather than
+    /// rendered.
+    static func isAdultLabeled(_ post: [String: Any]) -> Bool {
+        let appViewLabels = (post["labels"] as? [[String: Any]]) ?? []
+        if appViewLabels.contains(where: { adultLabels.contains(($0["val"] as? String) ?? "") }) {
+            return true
+        }
+        let record = post["record"] as? [String: Any]
+        let selfLabels = (record?["labels"] as? [String: Any])?["values"] as? [[String: Any]] ?? []
+        return selfLabels.contains { adultLabels.contains(($0["val"] as? String) ?? "") }
+    }
+
+    /// Extracts a `RawReply` from a `getPostThread` node's `post` object, or `nil` if it's missing
+    /// a field this schema requires — a malformed/unexpected AppView response shouldn't crash the
+    /// whole sync, just skip this one reply.
+    static func makeRawReply(from post: [String: Any]) -> RawReply? {
+        guard let uri = post["uri"] as? String, let rkey = uri.split(separator: "/").last,
+              let author = post["author"] as? [String: Any], let handle = author["handle"] as? String,
+              let record = post["record"] as? [String: Any], let text = record["text"] as? String,
+              let createdAt = parseDate(record["createdAt"])
+        else { return nil }
+        return RawReply(
+            rkey: String(rkey), authorHandle: handle, authorName: author["displayName"] as? String,
+            authorPhoto: (author["avatar"] as? String).flatMap(URL.init(string:)),
+            text: text, createdAt: createdAt)
+    }
+
+    /// Recursively flattens every reply under `node` (a `getPostThread` thread or reply object)
+    /// into `results`, depth-first. Skips `#blockedPost`/`#notFoundPost` branches (Bluesky-side
+    /// moderation/deletion — see the design doc) and adult-labeled posts, but still walks an
+    /// adult-labeled post's own children (their labels are independent of their parent's).
+    static func flattenReplies(_ node: [String: Any], into results: inout [RawReply]) {
+        guard (node["$type"] as? String) == "app.bsky.feed.defs#threadViewPost",
+              let post = node["post"] as? [String: Any]
+        else { return }
+        if !isAdultLabeled(post), let reply = makeRawReply(from: post) {
+            results.append(reply)
+        }
+        for child in (node["replies"] as? [[String: Any]]) ?? [] {
+            flattenReplies(child, into: &results)
+        }
+    }
+
+    private static func url(path: String, queryItems: [URLQueryItem]) -> URL? {
+        var components = URLComponents(string: "https://public.api.bsky.app/xrpc/\(path)")
+        components?.queryItems = queryItems
+        return components?.url
+    }
+
+    /// Fetches and flattens every reply under `atURI`'s thread, at any depth. Returns `nil` on any
+    /// hard failure (network error, non-2xx, undecodable body) — callers must treat `nil` as
+    /// "retry next time," never as "zero replies," since a root post that's genuinely gone comes
+    /// back as a *successful* response whose `thread` is `#notFoundPost`/`#blockedPost` (handled
+    /// here as an empty result, not a `nil` one).
+    ///
+    /// **Important:** this walks `thread["replies"]`, not `thread` itself. `thread["post"]` is the
+    /// *tracked post's own copy* (the same post `atURI` names) — `flattenReplies` on `thread`
+    /// directly would append the owner's own post as if it were a reply to itself. Each element of
+    /// `thread["replies"]`, by contrast, genuinely is a reply — that's where `flattenReplies`
+    /// (append this node's post, recurse into its own nested `replies`) is the correct walk.
+    static func fetchReplies(atURI: String, transport: Transport) async -> [RawReply]? {
+        guard let url = Self.url(path: "app.bsky.feed.getPostThread", queryItems: [
+            URLQueryItem(name: "uri", value: atURI),
+            URLQueryItem(name: "depth", value: String(threadDepth)),
+            URLQueryItem(name: "parentHeight", value: "0"),
+        ]) else { return nil }
+        guard let (data, http) = try? await transport(URLRequest(url: url)), (200..<300).contains(http.statusCode)
+        else { return nil }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let thread = json["thread"] as? [String: Any]
+        else { return nil }
+        guard (thread["$type"] as? String) == "app.bsky.feed.defs#threadViewPost" else { return [] }
+        var results: [RawReply] = []
+        for child in (thread["replies"] as? [[String: Any]]) ?? [] {
+            flattenReplies(child, into: &results)
+        }
+        return results
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter BlueskyThreadClientTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/BlueskyThreadClient.swift Tests/AnglesiteCoreTests/BlueskyThreadClientTests.swift
+git commit -m "feat(#1236): fetch and flatten Bluesky reply threads"
+```
+
+---
+
+### Task 5: `BlueskyThreadClient` — fetch likes and reposts, with pagination
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/BlueskyThreadClient.swift`
+- Modify: `Tests/AnglesiteCoreTests/BlueskyThreadClientTests.swift`
+
+**Interfaces:**
+- Produces: `BlueskyThreadClient.RawActorEvent` (internal struct: `actorDID`, `actorHandle`, `actorName: String?`, `actorPhoto: URL?`, `createdAt: Date?` — `nil` when the endpoint exposes no per-item timestamp, observed on `getRepostedBy`'s bare actor-profile items), `BlueskyThreadClient.fetchLikes(atURI:transport:) async -> [RawActorEvent]?`, `BlueskyThreadClient.fetchReposts(atURI:transport:) async -> [RawActorEvent]?` (both internal). Task 6 is the consumer.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/AnglesiteCoreTests/BlueskyThreadClientTests.swift` (inside the `BlueskyThreadClientTests` struct, after the `fetchReplies` tests):
+
+```swift
+    // MARK: - fetchLikes / fetchReposts
+
+    @Test("fetchLikes parses a getLikes response including each like's createdAt")
+    func fetchLikesHappyPath() async throws {
+        let body = Data("""
+        {"uri": "at://root.example/app.bsky.feed.post/3root", "likes": [
+          {"createdAt": "2026-08-01T11:00:00.000Z", "indexedAt": "2026-08-01T11:00:01.000Z",
+           "actor": {"did": "did:plc:dave", "handle": "dave.bsky.social", "displayName": "Dave"}}
+        ]}
+        """.utf8)
+        let likes = await BlueskyThreadClient.fetchLikes(
+            atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in (body, Self.response(200)) })
+        let unwrapped = try #require(likes)
+        #expect(unwrapped.count == 1)
+        #expect(unwrapped[0].actorHandle == "dave.bsky.social")
+        #expect(unwrapped[0].createdAt != nil)
+    }
+
+    @Test("fetchReposts parses a getRepostedBy response whose items are bare actor profiles with no createdAt")
+    func fetchRepostsHappyPath() async throws {
+        let body = Data("""
+        {"uri": "at://root.example/app.bsky.feed.post/3root", "repostedBy": [
+          {"did": "did:plc:erin", "handle": "erin.bsky.social", "displayName": "Erin"}
+        ]}
+        """.utf8)
+        let reposts = await BlueskyThreadClient.fetchReposts(
+            atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in (body, Self.response(200)) })
+        let unwrapped = try #require(reposts)
+        #expect(unwrapped.count == 1)
+        #expect(unwrapped[0].actorHandle == "erin.bsky.social")
+        #expect(unwrapped[0].createdAt == nil)
+    }
+
+    @Test("fetchLikes follows cursor across multiple pages")
+    func fetchLikesPaginates() async throws {
+        let page1 = Data("""
+        {"uri": "x", "cursor": "page2", "likes": [{"createdAt": "2026-08-01T11:00:00.000Z", "actor": {"did": "did:plc:1", "handle": "one.bsky.social"}}]}
+        """.utf8)
+        let page2 = Data("""
+        {"uri": "x", "likes": [{"createdAt": "2026-08-01T12:00:00.000Z", "actor": {"did": "did:plc:2", "handle": "two.bsky.social"}}]}
+        """.utf8)
+        let likes = await BlueskyThreadClient.fetchLikes(atURI: "at://root.example/app.bsky.feed.post/3root", transport: { request in
+            let sawCursor = request.url?.query?.contains("cursor=page2") ?? false
+            return (sawCursor ? page2 : page1, Self.response(200))
+        })
+        let unwrapped = try #require(likes)
+        #expect(unwrapped.map(\.actorHandle) == ["one.bsky.social", "two.bsky.social"])
+    }
+
+    @Test("fetchLikes stops paginating at the page cap rather than trusting an endless cursor chain")
+    func fetchLikesStopsAtPageCap() async throws {
+        let requestCount = Counter()
+        let likes = await BlueskyThreadClient.fetchLikes(atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in
+            let n = await requestCount.increment()
+            let body = Data("""
+            {"uri": "x", "cursor": "more", "likes": [{"createdAt": "2026-08-01T11:00:00.000Z", "actor": {"did": "did:plc:\(n)", "handle": "user\(n).bsky.social"}}]}
+            """.utf8)
+            return (body, Self.response(200))
+        })
+        let unwrapped = try #require(likes)
+        #expect(await requestCount.value == BlueskyThreadClient.maximumPages)
+        #expect(unwrapped.count == BlueskyThreadClient.maximumPages)
+    }
+
+    @Test("fetchLikes returns nil when the first page hard-fails")
+    func fetchLikesFirstPageFailureIsNil() async throws {
+        let likes = await BlueskyThreadClient.fetchLikes(
+            atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in (Data(), Self.response(500)) })
+        #expect(likes == nil)
+    }
+
+    @Test("fetchLikes returns pages already gathered when a later page fails, rather than discarding them")
+    func fetchLikesLaterPageFailureReturnsPartial() async throws {
+        let requestCount = Counter()
+        let likes = await BlueskyThreadClient.fetchLikes(atURI: "at://root.example/app.bsky.feed.post/3root", transport: { _ in
+            let n = await requestCount.increment()
+            if n == 1 {
+                let body = Data("""
+                {"uri": "x", "cursor": "page2", "likes": [{"createdAt": "2026-08-01T11:00:00.000Z", "actor": {"did": "did:plc:1", "handle": "one.bsky.social"}}]}
+                """.utf8)
+                return (body, Self.response(200))
+            }
+            return (Data(), Self.response(500))
+        })
+        let unwrapped = try #require(likes)
+        #expect(unwrapped.map(\.actorHandle) == ["one.bsky.social"])
+    }
+}
+
+private actor Counter {
+    private(set) var value = 0
+    @discardableResult
+    func increment() -> Int {
+        value += 1
+        return value
+    }
+}
+```
+
+Note the closing `}` of `BlueskyThreadClientTests` moves to just before the new `private actor Counter` — the new tests are added *inside* the struct, and `Counter` is a new top-level (file-private) helper after it.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter BlueskyThreadClientTests`
+Expected: FAIL to compile — `fetchLikes`/`fetchReposts`/`maximumPages` don't exist yet.
+
+- [ ] **Step 3: Add likes/reposts fetching to `BlueskyThreadClient.swift`**
+
+Add these members to the `BlueskyThreadClient` enum in `Sources/AnglesiteCore/BlueskyThreadClient.swift` (after `threadDepth`):
+
+```swift
+    /// Likes/reposts are paginated 100 at a time, up to this many pages — a generous, fixed cap
+    /// rather than trusting a peer-controlled `cursor` chain to terminate, matching
+    /// `AnnouncedPostSync.OutboxClient`'s own paging cap.
+    static let maximumPages = 20
+    static let pageSize = 100
+```
+
+Add, after `RawReply`:
+
+```swift
+    /// One like or repost, before mapping to `ReceivedInteraction`.
+    struct RawActorEvent: Sendable, Equatable {
+        let actorDID: String
+        let actorHandle: String
+        let actorName: String?
+        let actorPhoto: URL?
+        /// `nil` when the endpoint exposes no per-item timestamp — observed on `getRepostedBy`,
+        /// whose items are bare actor profiles with no `createdAt` of their own. The caller falls
+        /// back to sync time rather than inventing a value.
+        let createdAt: Date?
+    }
+```
+
+Add, after `flattenReplies`:
+
+```swift
+    /// Extracts one page of actor events from a `getLikes`/`getRepostedBy` response. `itemsKey` is
+    /// `"likes"` (each item wraps `{actor, createdAt}`) or `"repostedBy"` (each item *is* the
+    /// actor profile directly) — `item["actor"] ?? item` handles both shapes with one function.
+    static func makeActorEvents(from json: [String: Any], itemsKey: String) -> [RawActorEvent] {
+        let items = (json[itemsKey] as? [[String: Any]]) ?? []
+        return items.compactMap { item -> RawActorEvent? in
+            let actor = (item["actor"] as? [String: Any]) ?? item
+            guard let did = actor["did"] as? String, let handle = actor["handle"] as? String else { return nil }
+            return RawActorEvent(
+                actorDID: did, actorHandle: handle, actorName: actor["displayName"] as? String,
+                actorPhoto: (actor["avatar"] as? String).flatMap(URL.init(string:)),
+                createdAt: parseDate(item["createdAt"]))
+        }
+    }
+
+    /// Shared paging loop for `fetchLikes`/`fetchReposts`: follows `cursor` up to `maximumPages`,
+    /// stopping early once a page returns no cursor. Returns `nil` only on the *first* page's hard
+    /// failure — once at least one page has been read successfully, a later page failing mid-walk
+    /// still returns what was gathered so far, since a partial-but-real list is more useful than
+    /// discarding it, and a missed later page just means an undercount until the next site-open
+    /// retries (unlike `fetchReplies`'s all-or-nothing failure, this never has to decide "zero or
+    /// retry" for the whole post — see `BlueskyBackfeedSync`'s own all-or-nothing gate for that).
+    private static func paginate(
+        endpoint: String, atURI: String, itemsKey: String, transport: Transport
+    ) async -> [RawActorEvent]? {
+        var results: [RawActorEvent] = []
+        var cursor: String?
+        var page = 0
+        var fetchedAnyPage = false
+        repeat {
+            var items = [URLQueryItem(name: "uri", value: atURI), URLQueryItem(name: "limit", value: String(pageSize))]
+            if let cursor { items.append(URLQueryItem(name: "cursor", value: cursor)) }
+            guard let url = Self.url(path: endpoint, queryItems: items),
+                  let (data, http) = try? await transport(URLRequest(url: url)), (200..<300).contains(http.statusCode),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return fetchedAnyPage ? results : nil }
+            fetchedAnyPage = true
+            results.append(contentsOf: makeActorEvents(from: json, itemsKey: itemsKey))
+            cursor = json["cursor"] as? String
+            page += 1
+        } while cursor != nil && page < maximumPages
+        return results
+    }
+
+    static func fetchLikes(atURI: String, transport: Transport) async -> [RawActorEvent]? {
+        await paginate(endpoint: "app.bsky.feed.getLikes", atURI: atURI, itemsKey: "likes", transport: transport)
+    }
+
+    static func fetchReposts(atURI: String, transport: Transport) async -> [RawActorEvent]? {
+        await paginate(endpoint: "app.bsky.feed.getRepostedBy", atURI: atURI, itemsKey: "repostedBy", transport: transport)
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter BlueskyThreadClientTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/BlueskyThreadClient.swift Tests/AnglesiteCoreTests/BlueskyThreadClientTests.swift
+git commit -m "feat(#1236): fetch Bluesky likes and reposts with pagination"
+```
+
+---
+
+### Task 6: `BlueskyBackfeedSync` — orchestration and mapping
+
+**Files:**
+- Create: `Sources/AnglesiteCore/BlueskyBackfeedSync.swift`
+- Test: `Tests/AnglesiteCoreTests/BlueskyBackfeedSyncTests.swift`
+
+**Interfaces:**
+- Consumes: `POSSESyndicationLog` / `POSSESyndicationLog.Entry` (`Sources/AnglesiteCore/POSSESyndicationLog.swift` — `entries`, `.platform`, `.canonicalURL`, `.syndicationURL`), `POSSEStableKey.make(_:) -> String` (`Sources/AnglesiteCore/POSSEClients.swift:495`), `BlueskyThreadClient.{Transport, defaultTransport, RawReply, RawActorEvent, fetchReplies, fetchLikes, fetchReposts}` (Tasks 4-5), `ReceivedInteraction` with `.bluesky` (Task 1), `ReceivedInteractionCommitter.commit(interactions:scopedTo:into:)` (Task 2).
+- Produces: `BlueskyBackfeedSync.pullAndCommitIfConfigured(siteDirectory:configDirectory:transport:) async -> Int` (public) — the entry point Task 7 wires into `PreviewModel`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/BlueskyBackfeedSyncTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite(.serialized)
+struct BlueskyBackfeedSyncTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://public.api.bsky.app/")!, statusCode: status, httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func emptyThreadBody(rkey: String) -> Data {
+        Data("""
+        {"thread": {"$type": "app.bsky.feed.defs#threadViewPost",
+          "post": {"uri": "at://me.example/app.bsky.feed.post/\(rkey)", "author": {"did": "did:plc:me", "handle": "me.example"},
+                    "record": {"text": "my post", "createdAt": "2026-08-01T09:00:00.000Z"}}, "replies": []}}
+        """.utf8)
+    }
+    private static func emptyLikesBody() -> Data { Data(#"{"uri": "x", "likes": []}"#.utf8) }
+    private static func emptyRepostsBody() -> Data { Data(#"{"uri": "x", "repostedBy": []}"#.utf8) }
+
+    // MARK: - atURI
+
+    @Test("atURI derives the at:// URI and rkey from a bsky.app permalink")
+    func atURIParses() throws {
+        let parsed = try #require(BlueskyBackfeedSync.atURI(from: URL(string: "https://bsky.app/profile/alice.bsky.social/post/3abc")!))
+        #expect(parsed.uri == "at://alice.bsky.social/app.bsky.feed.post/3abc")
+        #expect(parsed.rkey == "3abc")
+    }
+
+    @Test("atURI returns nil for a URL that isn't a bsky.app post permalink")
+    func atURIRejectsUnrecognizedURL() {
+        #expect(BlueskyBackfeedSync.atURI(from: URL(string: "https://example.com/other")!) == nil)
+    }
+
+    // MARK: - pullAndCommit
+
+    @Test("pullAndCommit no-ops when the ledger has no bluesky entries")
+    func noOpsWithoutBlueskyEntries() async {
+        let ledger = POSSESyndicationLog(entries: [.init(
+            sourceFile: "src/content/blog/hi.md", canonicalURL: URL(string: "https://me.example/blog/hi")!,
+            platform: "mastodon", syndicationURL: URL(string: "https://mastodon.example/@me/1")!, postedAt: Date())])
+        let count = await BlueskyBackfeedSync.pullAndCommit(
+            ledger: ledger, siteDirectory: URL(fileURLWithPath: "/nonexistent"),
+            transport: { _ in
+                Issue.record("transport must not be called with no bluesky entries")
+                struct Unexpected: Error {}
+                throw Unexpected()
+            })
+        #expect(count == 0)
+    }
+
+    @Test("pullAndCommit fetches replies/likes/reposts for a tracked post and commits them")
+    func happyPath() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let ledger = POSSESyndicationLog(entries: [.init(
+            sourceFile: "src/content/blog/hi.md", canonicalURL: URL(string: "https://me.example/blog/hi")!,
+            platform: "bluesky", syndicationURL: URL(string: "https://bsky.app/profile/me.example/post/3root")!, postedAt: Date())])
+
+        let threadBody = Data("""
+        {"thread": {"$type": "app.bsky.feed.defs#threadViewPost",
+          "post": {"uri": "at://me.example/app.bsky.feed.post/3root", "author": {"did": "did:plc:me", "handle": "me.example"},
+                    "record": {"text": "my post", "createdAt": "2026-08-01T09:00:00.000Z"}},
+          "replies": [{"$type": "app.bsky.feed.defs#threadViewPost",
+            "post": {"uri": "at://alice.bsky.social/app.bsky.feed.post/3abc",
+                      "author": {"did": "did:plc:alice", "handle": "alice.bsky.social", "displayName": "Alice"},
+                      "record": {"text": "great post!", "createdAt": "2026-08-01T10:00:00.000Z"}}, "replies": []}]}}
+        """.utf8)
+        let likesBody = Data("""
+        {"uri": "x", "likes": [{"createdAt": "2026-08-01T11:00:00.000Z", "actor": {"did": "did:plc:dave", "handle": "dave.bsky.social"}}]}
+        """.utf8)
+
+        let count = await BlueskyBackfeedSync.pullAndCommit(ledger: ledger, siteDirectory: siteDirectory, transport: { request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("getPostThread") { return (threadBody, Self.response(200)) }
+            if path.hasSuffix("getLikes") { return (likesBody, Self.response(200)) }
+            if path.hasSuffix("getRepostedBy") { return (Self.emptyRepostsBody(), Self.response(200)) }
+            return (Data(), Self.response(404))
+        })
+        #expect(count == 2)
+        #expect(FileManager.default.fileExists(atPath: siteDirectory.appendingPathComponent("data/interactions/bsky-3abc.json").path))
+        let likeFiles = try FileManager.default.contentsOfDirectory(atPath: siteDirectory.appendingPathComponent("data/interactions").path)
+            .filter { $0.hasPrefix("bsky-like-") }
+        #expect(likeFiles.count == 1)
+    }
+
+    @Test("pullAndCommit skips the whole commit when one tracked post's fetch hard-fails, leaving prior snapshots untouched")
+    func hardFailureSkipsCommit() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let existing = try ReceivedInteraction(
+            id: "bsky-existing", type: .bluesky,
+            source: URL(string: "https://bsky.app/profile/alice.bsky.social/post/existing")!,
+            target: URL(string: "https://me.example/blog/hi")!, interactionType: .reply,
+            author: nil, content: "hi", published: Date(), verified: Date(), verificationStatus: .verified)
+        _ = await ReceivedInteractionCommitter.commit(interactions: [existing], scopedTo: [.bluesky], into: siteDirectory)
+
+        let ledger = POSSESyndicationLog(entries: [.init(
+            sourceFile: "src/content/blog/hi.md", canonicalURL: URL(string: "https://me.example/blog/hi")!,
+            platform: "bluesky", syndicationURL: URL(string: "https://bsky.app/profile/me.example/post/3root")!, postedAt: Date())])
+
+        let count = await BlueskyBackfeedSync.pullAndCommit(ledger: ledger, siteDirectory: siteDirectory, transport: { request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("getPostThread") { return (Self.emptyThreadBody(rkey: "3root"), Self.response(200)) }
+            if path.hasSuffix("getLikes") { return (Data(), Self.response(500)) }
+            if path.hasSuffix("getRepostedBy") { return (Self.emptyRepostsBody(), Self.response(200)) }
+            return (Data(), Self.response(404))
+        })
+        #expect(count == 0)
+        #expect(FileManager.default.fileExists(atPath: siteDirectory.appendingPathComponent("data/interactions/bsky-existing.json").path))
+    }
+
+    @Test("pullAndCommit's bluesky-scoped reconcile leaves an existing webmention-sourced snapshot untouched")
+    func doesNotDeleteWebmentionFiles() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let webmentionInteraction = try ReceivedInteraction(
+            id: "wm-abc123", type: .webmention,
+            source: URL(string: "https://alice.example/post")!, target: URL(string: "https://me.example/blog/hi")!,
+            interactionType: .reply, author: nil, content: "hi", published: Date(), verified: Date(), verificationStatus: .verified)
+        _ = await ReceivedInteractionCommitter.commit(interactions: [webmentionInteraction], scopedTo: [.webmention], into: siteDirectory)
+
+        let ledger = POSSESyndicationLog(entries: [.init(
+            sourceFile: "src/content/blog/hi.md", canonicalURL: URL(string: "https://me.example/blog/hi")!,
+            platform: "bluesky", syndicationURL: URL(string: "https://bsky.app/profile/me.example/post/3root")!, postedAt: Date())])
+
+        _ = await BlueskyBackfeedSync.pullAndCommit(ledger: ledger, siteDirectory: siteDirectory, transport: { request in
+            let path = request.url?.path ?? ""
+            if path.hasSuffix("getPostThread") { return (Self.emptyThreadBody(rkey: "3root"), Self.response(200)) }
+            if path.hasSuffix("getLikes") { return (Self.emptyLikesBody(), Self.response(200)) }
+            if path.hasSuffix("getRepostedBy") { return (Self.emptyRepostsBody(), Self.response(200)) }
+            return (Data(), Self.response(404))
+        })
+        #expect(FileManager.default.fileExists(atPath: siteDirectory.appendingPathComponent("data/interactions/wm-abc123.json").path))
+    }
+
+    // MARK: - pullAndCommitIfConfigured
+
+    @Test("pullAndCommitIfConfigured no-ops when there is no ledger file")
+    func noOpsWithoutLedger() async {
+        let fm = FileManager.default
+        let configDir = fm.temporaryDirectory.appendingPathComponent("bluesky-backfeed-config-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: configDir) }
+
+        let count = await BlueskyBackfeedSync.pullAndCommitIfConfigured(
+            siteDirectory: URL(fileURLWithPath: "/nonexistent"), configDirectory: configDir,
+            transport: { _ in
+                Issue.record("transport must not be called with no ledger")
+                struct Unexpected: Error {}
+                throw Unexpected()
+            })
+        #expect(count == 0)
+    }
+
+    private static func makeThrowawayGitRepo() throws -> URL {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("bluesky-backfeed-repo-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "placeholder\n".write(to: dir.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+
+        func git(_ args: [String]) throws {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = args
+            p.currentDirectoryURL = dir
+            p.environment = ProcessInfo.processInfo.environment.merging([
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "test@anglesite.test",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "test@anglesite.test",
+            ]) { _, new in new }
+            try p.run()
+            p.waitUntilExit()
+            guard p.terminationStatus == 0 else {
+                struct GitFailed: Error {}
+                throw GitFailed()
+            }
+        }
+        try git(["init", "-q"])
+        try git(["config", "user.email", "test@anglesite.test"])
+        try git(["config", "user.name", "test"])
+        try git(["add", "-A"])
+        try git(["commit", "-q", "-m", "initial"])
+        return dir
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter BlueskyBackfeedSyncTests`
+Expected: FAIL to compile — `BlueskyBackfeedSync` doesn't exist yet.
+
+- [ ] **Step 3: Create `BlueskyBackfeedSync.swift`**
+
+Create `Sources/AnglesiteCore/BlueskyBackfeedSync.swift`:
+
+```swift
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Orchestrates #1236's "pull the Bluesky replies/likes/reposts of every POSSE'd post and snapshot
+/// them into the site's git working copy" step, mirroring `ReceivedInteractionSync`'s shape but
+/// reading `POSSESyndicationLog` (the local POSSE ledger) instead of a Worker's D1 database — no
+/// Cloudflare token or provisioned Worker resource is needed, since Bluesky's `getPostThread`/
+/// `getLikes`/`getRepostedBy` are public, unauthenticated AppView endpoints (same trust posture as
+/// `AnnouncedPostSync`'s outbox fetch). Designed to be called once per site-open
+/// (`PreviewModel.open(site:)`), alongside the other per-site syncs.
+///
+/// See `docs/superpowers/specs/2026-08-17-bluesky-replies-comment-section-design.md` for the full
+/// design, including why `ReceivedInteractionCommitter.commit` needed a `scopedTo` parameter for
+/// this to share `data/interactions/` safely with `ReceivedInteractionSync`.
+public enum BlueskyBackfeedSync {
+    /// Derives the `at://` URI (and the post's own rkey) `BlueskyThreadClient` needs from a
+    /// `POSSESyndicationLog.Entry.syndicationURL` — the Bluesky permalink
+    /// `https://bsky.app/profile/<handle>/post/<rkey>` `BlueskyPOSSEClient.publicURL` produces
+    /// (`Sources/AnglesiteCore/POSSEClients.swift`). `nil` for anything not shaped like that
+    /// permalink — the entry is simply skipped rather than guessed at.
+    static func atURI(from syndicationURL: URL) -> (uri: String, rkey: String)? {
+        let components = syndicationURL.pathComponents
+        guard components.count == 5, components[1] == "profile", components[3] == "post" else { return nil }
+        return ("at://\(components[2])/app.bsky.feed.post/\(components[4])", components[4])
+    }
+
+    /// Maps one flattened reply to the git-canonical schema. `nil` only when
+    /// `ReceivedInteraction`'s own path-traversal guard rejects the derived id — not expected for
+    /// a real AT-proto rkey, but mirrors `ReceivedInteractionSync.makeInteraction`'s `try?` rather
+    /// than trusting the upstream shape unconditionally.
+    static func makeInteraction(from reply: BlueskyThreadClient.RawReply, target: URL, now: Date) -> ReceivedInteraction? {
+        try? ReceivedInteraction(
+            id: "bsky-\(reply.rkey)", type: .bluesky,
+            source: URL(string: "https://bsky.app/profile/\(reply.authorHandle)/post/\(reply.rkey)")!,
+            target: target, interactionType: .reply,
+            author: .init(
+                name: reply.authorName, url: URL(string: "https://bsky.app/profile/\(reply.authorHandle)"),
+                photo: reply.authorPhoto),
+            content: String(reply.text.prefix(500)),
+            published: reply.createdAt, verified: now, verificationStatus: .verified)
+    }
+
+    /// Maps one like/repost. Bluesky has no distinct per-like/-repost resource URL (unlike a
+    /// webmention `like-of`/`repost-of` post) — the interaction *is* the actor's relationship to
+    /// the target post, so `source` and `author.url` both fall back to the actor's own profile.
+    /// `id` folds in `targetRkey` so the same actor liking two different tracked posts can't
+    /// collide (`POSSEStableKey.make` already produces a `[0-9a-f]+` hash, a safe subset of the id
+    /// charset).
+    static func makeInteraction(
+        from event: BlueskyThreadClient.RawActorEvent, interactionType: ReceivedInteraction.InteractionType,
+        targetRkey: String, target: URL, now: Date
+    ) -> ReceivedInteraction? {
+        let kind = interactionType == .like ? "like" : "repost"
+        let profileURL = URL(string: "https://bsky.app/profile/\(event.actorHandle)")!
+        return try? ReceivedInteraction(
+            id: "bsky-\(kind)-" + POSSEStableKey.make("\(targetRkey)\n\(event.actorDID)"), type: .bluesky,
+            source: profileURL, target: target, interactionType: interactionType,
+            author: .init(name: event.actorName, url: profileURL, photo: event.actorPhoto),
+            content: nil, published: event.createdAt ?? now, verified: now, verificationStatus: .verified)
+    }
+
+    /// One tracked post's full result set, or `nil` if any of its three fetches hard-failed.
+    private static func interactions(
+        for entry: POSSESyndicationLog.Entry, transport: BlueskyThreadClient.Transport, now: Date
+    ) async -> [ReceivedInteraction]? {
+        guard let (atURI, rkey) = Self.atURI(from: entry.syndicationURL) else { return [] }
+        async let repliesTask = BlueskyThreadClient.fetchReplies(atURI: atURI, transport: transport)
+        async let likesTask = BlueskyThreadClient.fetchLikes(atURI: atURI, transport: transport)
+        async let repostsTask = BlueskyThreadClient.fetchReposts(atURI: atURI, transport: transport)
+        guard let replies = await repliesTask, let likes = await likesTask, let reposts = await repostsTask
+        else { return nil }
+
+        var out: [ReceivedInteraction] = []
+        out.append(contentsOf: replies.compactMap { Self.makeInteraction(from: $0, target: entry.canonicalURL, now: now) })
+        out.append(contentsOf: likes.compactMap {
+            Self.makeInteraction(from: $0, interactionType: .like, targetRkey: rkey, target: entry.canonicalURL, now: now)
+        })
+        out.append(contentsOf: reposts.compactMap {
+            Self.makeInteraction(from: $0, interactionType: .repost, targetRkey: rkey, target: entry.canonicalURL, now: now)
+        })
+        return out
+    }
+
+    /// Pulls every Bluesky-syndicated entry's replies/likes/reposts and reconciles them into
+    /// `siteDirectory`. Returns 0 (never throws, never partially reconciles) if `ledger` has no
+    /// `"bluesky"` entries, or if *any* tracked post's fetch hard-fails — a transient failure on
+    /// one post must not be misread as "this post now has zero replies" and wipe its real,
+    /// previously-fetched snapshots (see the design doc's failure-handling section).
+    public static func pullAndCommit(
+        ledger: POSSESyndicationLog, siteDirectory: URL,
+        transport: BlueskyThreadClient.Transport = BlueskyThreadClient.defaultTransport,
+        now: Date = Date()
+    ) async -> Int {
+        let entries = ledger.entries.filter { $0.platform == "bluesky" }
+        guard !entries.isEmpty else { return 0 }
+
+        var all: [ReceivedInteraction] = []
+        for entry in entries {
+            guard let interactions = await Self.interactions(for: entry, transport: transport, now: now) else { return 0 }
+            all.append(contentsOf: interactions)
+        }
+        let committedIDs = await ReceivedInteractionCommitter.commit(interactions: all, scopedTo: [.bluesky], into: siteDirectory)
+        return committedIDs.count
+    }
+
+    /// Reads the site's POSSE ledger from `configDirectory`; no-ops (returns 0, no network call)
+    /// when the site has never syndicated to Bluesky. `configDirectory` is the package's `Config/`
+    /// directory (`AnglesitePackage.configURL`), a sibling of `siteDirectory`
+    /// (`AnglesitePackage.sourceURL`).
+    public static func pullAndCommitIfConfigured(
+        siteDirectory: URL, configDirectory: URL,
+        transport: BlueskyThreadClient.Transport = BlueskyThreadClient.defaultTransport
+    ) async -> Int {
+        guard let ledger = POSSESyndicationLog.load(from: configDirectory) else { return 0 }
+        return await pullAndCommit(ledger: ledger, siteDirectory: siteDirectory, transport: transport)
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter BlueskyBackfeedSyncTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/BlueskyBackfeedSync.swift Tests/AnglesiteCoreTests/BlueskyBackfeedSyncTests.swift
+git commit -m "feat(#1236): orchestrate Bluesky backfeed into received-interaction snapshots"
+```
+
+---
+
+### Task 7: Wire `BlueskyBackfeedSync` into `PreviewModel.open(site:)`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/PreviewModel.swift:274-279`
+
+**Interfaces:**
+- Consumes: `BlueskyBackfeedSync.pullAndCommitIfConfigured(siteDirectory:configDirectory:) async -> Int` (Task 6).
+
+No new test: none of the four existing per-site syncs wired into this same block (`MicropubContentSync`, `AnnouncedPostSync`, `CommunityMembersSync`, and `ReceivedInteractionSync` itself) has dedicated coverage for its presence in this call list — each is unit-tested in its own file (Task 6 already covers `BlueskyBackfeedSync` directly), and this step is pure mechanical wiring.
+
+- [ ] **Step 1: Add the call**
+
+In `Sources/AnglesiteApp/PreviewModel.swift`, change:
+
+```swift
+            // #362: pull the webmention Worker's verified inbox from D1 and snapshot it into the
+            // git working copy. No-ops for sites without a provisioned D1 database
+            // (SiteSettings.provisionedWorkerResources.d1DatabaseID unset).
+            _ = await ReceivedInteractionSync.pullAndCommitIfConfigured(
+                siteDirectory: siteDirectory, configDirectory: configDirectory)
+            // #912: pull Micropub-created posts from MICROPUB_DB and sync each into a typed
+            // content file under src/content/. No-ops for sites without a provisioned D1
+            // database (same gate as ReceivedInteractionSync — Micropub shares the database).
+            _ = await MicropubContentSync.pullAndCommitIfConfigured(
+                siteDirectory: siteDirectory, configDirectory: configDirectory)
+```
+
+to:
+
+```swift
+            // #362: pull the webmention Worker's verified inbox from D1 and snapshot it into the
+            // git working copy. No-ops for sites without a provisioned D1 database
+            // (SiteSettings.provisionedWorkerResources.d1DatabaseID unset).
+            _ = await ReceivedInteractionSync.pullAndCommitIfConfigured(
+                siteDirectory: siteDirectory, configDirectory: configDirectory)
+            // #1236: pull replies/likes/reposts on every Bluesky-POSSE'd post from the public
+            // AppView and snapshot them alongside the webmention/AP interactions above. No-ops
+            // for sites that have never syndicated to Bluesky (no "bluesky" entry in the local
+            // POSSE ledger) — no Cloudflare token or provisioned Worker resource needed.
+            _ = await BlueskyBackfeedSync.pullAndCommitIfConfigured(
+                siteDirectory: siteDirectory, configDirectory: configDirectory)
+            // #912: pull Micropub-created posts from MICROPUB_DB and sync each into a typed
+            // content file under src/content/. No-ops for sites without a provisioned D1
+            // database (same gate as ReceivedInteractionSync — Micropub shares the database).
+            _ = await MicropubContentSync.pullAndCommitIfConfigured(
+                siteDirectory: siteDirectory, configDirectory: configDirectory)
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: build succeeds (this file lives in `AnglesiteApp`, the Xcode-built app target — `swift test --package-path .` alone doesn't compile it).
+
+If `Anglesite.xcodeproj` is stale or missing in this worktree, run `xcodegen generate` first (`AGENTS.md` ▸ "Worktrees" — the `.xcodeproj` is gitignored and regenerated from `project.yml`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/PreviewModel.swift
+git commit -m "feat(#1236): pull Bluesky backfeed on site-open"
+```
+
+---
+
+### Task 8: Full verification pass
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full Swift test suite**
+
+Run: `swift test --package-path .`
+Expected: PASS — including every test added in Tasks 1-6 and every pre-existing test (in particular `ReceivedInteractionCommitterTests`, `ReceivedInteractionSyncTests`, and anything else touching `data/interactions/`).
+
+- [ ] **Step 2: Run the template test suite**
+
+Run (from `Resources/Template/`): `npx tsx --test src/lib/interactions.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Build the app target**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Confirm `Interactions.astro` needed no changes**
+
+Run: `git diff --stat main -- Resources/Template/src/components/Interactions.astro`
+Expected: empty output — the design's central claim (the render side is already protocol-agnostic) holds; if this shows a diff, something in Tasks 1-7 accidentally touched rendering and should be reverted back to relying on `interactionType`-based generic rendering.
+
+- [ ] **Step 5: Review the full diff against `CONTRIBUTING.md` before opening the PR**
+
+Run: `git diff main --stat`
+
+Confirm: commit subjects are all ≤72 characters and reference `#1236`; no new third-party dependency was introduced; the PR body (when opened) uses `.github/PULL_REQUEST_TEMPLATE.md`'s exact headings including **Paired PR check** (answer: no MCP schema change, app-only); the PR description includes a `Closes #1236` line.

--- a/docs/superpowers/specs/2026-08-17-bluesky-replies-comment-section-design.md
+++ b/docs/superpowers/specs/2026-08-17-bluesky-replies-comment-section-design.md
@@ -1,0 +1,228 @@
+# Bluesky replies as the site's comment section (+ interaction backfeed)
+
+**Date:** 2026-08-17
+**Status:** Approved, ready for implementation planning
+**Tracks:** #1236
+**Builds on:** #362/V-3.4 (received-interaction canonicality, `docs/specs/2026-06-29-c3-received-interaction-canonicality.md`), #1234 (POSSE `bskyPostRef`/cover images), #1230
+
+## Problem
+
+`POSSESyndicationCommand` cross-posts each opted-in entry to Bluesky and sends a webmention
+backfeed from the canonical post to the Bluesky copy, but nothing flows the other way: replies,
+likes, and reposts an owner receives on Bluesky never appear back on their own site. The
+AT Protocol blog's `bsky-conversation` pattern shows this is cheap to do well — Bluesky's public
+AppView (`app.bsky.feed.getPostThread`, `getLikes`, `getRepostedBy`) is unauthenticated, permissive
+CORS, and requires no comment-hosting or moderation database of our own: the owner moderates by
+moderating their Bluesky thread.
+
+## Decision: store-canonically, reusing C3 exactly
+
+The issue's central open question — render-live (client-side fetch at page view) vs.
+store-canonically (build-time snapshot into git, matching #362's received-interaction model) — is
+decided in favor of **store-canonically**, for the same reasons #362 already gives: portability
+across hosting providers, pure-static-friendly (no Worker required, no client-side network call on
+every page view), and moderation-by-file-deletion consistent with how webmention/ActivityPub
+interactions already work.
+
+This is not a new rendering path. `Resources/Template/src/components/Interactions.astro` and
+`Resources/Template/src/lib/interactions.ts` already render `data/interactions/*.json` generically
+by `interactionType` (`reply` → threaded comment, `like`/`repost` → facepile, `mention`/`bookmark`
+→ "mentioned by" line) with no branch on protocol source. **The render side needs no changes** —
+only the write side (a new snapshot producer) and one schema widening (the `type` enum accepting
+`"bluesky"` alongside `"webmention"`/`"activitypub"`/`"micropub"`).
+
+## Where the thread URI comes from
+
+No new linkage is needed. `POSSESyndicationLog` (`Sources/AnglesiteCore/POSSESyndicationLog.swift`,
+`Config/posse-syndication.json`) already records, per successfully-syndicated entry:
+
+- `canonicalURL` — the site's own post URL (the `target` for its received interactions)
+- `syndicationURL` — the Bluesky permalink `https://bsky.app/profile/<handle>/post/<rkey>`
+  (`BlueskyPOSSEClient.publicURL`, `Sources/AnglesiteCore/POSSEClients.swift`)
+
+`<handle>/<rkey>` from `syndicationURL` is exactly the `at://<handle>/app.bsky.feed.post/<rkey>`
+URI `getPostThread`/`getLikes`/`getRepostedBy` need — the same construction
+`Resources/Template/scripts/embeds/adapters.ts`'s `resolveAdapter` already uses for inline Bluesky
+embeds. This sync does **not** touch `bskyPostRef`/`site.standard.document` at all; it is
+independent of the Standard Site publish pass.
+
+## Components
+
+### 1. `ReceivedInteraction.ProtocolType` — add `.bluesky`
+
+`Sources/AnglesiteCore/ReceivedInteraction.swift`. Purely additive; no change to the type's
+validation/serialization contract.
+
+### 2. `BlueskyThreadClient` (new)
+
+`Sources/AnglesiteCore/BlueskyThreadClient.swift`. Unauthenticated reader for
+`public.api.bsky.app/xrpc/`:
+
+- `app.bsky.feed.getPostThread?uri=<at-uri>&depth=100&parentHeight=0` — replies. `depth=100` is
+  comfortably beyond any realistic personal-blog comment thread; deeper nesting is a documented
+  limitation, not silently pretended-away (the API gives no truncation marker to detect and log
+  against).
+- `app.bsky.feed.getLikes?uri=<at-uri>&cid=<cid>&limit=100&cursor=…` — likes, cursor-paginated up
+  to a hard cap of 20 pages (2000 likes); a `console`/log-center warning fires if the cap is hit
+  with a cursor still pending, so truncation is visible rather than silent.
+- `app.bsky.feed.getRepostedBy` — same shape as `getLikes`, for reposts.
+
+Uses the same `POSSEHTTPTransport` typealias (`@Sendable (URLRequest) async throws -> (Data,
+HTTPURLResponse)`) as `POSSEClients.swift` for injectable, mockable transport in tests.
+
+### 3. `BlueskyBackfeedSync` (new)
+
+`Sources/AnglesiteCore/BlueskyBackfeedSync.swift`, mirroring `ReceivedInteractionSync`'s
+"`pullAndCommitIfConfigured` gated on site state, called once per site-open" shape — but the gate
+is "`POSSESyndicationLog` has at least one `platform == "bluesky"` entry," not a provisioned D1
+database, and no Cloudflare token is resolved (matches `AnnouncedPostSync`'s "no token needed"
+precedent).
+
+Per site-open:
+
+1. Load `POSSESyndicationLog` from `configDirectory`; no-op (return 0) if there are no `"bluesky"`
+   entries.
+2. For each such entry, derive the `at://` URI from `syndicationURL`, then fetch its thread, likes,
+   and reposts via `BlueskyThreadClient`.
+3. Map each into `ReceivedInteraction` (mapping rules below), with `target` = that entry's
+   `canonicalURL`.
+4. If **any** entry's fetch hits a hard failure (network error, non-2xx, undecodable body — as
+   opposed to a clean "not found" response), the whole pass skips its commit and returns 0. This
+   mirrors `ReceivedInteractionSync.pullAndCommit`'s existing behavior for a failed D1 query:
+   previously-synced snapshots are left untouched and the pass retries on the next site-open,
+   rather than a transient failure on one post being misread as "this post now has zero replies"
+   and deleting its real, previously-fetched snapshots.
+5. Otherwise, call `ReceivedInteractionCommitter.commit(interactions:, scopedTo: [.bluesky],
+   into: siteDirectory)` once with the full unioned set across every tracked post.
+
+### 4. `ReceivedInteractionCommitter.commit` — add `scopedTo`
+
+`Sources/AnglesiteCore/ReceivedInteractionCommitter.swift`. New parameter:
+
+```swift
+public static func commit(
+    interactions: [ReceivedInteraction],
+    scopedTo protocolTypes: Set<ReceivedInteraction.ProtocolType>? = nil,
+    into siteDirectory: URL,
+    ...
+) async -> [String]
+```
+
+**Why this is needed:** `data/interactions/` is about to gain a second independent writer.
+Today's reconcile ("delete any existing file whose id isn't in the set I just computed") assumes
+it owns the whole directory — correct when there is one source, wrong the moment there are two,
+since each source's reconcile pass would delete the other's files as "stale." `scopedTo` restricts
+staleness deletion to existing files whose own decoded `type` is in `protocolTypes`; files of any
+other (or unrecognized) type are left untouched, regardless of whether their id appears in the
+passed-in `interactions`.
+
+`nil` (the default) preserves exactly today's directory-wide behavior — every existing call site
+(the committer's own unit tests, all single-source) is unaffected. The two real per-source
+producers pass their own scope explicitly:
+
+- `ReceivedInteractionSync`'s production call: `scopedTo: [.webmention]`
+- `BlueskyBackfeedSync`'s call: `scopedTo: [.bluesky]`
+
+### 5. `PreviewModel.open(site:)` — wire in the new sync
+
+`Sources/AnglesiteApp/PreviewModel.swift`, alongside the existing pull-on-open sequence (currently
+`InboxSubmissionSync` → `ReceivedInteractionSync` → `MicropubContentSync` → `AnnouncedPostSync` →
+`CommunityMembersSync`). Add `BlueskyBackfeedSync.pullAndCommitIfConfigured(siteDirectory:,
+configDirectory:)` to that list.
+
+### 6. `interactions.ts` — schema widening only
+
+`Resources/Template/src/lib/interactions.ts`: `type: z.enum([...])` gains `"bluesky"`. No other
+change — `interactionsFor`, `parseInteractions`, and `Interactions.astro` are already generic
+across `type`.
+
+## Mapping rules
+
+### Replies → `ReceivedInteraction(interactionType: .reply)`
+
+Walk `thread.replies[]` recursively (both first-level and nested replies-to-replies), skipping any
+node whose `$type` is `app.bsky.feed.defs#blockedPost` or `#notFoundPost` (moderation/deletion —
+see below), and skipping any post carrying a self-label or AppView label in
+`{porn, sexual, nudity, graphic-media}` (there is no content-warning UI in `Interactions.astro` to
+gate display on, so exclusion is the safe default). Every surviving reply — at any depth — flattens
+into the **same** chronological comment list the target page already renders; there is no nested-
+reply UI today and this does not add one.
+
+- `id`: `"bsky-\(rkey)"` — the reply post's own `at://` rkey. AT-proto TIDs are lowercase
+  base32-sortable strings, already a subset of `ReceivedInteraction`'s `[A-Za-z0-9_-]+` id
+  validation.
+- `type`: `.bluesky`
+- `source`: `https://bsky.app/profile/<handle-or-did>/post/<rkey>` (the reply's own permalink)
+- `target`: the tracked entry's `canonicalURL`
+- `author`: `name` = `displayName ?? handle`, `url` = `https://bsky.app/profile/<handle>`,
+  `photo` = `avatar`
+- `content`: `record.text`, truncated to ~500 chars per the existing convention
+- `published`: `record.createdAt`
+- `verified`: sync time (the AppView response itself is the verification — there is no separate
+  handshake to record a distinct verification instant)
+- `verificationStatus`: `.verified`
+
+### Likes/reposts → `ReceivedInteraction(interactionType: .like / .repost)`
+
+Bluesky has no distinct per-like/-repost resource URL (unlike a webmention `like-of`/`repost-of`
+post) — the interaction *is* an actor's relationship to the target post. Both fields fall back to
+the actor's own identity:
+
+- `id`: `"bsky-like-" + POSSEStableKey.make("\(targetRkey)\n\(actorDID)")` (reposts: `"bsky-repost-"`
+  prefix). Reuses the existing FNV-1a hex hash helper (`Sources/AnglesiteCore/POSSEClients.swift`)
+  — already produces a `[0-9a-f]+` string, a safe subset of the id charset. Includes the target
+  post's rkey so the same actor liking two different tracked posts doesn't collide.
+- `source` / `author.url`: `https://bsky.app/profile/<handle>` (same value in both fields for this
+  interaction kind, which is fine — the facepile in `Interactions.astro` already prefers
+  `author.url` and only falls back to `source`)
+- `author.name`/`photo`: from the like/repost actor
+- `content`: `nil`
+- `published`: the like/repost record's `createdAt`
+- `verified`/`verificationStatus`: same as replies (sync time, `.verified`)
+
+## Moderation semantics
+
+Deliberately **identical** to today's webmention/ActivityPub interactions, not a new mechanism:
+
+- A reply/like/repost removed on Bluesky's side (post deleted, actor blocks the site's account,
+  etc.) simply stops appearing in the next `getPostThread`/`getLikes`/`getRepostedBy` response, so
+  the next full-set reconcile deletes its snapshot file — the same "sender-side delete" behavior
+  #362 already documents for webmention.
+- Owner-side moderation (deleting the local JSON file to hide something the owner disagrees with
+  but that's still live upstream) has the **same pre-existing limitation** #362 already notes for
+  webmention/AP: since every site-open re-derives the *full current* upstream set, a manually
+  deleted file for a still-live upstream interaction reappears on the next resync. This is a known
+  gap tracked by a future moderation UI (V-5.3, #370) — this feature does not attempt to solve it,
+  only to match existing behavior exactly, per the issue's "must disappear from the site the same
+  way" framing (parity, not a new guarantee).
+
+## Explicitly out of scope
+
+- A real moderation/hide field (`moderation` in the schema) — pre-existing follow-up (#370/V-5.3).
+- Unbounded pagination beyond the documented caps (thread depth 100, 20 pages of likes/reposts
+  each) — logged when the like/repost cap is hit; thread-depth truncation cannot be detected from
+  the API response and is only documented, not logged.
+- Nested/threaded comment UI — replies flatten into the existing chronological list.
+- Any change to `POSSESyndicationCommand`, `bskyPostRef`, or `site.standard.document` — this sync
+  is fully independent of the Standard Site publish pass.
+
+## Testing
+
+- Swift: `BlueskyThreadClientTests` — decode a synthetic `getPostThread` response with nested
+  replies, a `#blockedPost` branch, a `#notFoundPost` branch, and a self-labeled adult-content
+  reply; decode `getLikes`/`getRepostedBy` responses including cursor pagination and the cap.
+- Swift: `BlueskyBackfeedSyncTests` — no-ops with an empty/missing ledger; happy path produces the
+  expected `ReceivedInteraction`s and commits once; a hard fetch failure on one tracked post skips
+  the commit for the whole pass (previously-synced files untouched).
+- Swift: `ReceivedInteractionCommitterTests` — new case(s) proving `scopedTo` isolation: committing
+  `.bluesky` interactions does not delete existing `.webmention` files and vice versa; existing
+  (nil-scope) tests continue to pass unchanged.
+- Template: `interactions.test.ts` — extend fixtures/assertions to cover `type: "bluesky"`.
+- No changes needed to the `scripts/embeds/` test suite — that pipeline (inline post embeds) is
+  unrelated to this feature.
+
+## Repo scope
+
+Anglesite-app only — no MCP schema change, so no paired `anglesite-skills` PR. Template changes
+(`Resources/Template/src/lib/interactions.ts`) are app-only per `AGENTS.md` ▸ "Two-repo
+coordination."

--- a/docs/superpowers/specs/2026-08-17-bluesky-replies-comment-section-design.md
+++ b/docs/superpowers/specs/2026-08-17-bluesky-replies-comment-section-design.md
@@ -62,10 +62,17 @@ validation/serialization contract.
   comfortably beyond any realistic personal-blog comment thread; deeper nesting is a documented
   limitation, not silently pretended-away (the API gives no truncation marker to detect and log
   against).
-- `app.bsky.feed.getLikes?uri=<at-uri>&cid=<cid>&limit=100&cursor=…` — likes, cursor-paginated up
-  to a hard cap of 20 pages (2000 likes); a `console`/log-center warning fires if the cap is hit
-  with a cursor still pending, so truncation is visible rather than silent.
-- `app.bsky.feed.getRepostedBy` — same shape as `getLikes`, for reposts.
+- `app.bsky.feed.getLikes?uri=<at-uri>&limit=100&cursor=…` — likes, cursor-paginated up to a hard
+  cap of 20 pages (2000 likes) — no `cid` is passed, since `POSSESyndicationLog` never records one
+  and the parameter is optional. The cap is silent (matches `AnnouncedPostSync.OutboxClient`'s own
+  50-page outbox cap, also silent) rather than logged: these sync types have no established
+  logging convention to hook into (unlike `MicropubContentSync`/`InboxSubmissionSync`, which do
+  log), so this follows its closer sibling (`ReceivedInteractionSync`, `AnnouncedPostSync`) rather
+  than inventing one.
+- `app.bsky.feed.getRepostedBy` — same shape as `getLikes`, for reposts. Its items are bare actor
+  profiles with no per-item timestamp (unlike `getLikes`'s `{actor, createdAt}` wrapping) — the
+  mapping treats a missing `createdAt` as "fall back to sync time" so it degrades correctly
+  whichever shape a given AppView response actually has, rather than asserting one.
 
 Uses the same `POSSEHTTPTransport` typealias (`@Sendable (URLRequest) async throws -> (Data,
 HTTPURLResponse)`) as `POSSEClients.swift` for injectable, mockable transport in tests.
@@ -200,8 +207,8 @@ Deliberately **identical** to today's webmention/ActivityPub interactions, not a
 
 - A real moderation/hide field (`moderation` in the schema) — pre-existing follow-up (#370/V-5.3).
 - Unbounded pagination beyond the documented caps (thread depth 100, 20 pages of likes/reposts
-  each) — logged when the like/repost cap is hit; thread-depth truncation cannot be detected from
-  the API response and is only documented, not logged.
+  each) — both caps are silent (see "Components" ▸ "BlueskyThreadClient" above), matching
+  `AnnouncedPostSync.OutboxClient`'s own precedent; neither is logged.
 - Nested/threaded comment UI — replies flatten into the existing chronological list.
 - Any change to `POSSESyndicationCommand`, `bskyPostRef`, or `site.standard.document` — this sync
   is fully independent of the Standard Site publish pass.


### PR DESCRIPTION
Closes #1236

## Summary

- Adds a Bluesky replies/likes/reposts backfeed: pulls each POSSE'd post's Bluesky thread from the public, unauthenticated AppView (`getPostThread`/`getLikes`/`getRepostedBy`) and snapshots the result into `data/interactions/`, reusing the existing received-interaction render pipeline (`Interactions.astro`) as-is — no rendering changes needed.
- Adds a `scopedTo` parameter to `ReceivedInteractionCommitter.commit` so this new writer and the existing webmention/ActivityPub writer can safely share `data/interactions/` without either one deleting the other's snapshot files during reconcile.
- Wires the new sync (`BlueskyBackfeedSync.pullAndCommitIfConfigured`) into `PreviewModel.open(site:)`, alongside the existing per-site-open syncs. No Cloudflare token or provisioned Worker resource is needed — the AppView endpoints are public.
- Design doc: `docs/superpowers/specs/2026-08-17-bluesky-replies-comment-section-design.md`. Implementation plan: `docs/superpowers/plans/2026-08-17-bluesky-replies-comment-section.md`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — full suite green (3995+ tests across all targets), including new `BlueskyThreadClientTests`, `BlueskyBackfeedSyncTests`, and scoped-reconcile coverage in `ReceivedInteractionCommitterTests`/`ReceivedInteractionSyncTests`.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — `scripts/build-app.sh` Debug build succeeded.
- [x] `npx tsx --test src/lib/interactions.test.ts` (from `Resources/Template/`) — 10/10 passing, covering the new `type: "bluesky"` schema case.
- [ ] Manual smoke: not performed — this PR adds no new UI; it feeds the existing, already-shipped `Interactions.astro` comment/facepile component with a new upstream source. `git diff --stat main -- Resources/Template/src/components/Interactions.astro` is empty, confirming the render side needed no changes.

## Process notes

Built via brainstorming → design spec → implementation plan → subagent-driven execution (8 tasks, each independently task-reviewed) → a final whole-branch review that found 5 Important issues (spurious commits from unstable timestamps, a force-unwrapped URL on untrusted API data, one permanently-failing post silently disabling backfeed for the whole site, a partial-pagination edge case that could delete real snapshots, and a missing display-name fallback) — all fixed and verified in a scoped re-review before this PR was opened.