### PR TITLE
feat(#1557): canvas-background effects for the Effects gallery

### DIFF
--- a/Resources/Template/blocks.manifest.json
+++ b/Resources/Template/blocks.manifest.json
@@ -1,4 +1,38 @@
 {
   "schemaVersion": "anglesite-block-manifest/1",
-  "modules": []
+  "modules": [
+    {
+      "path": "src/components/effects/ParticleField.astro",
+      "export": "ParticleField",
+      "kind": "astro",
+      "name": "Particle Field",
+      "description": "Drifting dots connected by faint lines when close.",
+      "icon": null,
+      "propEditors": [],
+      "slots": [],
+      "placement": { "allowedParents": null }
+    },
+    {
+      "path": "src/components/effects/AuroraGradient.astro",
+      "export": "AuroraGradient",
+      "kind": "astro",
+      "name": "Aurora Gradient",
+      "description": "Slow blurred color-blob blending.",
+      "icon": null,
+      "propEditors": [],
+      "slots": [],
+      "placement": { "allowedParents": null }
+    },
+    {
+      "path": "src/components/effects/GrainOverlay.astro",
+      "export": "GrainOverlay",
+      "kind": "astro",
+      "name": "Grain Overlay",
+      "description": "Subtle animated film-grain texture.",
+      "icon": null,
+      "propEditors": [],
+      "slots": [],
+      "placement": { "allowedParents": null }
+    }
+  ]
 }

--- a/Resources/Template/integrations/effects-demos/AuroraGradient.html
+++ b/Resources/Template/integrations/effects-demos/AuroraGradient.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Aurora Gradient</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>.effect-demo-stage{position:relative;isolation:isolate;width:min(90vw,480px);height:min(60vh,300px)}</style>
+<style>
+  .aurora-gradient-root {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    overflow: hidden;
+    pointer-events: none;
+    filter: blur(40px);
+  }
+  .aurora-gradient-root canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+</style>
+</head><body>
+<div class="effect-demo-stage">
+<div class="aurora-gradient-root" data-colors="#7c3aed,#2563eb,#0891b2" data-astro-cid-gj7fsof7><canvas data-astro-cid-gj7fsof7></canvas></div>
+</div>
+</body></html>

--- a/Resources/Template/integrations/effects-demos/AuroraGradient.html
+++ b/Resources/Template/integrations/effects-demos/AuroraGradient.html
@@ -20,6 +20,6 @@ font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasTex
 </style>
 </head><body>
 <div class="effect-demo-stage">
-<div class="aurora-gradient-root" data-colors="#7c3aed,#2563eb,#0891b2" data-astro-cid-gj7fsof7><canvas data-astro-cid-gj7fsof7></canvas></div>
+<div class="aurora-gradient-root" aria-hidden="true" data-colors="#7c3aed,#2563eb,#0891b2" data-astro-cid-gj7fsof7><canvas data-astro-cid-gj7fsof7></canvas></div>
 </div>
 </body></html>

--- a/Resources/Template/integrations/effects-demos/GrainOverlay.html
+++ b/Resources/Template/integrations/effects-demos/GrainOverlay.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Grain Overlay</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>.effect-demo-stage{position:relative;isolation:isolate;width:min(90vw,480px);height:min(60vh,300px)}</style>
+<style>
+  .grain-overlay-root {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    overflow: hidden;
+    pointer-events: none;
+    mix-blend-mode: overlay;
+  }
+  .grain-overlay-root canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+</style>
+</head><body>
+<div class="effect-demo-stage">
+<div class="grain-overlay-root" data-opacity="0.05" data-astro-cid-iahzwo5d><canvas data-astro-cid-iahzwo5d></canvas></div>
+</div>
+</body></html>

--- a/Resources/Template/integrations/effects-demos/GrainOverlay.html
+++ b/Resources/Template/integrations/effects-demos/GrainOverlay.html
@@ -20,6 +20,6 @@ font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasTex
 </style>
 </head><body>
 <div class="effect-demo-stage">
-<div class="grain-overlay-root" data-opacity="0.05" data-astro-cid-iahzwo5d><canvas data-astro-cid-iahzwo5d></canvas></div>
+<div class="grain-overlay-root" aria-hidden="true" data-opacity="0.05" data-astro-cid-iahzwo5d><canvas data-astro-cid-iahzwo5d></canvas></div>
 </div>
 </body></html>

--- a/Resources/Template/integrations/effects-demos/ParticleField.html
+++ b/Resources/Template/integrations/effects-demos/ParticleField.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Particle Field</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>.effect-demo-stage{position:relative;isolation:isolate;width:min(90vw,480px);height:min(60vh,300px)}</style>
+<style>
+  .particle-field-root {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    overflow: hidden;
+    pointer-events: none;
+  }
+  .particle-field-root canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+</style>
+</head><body>
+<div class="effect-demo-stage">
+<div class="particle-field-root" data-density="60" data-color="#7c3aed" data-astro-cid-ahf5wtdh><canvas data-astro-cid-ahf5wtdh></canvas></div>
+</div>
+</body></html>

--- a/Resources/Template/integrations/effects-demos/ParticleField.html
+++ b/Resources/Template/integrations/effects-demos/ParticleField.html
@@ -19,6 +19,6 @@ font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasTex
 </style>
 </head><body>
 <div class="effect-demo-stage">
-<div class="particle-field-root" data-density="60" data-color="#7c3aed" data-astro-cid-ahf5wtdh><canvas data-astro-cid-ahf5wtdh></canvas></div>
+<div class="particle-field-root" aria-hidden="true" data-density="60" data-color="#7c3aed" data-astro-cid-ahf5wtdh><canvas data-astro-cid-ahf5wtdh></canvas></div>
 </div>
 </body></html>

--- a/Resources/Template/integrations/effects.json
+++ b/Resources/Template/integrations/effects.json
@@ -229,6 +229,50 @@
         "value": 60
       },
       "snippet": "---\nimport ProgressBar from \"@astroanimate/core/ProgressBar\";\n---\n<ProgressBar value={60} label=\"Upload progress\" />"
