### PR TITLE
feat(#1560): generative-art effects (BlobMorph, MeshGradient, DotGridPulse)

### DIFF
--- a/Resources/Template/blocks.manifest.json
+++ b/Resources/Template/blocks.manifest.json
@@ -1,4 +1,17 @@
 {
   "schemaVersion": "anglesite-block-manifest/1",
-  "modules": []
+  "modules": [
+    {
+      "path": "src/components/effects/BlobMorph.astro",
+      "name": "Blob Morph"
+    },
+    {
+      "path": "src/components/effects/MeshGradient.astro",
+      "name": "Mesh Gradient"
+    },
+    {
+      "path": "src/components/effects/DotGridPulse.astro",
+      "name": "Dot Grid Pulse"
+    }
+  ]
 }

--- a/Resources/Template/integrations/effects-demos/BlobMorph.html
+++ b/Resources/Template/integrations/effects-demos/BlobMorph.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Blob Morph</title>
+<style>body{margin:0;position:relative;min-height:100vh;display:grid;place-items:center;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  .blob-morph {
+    width: var(--blob-size, 320px);
+    height: var(--blob-size, 320px);
+    background: color-mix(in srgb, var(--blob-color, currentColor) 25%, transparent);
+    animation: blob-morph-shift 12s ease-in-out infinite;
+  }
+  @keyframes blob-morph-shift {
+    0%, 100% { border-radius: 42% 58% 65% 35% / 45% 40% 60% 55%; }
+    33% { border-radius: 60% 40% 30% 70% / 55% 65% 35% 45%; }
+    66% { border-radius: 35% 65% 55% 45% / 40% 30% 70% 60%; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .blob-morph { animation: none; border-radius: 45% 55% 60% 40% / 50% 45% 55% 50%; }
+  }
+</style>
+</head><body>
+<div class="blob-morph" style="--blob-color: currentColor; --blob-size: 320px" data-astro-cid-iq7owtmc></div>
+</body></html>

--- a/Resources/Template/integrations/effects-demos/DotGridPulse.html
+++ b/Resources/Template/integrations/effects-demos/DotGridPulse.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Dot Grid Pulse</title>
+<style>body{margin:0;position:relative;min-height:100vh;display:grid;place-items:center;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  .dot-grid-pulse {
+    display: grid;
+    grid-template-columns: repeat(var(--dgp-columns, 8), 1fr);
+    gap: 1em;
+    padding: 1em;
+  }
+  .dot-grid-pulse-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--dgp-color, currentColor);
+    animation: dot-grid-pulse-fade 2.4s ease-in-out infinite;
+    animation-delay: var(--dgp-delay, 0s);
+  }
+  @keyframes dot-grid-pulse-fade {
+    0%, 100% { opacity: 0.15; }
+    50% { opacity: 1; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dot-grid-pulse-dot { animation: none; opacity: 0.6; }
+  }
+</style>
+</head><body>
+<div class="dot-grid-pulse" style="--dgp-columns: 8; --dgp-color: currentColor" data-astro-cid-ccc3d5r3><span class="dot-grid-pulse-dot" style="--dgp-delay: 0s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.1s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.2s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.30000000000000004s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.4s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.5s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.6000000000000001s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.7000000000000001s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.1s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.2s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.30000000000000004s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.4s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.5s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.6s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.7000000000000001s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.8s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.2s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.30000000000000004s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.4s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.5s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.6000000000000001s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.7s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.8s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.9000000000000001s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.30000000000000004s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.4s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.5s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.6000000000000001s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.7000000000000001s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.8s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 0.9000000000000001s" data-astro-cid-ccc3d5r3></span><span class="dot-grid-pulse-dot" style="--dgp-delay: 1s" data-astro-cid-ccc3d5r3></span></div>
+</body></html>

--- a/Resources/Template/integrations/effects-demos/MeshGradient.html
+++ b/Resources/Template/integrations/effects-demos/MeshGradient.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Mesh Gradient</title>
+<style>body{margin:0;position:relative;min-height:100vh;display:grid;place-items:center;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  .mesh-gradient {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+  .mesh-gradient-blob {
+    animation: mesh-gradient-drift 18s ease-in-out infinite;
+    animation-delay: var(--mesh-delay, 0s);
+    transform-origin: center;
+  }
+  @keyframes mesh-gradient-drift {
+    0%, 100% { transform: translate(0, 0) scale(1); }
+    50% { transform: translate(20px, -15px) scale(1.1); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .mesh-gradient-blob { animation: none; }
+  }
+</style>
+</head><body>
+<svg class="mesh-gradient" viewBox="0 0 400 400" preserveAspectRatio="xMidYMid slice" aria-hidden="true" data-astro-cid-z2cllfib><defs data-astro-cid-z2cllfib><radialGradient id="mesh-gradient-0" cx="50%" cy="50%" r="60%" data-astro-cid-z2cllfib><stop offset="0%" stop-color="#7c3aed" stop-opacity="0.6" data-astro-cid-z2cllfib></stop><stop offset="100%" stop-color="#7c3aed" stop-opacity="0" data-astro-cid-z2cllfib></stop></radialGradient><radialGradient id="mesh-gradient-1" cx="50%" cy="50%" r="60%" data-astro-cid-z2cllfib><stop offset="0%" stop-color="#2563eb" stop-opacity="0.6" data-astro-cid-z2cllfib></stop><stop offset="100%" stop-color="#2563eb" stop-opacity="0" data-astro-cid-z2cllfib></stop></radialGradient><radialGradient id="mesh-gradient-2" cx="50%" cy="50%" r="60%" data-astro-cid-z2cllfib><stop offset="0%" stop-color="#0891b2" stop-opacity="0.6" data-astro-cid-z2cllfib></stop><stop offset="100%" stop-color="#0891b2" stop-opacity="0" data-astro-cid-z2cllfib></stop></radialGradient><radialGradient id="mesh-gradient-3" cx="50%" cy="50%" r="60%" data-astro-cid-z2cllfib><stop offset="0%" stop-color="#db2777" stop-opacity="0.6" data-astro-cid-z2cllfib></stop><stop offset="100%" stop-color="#db2777" stop-opacity="0" data-astro-cid-z2cllfib></stop></radialGradient></defs><circle cx="80" cy="80" r="180" fill="url(#mesh-gradient-0)" class="mesh-gradient-blob" style="--mesh-delay: 0s" data-astro-cid-z2cllfib></circle><circle cx="170" cy="217" r="180" fill="url(#mesh-gradient-1)" class="mesh-gradient-blob" style="--mesh-delay: -3s" data-astro-cid-z2cllfib></circle><circle cx="260" cy="114" r="180" fill="url(#mesh-gradient-2)" class="mesh-gradient-blob" style="--mesh-delay: -6s" data-astro-cid-z2cllfib></circle><circle cx="350" cy="251" r="180" fill="url(#mesh-gradient-3)" class="mesh-gradient-blob" style="--mesh-delay: -9s" data-astro-cid-z2cllfib></circle></svg>
+</body></html>

--- a/Resources/Template/integrations/effects.json
+++ b/Resources/Template/integrations/effects.json
@@ -229,6 +229,54 @@
         "value": 60
       },
       "snippet": "---\nimport ProgressBar from \"@astroanimate/core/ProgressBar\";\n---\n<ProgressBar value={60} label=\"Upload progress\" />"
+    },
+    {
+      "component": "BlobMorph",
+      "title": "Blob Morph",
+      "ownerDescription": "A soft, organic shape that continuously morphs between blob outlines.",
+      "category": "generativeArt",
+      "keyProps": {
+        "color": "CSS color (default \"currentColor\")",
+        "size": "CSS size, e.g. \"320px\" (default \"320px\")"
+      },
+      "props": {},
+      "snippet": "---\nimport BlobMorph from \"../components/effects/BlobMorph.astro\";\n---\n<BlobMorph color=\"#7c3aed\" size=\"280px\" />",
+      "placement": {
+        "kind": "inline",
+        "allowedParents": null
+      }
+    },
+    {
+      "component": "MeshGradient",
+      "title": "Mesh Gradient",
+      "ownerDescription": "A soft, drifting gradient mesh built from overlapping radial blobs.",
+      "category": "generativeArt",
+      "keyProps": {
+        "colors": "array of CSS colors (default 4-color palette)"
+      },
+      "props": {},
+      "snippet": "---\nimport MeshGradient from \"../components/effects/MeshGradient.astro\";\n---\n<MeshGradient colors={[\"#7c3aed\", \"#2563eb\", \"#0891b2\", \"#db2777\"]} />",
+      "placement": {
+        "kind": "inline",
+        "allowedParents": null
+      }
+    },
+    {
+      "component": "DotGridPulse",
+      "title": "Dot Grid Pulse",
+      "ownerDescription": "A grid of dots that pulses in a gentle diagonal wave.",
+      "category": "generativeArt",
+      "keyProps": {
+        "columns": "number of columns (default 8)",
+        "rows": "number of rows (default 4)",
+        "color": "CSS color (default \"currentColor\")"
+      },
+      "props": {},
+      "snippet": "---\nimport DotGridPulse from \"../components/effects/DotGridPulse.astro\";\n---\n<DotGridPulse columns={8} rows={4} color=\"#2563eb\" />",
+      "placement": {
+        "kind": "inline",
+        "allowedParents": null
+      }
     }
   ]
 }

--- a/Resources/Template/src/components/effects/BlobMorph.astro
+++ b/Resources/Template/src/components/effects/BlobMorph.astro
@@ -1,0 +1,25 @@
+---
+interface Props {
+  color?: string;
+  size?: string;
+}
+const { color = "currentColor", size = "320px" } = Astro.props;
+---
+<div class="blob-morph" style={`--blob-color: ${color}; --blob-size: ${size}`}></div>
+
+<style>
+  .blob-morph {
+    width: var(--blob-size, 320px);
+    height: var(--blob-size, 320px);
+    background: color-mix(in srgb, var(--blob-color, currentColor) 25%, transparent);
+    animation: blob-morph-shift 12s ease-in-out infinite;
+  }
+  @keyframes blob-morph-shift {
+    0%, 100% { border-radius: 42% 58% 65% 35% / 45% 40% 60% 55%; }
+    33% { border-radius: 60% 40% 30% 70% / 55% 65% 35% 45%; }
+    66% { border-radius: 35% 65% 55% 45% / 40% 30% 70% 60%; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .blob-morph { animation: none; border-radius: 45% 55% 60% 40% / 50% 45% 55% 50%; }
+  }
+</style>

--- a/Resources/Template/src/components/effects/DotGridPulse.astro
+++ b/Resources/Template/src/components/effects/DotGridPulse.astro
@@ -1,0 +1,38 @@
+---
+interface Props {
+  columns?: number;
+  rows?: number;
+  color?: string;
+}
+const { columns = 8, rows = 4, color = "currentColor" } = Astro.props;
+const dots = Array.from({ length: columns * rows }, (_, i) => i);
+---
+<div class="dot-grid-pulse" style={`--dgp-columns: ${columns}; --dgp-color: ${color}`}>
+  {dots.map((i) => (
+    <span class="dot-grid-pulse-dot" style={`--dgp-delay: ${(i % columns) * 0.1 + Math.floor(i / columns) * 0.1}s`}></span>
+  ))}
+</div>
+
+<style>
+  .dot-grid-pulse {
+    display: grid;
+    grid-template-columns: repeat(var(--dgp-columns, 8), 1fr);
+    gap: 1em;
+    padding: 1em;
+  }
+  .dot-grid-pulse-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--dgp-color, currentColor);
+    animation: dot-grid-pulse-fade 2.4s ease-in-out infinite;
+    animation-delay: var(--dgp-delay, 0s);
+  }
+  @keyframes dot-grid-pulse-fade {
+    0%, 100% { opacity: 0.15; }
+    50% { opacity: 1; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dot-grid-pulse-dot { animation: none; opacity: 0.6; }
+  }
+</style>

--- a/Resources/Template/src/components/effects/MeshGradient.astro
+++ b/Resources/Template/src/components/effects/MeshGradient.astro
@@ -1,0 +1,46 @@
+---
+interface Props {
+  colors?: string[];
+}
+const { colors = ["#7c3aed", "#2563eb", "#0891b2", "#db2777"] } = Astro.props;
+---
+<svg class="mesh-gradient" viewBox="0 0 400 400" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+  <defs>
+    {colors.map((color, i) => (
+      <radialGradient id={`mesh-gradient-${i}`} cx="50%" cy="50%" r="60%">
+        <stop offset="0%" stop-color={color} stop-opacity="0.6" />
+        <stop offset="100%" stop-color={color} stop-opacity="0" />
+      </radialGradient>
+    ))}
+  </defs>
+  {colors.map((_, i) => (
+    <circle
+      cx={80 + i * 90}
+      cy={80 + ((i * 137) % 240)}
+      r="180"
+      fill={`url(#mesh-gradient-${i})`}
+      class="mesh-gradient-blob"
+      style={`--mesh-delay: ${i * -3}s`}
+    />
+  ))}
+</svg>
+
+<style>
+  .mesh-gradient {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+  .mesh-gradient-blob {
+    animation: mesh-gradient-drift 18s ease-in-out infinite;
+    animation-delay: var(--mesh-delay, 0s);
+    transform-origin: center;
+  }
+  @keyframes mesh-gradient-drift {
+    0%, 100% { transform: translate(0, 0) scale(1); }
+    50% { transform: translate(20px, -15px) scale(1.1); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .mesh-gradient-blob { animation: none; }
+  }
+</style>

--- a/Resources/Template/src/lib/effects-generative-art.spec.ts
+++ b/Resources/Template/src/lib/effects-generative-art.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { loadEffectsCatalog, placeableEntries } from "../../scripts/effects-catalog";
+
+const catalog = loadEffectsCatalog();
+const entries = placeableEntries(catalog).filter((e) => e.category === "generativeArt");
+
+describe("effects library (generative art)", () => {
+  it("has exactly 3 generative-art entries, all inline placement", () => {
+    expect(entries.length).toBe(3);
+    for (const entry of entries) {
+      expect(entry.placement?.kind, entry.component).toBe("inline");
+    }
+  });
+
+  it("every entry has a matching blocks.manifest.json module", () => {
+    const manifest = JSON.parse(readFileSync("blocks.manifest.json", "utf8")) as {
+      modules: { path: string; name: string }[];
+    };
+    for (const entry of entries) {
+      const expectedPath = `src/components/effects/${entry.component}.astro`;
+      const module = manifest.modules.find((m) => m.path === expectedPath);
+      expect(module, `${entry.component} missing from blocks.manifest.json`).toBeDefined();
+      expect(module?.name).toBe(entry.title);
+    }
+  });
+
+  it("never emits a <script> tag", () => {
+    for (const entry of entries) {
+      const source = readFileSync(`src/components/effects/${entry.component}.astro`, "utf8");
+      // Strip HTML comments first so comment prose mentioning the tag can't
+      // trip this check (mirrors effects-catalog.spec.ts's approach), then
+      // check the raw source for a literal opening tag.
+      let sourceWithoutComments = source;
+      for (let previous = ""; previous !== sourceWithoutComments; ) {
+        previous = sourceWithoutComments;
+        sourceWithoutComments = sourceWithoutComments.replace(/<!--[\s\S]*?-->/g, "");
+      }
+      expect(sourceWithoutComments, entry.component).not.toContain("<script");
+    }
+  });
+
+  for (const entry of entries) {
+    describe(entry.component, () => {
+      it("renders and guards reduced motion", async () => {
+        const container = await AstroContainer.create();
+        const mod = await import(/* @vite-ignore */ `../components/effects/${entry.component}.astro`);
+        const html = await container.renderToString(mod.default, { props: entry.props });
+        expect(html.length).toBeGreaterThan(0);
+        const source = readFileSync(`src/components/effects/${entry.component}.astro`, "utf8");
+        expect(source, entry.component).toContain("@media (prefers-reduced-motion: reduce)");
+      });
+
+      it("demo snapshot is fresh", async () => {
+        const container = await AstroContainer.create();
+        const mod = await import(/* @vite-ignore */ `../components/effects/${entry.component}.astro`);
+        const inner = await container.renderToString(mod.default, { props: entry.props });
+        const source = readFileSync(`src/components/effects/${entry.component}.astro`, "utf8");
+        const css = [...source.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map((m) => m[1]).join("\n");
+        const page = [
+          "<!doctype html>",
+          `<html lang="en"><head><meta charset="utf-8"><title>${entry.title}</title>`,
+          "<style>body{margin:0;position:relative;min-height:100vh;display:grid;place-items:center;",
+          "font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>",
+          `<style>${css}</style>`,
+          "</head><body>",
+          inner,
+          "</body></html>",
+          "",
+        ].join("\n").replace(/\r\n/g, "\n");
+        await expect(page).toMatchFileSnapshot(`../../integrations/effects-demos/${entry.component}.html`);
+      });
+    });
+  }
+});

--- a/Resources/Template/vitest.astro.config.ts
+++ b/Resources/Template/vitest.astro.config.ts
@@ -2,6 +2,6 @@ import { getViteConfig } from "astro/config";
 
 export default getViteConfig({
   test: {
-    include: ["src/lib/effects-catalog.spec.ts"],
+    include: ["src/lib/effects-catalog.spec.ts", "src/lib/effects-generative-art.spec.ts"],
   },
 });


### PR DESCRIPTION
Closes #1560

## Summary

- Adds three placeable, pure CSS/SVG generative-art effects — `BlobMorph`, `MeshGradient`, `DotGridPulse` — with no `<script>` tags, per Task 17 of the [effects-gallery plan](docs/superpowers/plans/2026-08-17-effects-gallery.md).
- Appends the three `generativeArt`/`inline`-placement entries to `integrations/effects.json` and matching modules to `blocks.manifest.json`, both append-only (no existing entries touched).
- Adds `src/lib/effects-generative-art.spec.ts` (registered in `vitest.astro.config.ts`), generating the three `integrations/effects-demos/*.html` snapshots asserted by the Swift `EffectCatalogTests`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `cd Resources/Template && npm run test:astro` — both `effects-catalog.spec.ts` and `effects-generative-art.spec.ts` pass (44 tests)
- [x] `cd Resources/Template && npm test` — full template suite passes (902 node tests + 44 vitest tests)
- [x] `swift test --package-path . --filter EffectCatalog` — all 4 `EffectCatalogTests` pass (demo files found for every catalog entry; only new-category entries carry `placement`)
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run; this slice is confined to `Resources/Template/` with no Swift changes (per issue scope)
- [ ] Manual smoke: N/A — no Swift/UI changes in this slice