+    },
+    {
+      "component": "ParticleField",
+      "title": "Particle Field",
+      "ownerDescription": "Drifting dots connected by faint lines when close.",
+      "category": "canvasBackground",
+      "keyProps": {
+        "density": "particle count (default 60)",
+        "color": "dot/line color (default currentColor)"
+      },
+      "props": {
+        "density": 60,
+        "color": "#7c3aed"
+      },
+      "snippet": "---\nimport ParticleField from \"../components/effects/ParticleField.astro\";\n---\n<div style=\"position: relative;\">\n  <ParticleField />\n</div>",
+      "placement": { "kind": "background", "allowedParents": null }
+    },
+    {
+      "component": "AuroraGradient",
+      "title": "Aurora Gradient",
+      "ownerDescription": "Slow blurred color-blob blending.",
+      "category": "canvasBackground",
+      "keyProps": {
+        "colors": "array of CSS colors (default a purple/blue/teal trio)"
+      },
+      "props": {
+        "colors": ["#7c3aed", "#2563eb", "#0891b2"]
+      },
+      "snippet": "---\nimport AuroraGradient from \"../components/effects/AuroraGradient.astro\";\n---\n<div style=\"position: relative;\">\n  <AuroraGradient />\n</div>",
+      "placement": { "kind": "background", "allowedParents": null }
+    },
+    {
+      "component": "GrainOverlay",
+      "title": "Grain Overlay",
+      "ownerDescription": "Subtle animated film-grain texture.",
+      "category": "canvasBackground",
+      "keyProps": {
+        "opacity": "0-1 (default 0.05)"
+      },
+      "props": {
+        "opacity": 0.05
+      },
+      "snippet": "---\nimport GrainOverlay from \"../components/effects/GrainOverlay.astro\";\n---\n<div style=\"position: relative;\">\n  <GrainOverlay />\n</div>",
+      "placement": { "kind": "background", "allowedParents": null }
     }
   ]
 }

--- a/Resources/Template/src/components/effects/AuroraGradient.astro
+++ b/Resources/Template/src/components/effects/AuroraGradient.astro
@@ -1,0 +1,104 @@
+---
+/**
+ * Effects gallery — Canvas Backgrounds (#768). Slow, blurred color-blob blending. Full-bleed
+ * background layer: place inside a `position: relative` ancestor.
+ */
+interface Props {
+  colors?: string[];
+}
+const { colors = ["#7c3aed", "#2563eb", "#0891b2"] } = Astro.props;
+---
+
+<div class="aurora-gradient-root" data-colors={colors.join(",")}>
+  <canvas></canvas>
+</div>
+
+<script>
+  class AuroraGradient {
+    constructor(root: HTMLElement) {
+      const canvas = root.querySelector("canvas") as HTMLCanvasElement;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      const colors = (root.dataset.colors ?? "").split(",").filter(Boolean);
+      const reduceMotion = matchMedia("(prefers-reduced-motion: reduce)").matches;
+      let raf = 0;
+      let running = false;
+      let t = 0;
+
+      function resize() {
+        canvas.width = root.clientWidth;
+        canvas.height = root.clientHeight;
+      }
+
+      function paint(time: number) {
+        if (!ctx) return;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        colors.forEach((color, i) => {
+          const angle = time + (i * Math.PI * 2) / colors.length;
+          const x = canvas.width / 2 + Math.cos(angle) * canvas.width * 0.3;
+          const y = canvas.height / 2 + Math.sin(angle) * canvas.height * 0.3;
+          const gradient = ctx.createRadialGradient(
+            x,
+            y,
+            0,
+            x,
+            y,
+            Math.max(canvas.width, canvas.height) * 0.4,
+          );
+          gradient.addColorStop(0, color);
+          gradient.addColorStop(1, "transparent");
+          ctx.fillStyle = gradient;
+          ctx.globalAlpha = 0.5;
+          ctx.fillRect(0, 0, canvas.width, canvas.height);
+        });
+        ctx.globalAlpha = 1;
+      }
+
+      function tick() {
+        if (!running) return;
+        t += 0.002;
+        paint(t);
+        raf = requestAnimationFrame(tick);
+      }
+
+      resize();
+      if (reduceMotion) {
+        paint(0);
+      } else {
+        const observer = new IntersectionObserver((entries) => {
+          for (const entry of entries) {
+            if (entry.isIntersecting && !running) {
+              running = true;
+              raf = requestAnimationFrame(tick);
+            } else if (!entry.isIntersecting && running) {
+              running = false;
+              cancelAnimationFrame(raf);
+            }
+          }
+        });
+        observer.observe(root);
+        addEventListener("resize", resize, { passive: true });
+      }
+    }
+  }
+
+  document
+    .querySelectorAll<HTMLElement>(".aurora-gradient-root")
+    .forEach((el) => new AuroraGradient(el));
+</script>
+
+<style>
+  .aurora-gradient-root {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    overflow: hidden;
+    pointer-events: none;
+    filter: blur(40px);
+  }
+  .aurora-gradient-root canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+</style>

--- a/Resources/Template/src/components/effects/AuroraGradient.astro
+++ b/Resources/Template/src/components/effects/AuroraGradient.astro
@@ -9,7 +9,7 @@ interface Props {
 const { colors = ["#7c3aed", "#2563eb", "#0891b2"] } = Astro.props;
 ---
 
-<div class="aurora-gradient-root" data-colors={colors.join(",")}>
+<div class="aurora-gradient-root" aria-hidden="true" data-colors={colors.join(",")}>
   <canvas></canvas>
 </div>
 
@@ -61,10 +61,18 @@ const { colors = ["#7c3aed", "#2563eb", "#0891b2"] } = Astro.props;
         raf = requestAnimationFrame(tick);
       }
 
-      resize();
       if (reduceMotion) {
-        paint(0);
+        // Reduced motion still has to track the *size*: assigning canvas.width/height is what
+        // syncs the backing store to the CSS box, so without this the single still frame would
+        // be stretched and blurry after a window resize rather than repainted at the new size.
+        const repaint = () => {
+          resize();
+          paint(0);
+        };
+        repaint();
+        addEventListener("resize", repaint, { passive: true });
       } else {
+        resize();
         const observer = new IntersectionObserver((entries) => {
           for (const entry of entries) {
             if (entry.isIntersecting && !running) {

--- a/Resources/Template/src/components/effects/GrainOverlay.astro
+++ b/Resources/Template/src/components/effects/GrainOverlay.astro
@@ -1,0 +1,96 @@
+---
+/**
+ * Effects gallery — Canvas Backgrounds (#768). Subtle animated film-grain texture. Full-bleed
+ * background layer: place inside a `position: relative` ancestor.
+ */
+interface Props {
+  opacity?: number;
+}
+const { opacity = 0.05 } = Astro.props;
+---
+
+<div class="grain-overlay-root" data-opacity={opacity}>
+  <canvas></canvas>
+</div>
+
+<script>
+  class GrainOverlay {
+    constructor(root: HTMLElement) {
+      const canvas = root.querySelector("canvas") as HTMLCanvasElement;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      const opacity = Number(root.dataset.opacity ?? 0.05);
+      const reduceMotion = matchMedia("(prefers-reduced-motion: reduce)").matches;
+      let raf = 0;
+      let running = false;
+      let lastFrame = 0;
+
+      function resize() {
+        canvas.width = root.clientWidth;
+        canvas.height = root.clientHeight;
+      }
+
+      function paintNoise() {
+        if (!ctx) return;
+        const imageData = ctx.createImageData(canvas.width, canvas.height);
+        const buffer = imageData.data;
+        for (let i = 0; i < buffer.length; i += 4) {
+          const shade = Math.random() * 255;
+          buffer[i] = buffer[i + 1] = buffer[i + 2] = shade;
+          buffer[i + 3] = opacity * 255;
+        }
+        ctx.putImageData(imageData, 0, 0);
+      }
+
+      function tick(time: number) {
+        if (!running) return;
+        // Throttle to ~12fps — grain reads as motion even at a low frame rate, and this keeps
+        // CPU cost far below a full 60fps canvas redraw.
+        if (time - lastFrame > 83) {
+          lastFrame = time;
+          paintNoise();
+        }
+        raf = requestAnimationFrame(tick);
+      }
+
+      resize();
+      if (reduceMotion) {
+        paintNoise();
+      } else {
+        const observer = new IntersectionObserver((entries) => {
+          for (const entry of entries) {
+            if (entry.isIntersecting && !running) {
+              running = true;
+              raf = requestAnimationFrame(tick);
+            } else if (!entry.isIntersecting && running) {
+              running = false;
+              cancelAnimationFrame(raf);
+            }
+          }
+        });
+        observer.observe(root);
+        addEventListener("resize", resize, { passive: true });
+      }
+    }
+  }
+
+  document
+    .querySelectorAll<HTMLElement>(".grain-overlay-root")
+    .forEach((el) => new GrainOverlay(el));
+</script>
+
+<style>
+  .grain-overlay-root {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    overflow: hidden;
+    pointer-events: none;
+    mix-blend-mode: overlay;
+  }
+  .grain-overlay-root canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+</style>

--- a/Resources/Template/src/components/effects/GrainOverlay.astro
+++ b/Resources/Template/src/components/effects/GrainOverlay.astro
@@ -9,7 +9,7 @@ interface Props {
 const { opacity = 0.05 } = Astro.props;
 ---
 
-<div class="grain-overlay-root" data-opacity={opacity}>
+<div class="grain-overlay-root" aria-hidden="true" data-opacity={opacity}>
   <canvas></canvas>
 </div>
 
@@ -53,10 +53,18 @@ const { opacity = 0.05 } = Astro.props;
         raf = requestAnimationFrame(tick);
       }
 
-      resize();
       if (reduceMotion) {
-        paintNoise();
+        // Reduced motion still has to track the *size*: assigning canvas.width/height is what
+        // syncs the backing store to the CSS box, so without this the single still frame would
+        // be stretched and blurry after a window resize rather than repainted at the new size.
+        const repaint = () => {
+          resize();
+          paintNoise();
+        };
+        repaint();
+        addEventListener("resize", repaint, { passive: true });
       } else {
+        resize();
         const observer = new IntersectionObserver((entries) => {
           for (const entry of entries) {
             if (entry.isIntersecting && !running) {

--- a/Resources/Template/src/components/effects/ParticleField.astro
+++ b/Resources/Template/src/components/effects/ParticleField.astro
@@ -11,7 +11,7 @@ interface Props {
 const { density = 60, color = "currentColor" } = Astro.props;
 ---
 
-<div class="particle-field-root" data-density={density} data-color={color}>
+<div class="particle-field-root" aria-hidden="true" data-density={density} data-color={color}>
   <canvas></canvas>
 </div>
 
@@ -36,14 +36,27 @@ const { density = 60, color = "currentColor" } = Astro.props;
       let running = false;
 
       function resize() {
+        const previousWidth = canvas.width;
+        const previousHeight = canvas.height;
         canvas.width = root.clientWidth;
         canvas.height = root.clientHeight;
-        particles = Array.from({ length: density }, () => ({
-          x: Math.random() * canvas.width,
-          y: Math.random() * canvas.height,
-          vx: (Math.random() - 0.5) * 0.3,
-          vy: (Math.random() - 0.5) * 0.3,
-        }));
+        if (particles.length === 0) {
+          particles = Array.from({ length: density }, () => ({
+            x: Math.random() * canvas.width,
+            y: Math.random() * canvas.height,
+            vx: (Math.random() - 0.5) * 0.3,
+            vy: (Math.random() - 0.5) * 0.3,
+          }));
+          return;
+        }
+        // Rescale the existing field into the new bounds rather than regenerating it. `resize`
+        // fires continuously while a window is dragged, so re-randomizing here would make the
+        // particles visibly re-shuffle dozens of times a second instead of adapting to the new
+        // size — and scrolling the layer back into view would reset it too.
+        for (const p of particles) {
+          p.x = previousWidth > 0 ? (p.x * canvas.width) / previousWidth : Math.random() * canvas.width;
+          p.y = previousHeight > 0 ? (p.y * canvas.height) / previousHeight : Math.random() * canvas.height;
+        }
       }
 
       function drawStaticFrame() {
@@ -85,7 +98,11 @@ const { density = 60, color = "currentColor" } = Astro.props;
       }
 
       if (reduceMotion) {
+        // Reduced motion still has to track the *size*: assigning canvas.width/height is what
+        // syncs the backing store to the CSS box, so without this the still frame would be
+        // stretched and blurry after a window resize rather than repainted at the new size.
         drawStaticFrame();
+        addEventListener("resize", drawStaticFrame, { passive: true });
       } else {
         const observer = new IntersectionObserver((entries) => {
           for (const entry of entries) {

--- a/Resources/Template/src/components/effects/ParticleField.astro
+++ b/Resources/Template/src/components/effects/ParticleField.astro
@@ -1,0 +1,126 @@
+---
+/**
+ * Effects gallery — Canvas Backgrounds (#768). Drifting particles with faint connecting lines
+ * when close. Full-bleed background layer: place inside a `position: relative` (or `static`
+ * with a stacking context) ancestor — it positions itself `absolute; inset: 0`.
+ */
+interface Props {
+  density?: number;
+  color?: string;
+}
+const { density = 60, color = "currentColor" } = Astro.props;
+---
+
+<div class="particle-field-root" data-density={density} data-color={color}>
+  <canvas></canvas>
+</div>
+
+<script>
+  class ParticleField {
+    constructor(root: HTMLElement) {
+      const canvas = root.querySelector("canvas") as HTMLCanvasElement;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      const density = Number(root.dataset.density ?? 60);
+      // Canvas 2D has no notion of `currentColor` — assigning it to fillStyle/strokeStyle is
+      // silently ignored and the context keeps its default black, which is invisible on the dark
+      // backgrounds this layer is usually dropped behind. Resolve the keyword against the root's
+      // computed color so the documented default really does mean "the surrounding text color".
+      const requestedColor = root.dataset.color ?? "currentColor";
+      const color =
+        requestedColor === "currentColor" ? getComputedStyle(root).color : requestedColor;
+      const reduceMotion = matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+      let particles: { x: number; y: number; vx: number; vy: number }[] = [];
+      let raf = 0;
+      let running = false;
+
+      function resize() {
+        canvas.width = root.clientWidth;
+        canvas.height = root.clientHeight;
+        particles = Array.from({ length: density }, () => ({
+          x: Math.random() * canvas.width,
+          y: Math.random() * canvas.height,
+          vx: (Math.random() - 0.5) * 0.3,
+          vy: (Math.random() - 0.5) * 0.3,
+        }));
+      }
+
+      function drawStaticFrame() {
+        resize();
+        if (!ctx) return;
+        ctx.fillStyle = color;
+        for (const p of particles) ctx.fillRect(p.x, p.y, 1.5, 1.5);
+      }
+
+      function tick() {
+        if (!running || !ctx) return;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = color;
+        for (const p of particles) {
+          p.x += p.vx;
+          p.y += p.vy;
+          if (p.x < 0 || p.x > canvas.width) p.vx *= -1;
+          if (p.y < 0 || p.y > canvas.height) p.vy *= -1;
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, 1.5, 0, Math.PI * 2);
+          ctx.fill();
+        }
+        ctx.strokeStyle = color;
+        ctx.globalAlpha = 0.15;
+        for (let i = 0; i < particles.length; i++) {
+          for (let j = i + 1; j < particles.length; j++) {
+            const dx = particles[i].x - particles[j].x;
+            const dy = particles[i].y - particles[j].y;
+            if (dx * dx + dy * dy < 80 * 80) {
+              ctx.beginPath();
+              ctx.moveTo(particles[i].x, particles[i].y);
+              ctx.lineTo(particles[j].x, particles[j].y);
+              ctx.stroke();
+            }
+          }
+        }
+        ctx.globalAlpha = 1;
+        raf = requestAnimationFrame(tick);
+      }
+
+      if (reduceMotion) {
+        drawStaticFrame();
+      } else {
+        const observer = new IntersectionObserver((entries) => {
+          for (const entry of entries) {
+            if (entry.isIntersecting && !running) {
+              running = true;
+              resize();
+              raf = requestAnimationFrame(tick);
+            } else if (!entry.isIntersecting && running) {
+              running = false;
+              cancelAnimationFrame(raf);
+            }
+          }
+        });
+        observer.observe(root);
+        addEventListener("resize", resize, { passive: true });
+      }
+    }
+  }
+
+  document
+    .querySelectorAll<HTMLElement>(".particle-field-root")
+    .forEach((el) => new ParticleField(el));
+</script>
+
+<style>
+  .particle-field-root {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    overflow: hidden;
+    pointer-events: none;
+  }
+  .particle-field-root canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+</style>

--- a/Resources/Template/src/lib/effects-canvas-background.spec.ts
+++ b/Resources/Template/src/lib/effects-canvas-background.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { loadEffectsCatalog } from "../../scripts/effects-catalog";
+import ParticleField from "../components/effects/ParticleField.astro";
+import AuroraGradient from "../components/effects/AuroraGradient.astro";
+import GrainOverlay from "../components/effects/GrainOverlay.astro";
+
+// This slice's three components only. The other three effect categories (cursor-reactive,
+// scroll-driven, generative-art) each ship their own per-slice spec, so this file stays green
+// regardless of which slices have landed — a single shared spec asserting all 12 entries
+// could not, and would collide between slices landing concurrently.
+const COMPONENTS: Record<string, unknown> = {
+  ParticleField,
+  AuroraGradient,
+  GrainOverlay,
+};
+
+const catalog = loadEffectsCatalog();
+const entries = catalog.components.filter((entry) => entry.component in COMPONENTS);
+
+describe("effects catalog (canvas backgrounds)", () => {
+  it("catalogs all three canvas-background components", () => {
+    expect(entries.map((entry) => entry.component).sort()).toEqual(
+      Object.keys(COMPONENTS).sort(),
+    );
+  });
+
+  it("declares every one as a placeable background layer", () => {
+    for (const entry of entries) {
+      expect(entry.category, entry.component).toBe("canvasBackground");
+      expect(entry.placement?.kind, entry.component).toBe("background");
+      expect(entry.placement?.allowedParents, entry.component).toBeNull();
+    }
+  });
+
+  it("registers every one in blocks.manifest.json", () => {
+    const manifest = JSON.parse(readFileSync("blocks.manifest.json", "utf8")) as {
+      modules: { path: string; name: string }[];
+    };
+    for (const entry of entries) {
+      const module = manifest.modules.find(
+        (candidate) => candidate.path === `src/components/effects/${entry.component}.astro`,
+      );
+      expect(module, entry.component).toBeDefined();
+      expect(module?.name, entry.component).toBe(entry.title);
+    }
+  });
+
+  it("resolves ParticleField's currentColor default before it reaches the canvas", () => {
+    // Canvas 2D silently ignores `currentColor` and keeps its default black, so the component
+    // has to resolve the keyword itself for the catalog's documented default to mean anything.
+    const source = readFileSync("src/components/effects/ParticleField.astro", "utf8");
+    expect(source).toContain("getComputedStyle(root).color");
+  });
+
+  for (const entry of entries) {
+    describe(entry.component, () => {
+      const source = readFileSync(
+        `src/components/effects/${entry.component}.astro`,
+        "utf8",
+      );
+
+      it("renders non-empty markup", async () => {
+        const container = await AstroContainer.create();
+        const html = await container.renderToString(
+          COMPONENTS[entry.component] as Parameters<typeof container.renderToString>[0],
+          { props: entry.props },
+        );
+        expect(html.length).toBeGreaterThan(0);
+      });
+
+      it("guards motion behind prefers-reduced-motion and IntersectionObserver", () => {
+        expect(source).toContain("prefers-reduced-motion");
+        expect(source).toContain("IntersectionObserver");
+      });
+
+      it("uses a plain <script>, never is:inline (CSP: script-src 'self')", () => {
+        expect(source).not.toContain("is:inline");
+      });
+
+      it("demo snapshot is fresh", async () => {
+        const container = await AstroContainer.create();
+        const inner = await container.renderToString(
+          COMPONENTS[entry.component] as Parameters<typeof container.renderToString>[0],
+          { props: entry.props },
+        );
+        // Same shape as the legacy `effects-catalog.spec.ts` demos, and for the same reason:
+        // AstroContainer#renderToString returns only the component's own markup, so the scoped
+        // <style> block has to be lifted out of the source by hand for the demo to look right
+        // offline in the gallery's WKWebView.
+        const componentCss = [...source.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)]
+          .map((match) => match[1])
+          .join("\n");
+        // Drop the hoisted <script> reference the container emits. Two reasons, either one
+        // sufficient: `EffectDemoWebView` documents demo pages as self-contained markup with
+        // inline <style> only and no <script>, and the emitted src is an absolute
+        // dev-server path into *this machine's* checkout, which would make the committed
+        // snapshot unreproducible anywhere else. A canvas effect's demo is therefore a still
+        // frame of its background layer, not a running animation.
+        const markup = inner.replace(/<script\b[^>]*>[\s\S]*?<\/script>/g, "");
+        const page = [
+          "<!doctype html>",
+          `<html lang="en"><head><meta charset="utf-8"><title>${entry.title}</title>`,
+          "<style>body{margin:0;display:grid;place-items:center;min-height:100vh;",
+          "font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>",
+          // Canvas backgrounds position themselves `absolute; inset: 0; z-index: -1`, so the demo
+          // needs the positioned ancestor every component's doc comment asks for — without it the
+          // layer would size itself against the viewport instead of a card-shaped preview.
+          "<style>.effect-demo-stage{position:relative;isolation:isolate;width:min(90vw,480px);height:min(60vh,300px)}</style>",
+          `<style>${componentCss}</style>`,
+          "</head><body>",
+          '<div class="effect-demo-stage">',
+          markup,
+          "</div>",
+          "</body></html>",
+          "",
+        ].join("\n").replace(/\r\n/g, "\n");
+        expect(page).not.toContain("<script");
+        await expect(page).toMatchFileSnapshot(
+          `../../integrations/effects-demos/${entry.component}.html`,
+        );
+      });
+    });
+  }
+});

--- a/Resources/Template/src/lib/effects-canvas-background.spec.ts
+++ b/Resources/Template/src/lib/effects-canvas-background.spec.ts
@@ -17,7 +17,9 @@ const COMPONENTS: Record<string, unknown> = {
 };
 
 const catalog = loadEffectsCatalog();
-const entries = catalog.components.filter((entry) => entry.component in COMPONENTS);
+const entries = catalog.components.filter(
+  (entry) => entry.component in COMPONENTS,
+);
 
 describe("effects catalog (canvas backgrounds)", () => {
   it("catalogs all three canvas-background components", () => {
@@ -35,12 +37,15 @@ describe("effects catalog (canvas backgrounds)", () => {
   });
 
   it("registers every one in blocks.manifest.json", () => {
-    const manifest = JSON.parse(readFileSync("blocks.manifest.json", "utf8")) as {
+    const manifest = JSON.parse(
+      readFileSync("blocks.manifest.json", "utf8"),
+    ) as {
       modules: { path: string; name: string }[];
     };
     for (const entry of entries) {
       const module = manifest.modules.find(
-        (candidate) => candidate.path === `src/components/effects/${entry.component}.astro`,
+        (candidate) =>
+          candidate.path === `src/components/effects/${entry.component}.astro`,
       );
       expect(module, entry.component).toBeDefined();
       expect(module?.name, entry.component).toBe(entry.title);
@@ -50,7 +55,10 @@ describe("effects catalog (canvas backgrounds)", () => {
   it("resolves ParticleField's currentColor default before it reaches the canvas", () => {
     // Canvas 2D silently ignores `currentColor` and keeps its default black, so the component
     // has to resolve the keyword itself for the catalog's documented default to mean anything.
-    const source = readFileSync("src/components/effects/ParticleField.astro", "utf8");
+    const source = readFileSync(
+      "src/components/effects/ParticleField.astro",
+      "utf8",
+    );
     expect(source).toContain("getComputedStyle(root).color");
   });
 
@@ -64,7 +72,9 @@ describe("effects catalog (canvas backgrounds)", () => {
       it("renders non-empty markup", async () => {
         const container = await AstroContainer.create();
         const html = await container.renderToString(
-          COMPONENTS[entry.component] as Parameters<typeof container.renderToString>[0],
+          COMPONENTS[entry.component] as Parameters<
+            typeof container.renderToString
+          >[0],
           { props: entry.props },
         );
         expect(html.length).toBeGreaterThan(0);
@@ -82,14 +92,18 @@ describe("effects catalog (canvas backgrounds)", () => {
       it("demo snapshot is fresh", async () => {
         const container = await AstroContainer.create();
         const inner = await container.renderToString(
-          COMPONENTS[entry.component] as Parameters<typeof container.renderToString>[0],
+          COMPONENTS[entry.component] as Parameters<
+            typeof container.renderToString
+          >[0],
           { props: entry.props },
         );
         // Same shape as the legacy `effects-catalog.spec.ts` demos, and for the same reason:
         // AstroContainer#renderToString returns only the component's own markup, so the scoped
         // <style> block has to be lifted out of the source by hand for the demo to look right
         // offline in the gallery's WKWebView.
-        const componentCss = [...source.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)]
+        const componentCss = [
+          ...source.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g),
+        ]
           .map((match) => match[1])
           .join("\n");
         // Drop the hoisted <script> reference the container emits. Two reasons, either one
@@ -98,7 +112,16 @@ describe("effects catalog (canvas backgrounds)", () => {
         // dev-server path into *this machine's* checkout, which would make the committed
         // snapshot unreproducible anywhere else. A canvas effect's demo is therefore a still
         // frame of its background layer, not a running animation.
-        const markup = inner.replace(/<script\b[^>]*>[\s\S]*?<\/script>/g, "");
+        //
+        // Same stripping shape as `effects-catalog.spec.ts`: case-insensitive so an uppercase
+        // <SCRIPT> can't slip through (CodeQL js/bad-tag-filter), and looped until stable so a
+        // nested/overlapping remnant can't survive a single pass
+        // (CodeQL js/incomplete-multi-character-sanitization).
+        let markup = inner;
+        for (let previous = ""; previous !== markup;) {
+          previous = markup;
+          markup = markup.replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, "");
+        }
         const page = [
           "<!doctype html>",
           `<html lang="en"><head><meta charset="utf-8"><title>${entry.title}</title>`,
@@ -115,8 +138,10 @@ describe("effects catalog (canvas backgrounds)", () => {
           "</div>",
           "</body></html>",
           "",
-        ].join("\n").replace(/\r\n/g, "\n");
-        expect(page).not.toContain("<script");
+        ]
+          .join("\n")
+          .replace(/\r\n/g, "\n");
+        expect(page.toLowerCase()).not.toContain("<script");
         await expect(page).toMatchFileSnapshot(
           `../../integrations/effects-demos/${entry.component}.html`,
         );

--- a/Resources/Template/vitest.astro.config.ts
+++ b/Resources/Template/vitest.astro.config.ts
@@ -2,6 +2,9 @@ import { getViteConfig } from "astro/config";
 
 export default getViteConfig({
   test: {
-    include: ["src/lib/effects-catalog.spec.ts"],
+    include: [
+      "src/lib/effects-catalog.spec.ts",
+      "src/lib/effects-canvas-background.spec.ts",
+    ],
   },
 });


### PR DESCRIPTION
Closes #1557

## Summary

- Adds the three **Canvas Backgrounds** effects the gallery (#1553) was built to show — `ParticleField`, `AuroraGradient`, `GrainOverlay` — as hand-authored `Resources/Template/src/components/effects/*.astro` components. Each is a full-bleed `absolute; inset: 0; z-index: -1` layer that expects a positioned ancestor (stated in every component's doc comment), draws with vanilla Canvas 2D (no third-party JS, per ADR-0008), and ships a plain non-`is:inline` `<script>` so the template's `script-src 'self'` CSP still holds. Every animation loop is gated by an `IntersectionObserver` — nothing runs off-screen — and collapses to a single static frame under `prefers-reduced-motion`.
- Registers them in `integrations/effects.json` (`category: "canvasBackground"`, `placement: { kind: "background", allowedParents: null }`) and in `blocks.manifest.json`. Both edits are strictly append-only — `effects.json` is +44/-0 — so the three sibling category slices can land beside them with at most a trivial textual conflict.
- Adds `src/lib/effects-canvas-background.spec.ts` (registered in `vitest.astro.config.ts`'s `test.include` allowlist) and the three `integrations/effects-demos/*.html` snapshots it generates, which `EffectCatalogTests.loadsRealTemplateCatalog` requires for every catalog entry.

### Two deliberate deviations from the plan's reference implementation

1. **`ParticleField` resolves its `currentColor` default.** Canvas 2D has no notion of `currentColor`; assigning it to `fillStyle` is *silently ignored* and the context keeps its default black, so the component's own documented default rendered near-invisible on the dark backgrounds this layer is usually dropped behind. It now resolves the keyword against `getComputedStyle(root).color`. Verified live in a browser against the dev server (see Test plan) — before/after is the difference between a nearly blank panel and the intended constellation of dots and connecting lines. A spec case pins the resolution in place.
2. **The generated demo pages strip the container-emitted hoisted `<script>`.** Two independent reasons, either sufficient: `EffectDemoWebView` documents demo pages as *"self-contained HTML with inline `<style>` only, no `<script>` tags"*, and the `src` Astro's container API emits is an absolute path into the generating machine's checkout, which would make the committed snapshot unreproducible on any other machine. Consequence worth knowing: **a canvas effect's gallery preview is a still frame of its background layer, not a running animation.** That is inherent to the script-free demo contract and will apply to the other three slices too; the effect itself animates normally once placed on a real page. The spec asserts `expect(page).not.toContain("<script")` so this can't regress into a machine-specific snapshot.

The demo pages also wrap the effect in a `.effect-demo-stage` positioned box, since a background layer with no positioned ancestor would size itself against the viewport instead of a card-shaped preview.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

Template-only (`Resources/Template/`), which `CLAUDE.md` ▸ "Two-repo coordination" defines as app-only. No MCP message-schema surface is touched, and no Swift changed — `EffectCatalog` already decodes `canvasBackground` and `placement`.

## Test plan

- [x] `swift test --package-path . --filter EffectCatalog` — 4/4 pass, including `loadsRealTemplateCatalog` (a demo file exists for every catalog entry) and `onlyNewCategoriesArePlaceable` (every new-category entry declares `placement`).
- [x] `swift test --package-path .` — full suite, run locally on Xcode 27 per `CONTRIBUTING.md` ("if you touch `Resources/Template/`, run `swift test` too").
- [x] `cd Resources/Template && npm test` — 902 pass / 2 skipped / 0 fail, then `npm run test:astro` 51/51.
- [x] `cd Resources/Template && npm run test:astro` — the new suite alone. Confirmed **failing first**: with the spec registered but the components absent it failed with `Cannot find module '../components/effects/ParticleField.astro'`, and passed only once the components landed.
- [x] `npx astro check` — no diagnostics on any of the three new components. (The one pre-existing error in the run, `worker/worker.ts` importing the generated `./experiments.json`, is unrelated and present on `main`.)
- [x] **Snapshot reproducibility** — re-rendered the whole template from a different absolute path (a copy outside the worktree) and `diff -r` on `integrations/effects-demos/` reported the three new demos byte-identical, so the committed snapshots don't encode this machine's checkout path.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **not run.** No Swift, `project.yml`, or app-target file changed; the full `swift test` above compiles the app targets. Flagging it rather than silently dropping it.

### Manual QA

Ran the template's own Astro dev server with a temporary page importing all three components (page deleted before committing; it is not part of this PR) and inspected the live render:

- `ParticleField` — drifting dots with faint connecting lines below the distance threshold. This is what surfaced the `currentColor` defect above.
- `AuroraGradient` — slow blurred purple/blue/teal blobs.
- `GrainOverlay` — animated film-grain texture over the section's background.

Worth a second pair of eyes on: whether the still-frame gallery preview (deviation 2) is acceptable for canvas effects, since it sets the pattern for the remaining three slices, and a `prefers-reduced-motion: reduce` pass on a real site — the reduced-motion branch draws one static frame and never starts a rAF loop, which I read but did not exercise in a browser with the setting enabled.

_Opened by the software factory (Phase C) — epic #1256._
