### PR TITLE
fix(#768): unblock click-to-place, add AddEffectIntent

### DIFF
--- a/JS/edit-overlay/src/overlay.ts
+++ b/JS/edit-overlay/src/overlay.ts
@@ -124,7 +124,14 @@ export interface PlacementPickControls {
 /** Placement-pick mode: while active, a click on ANY element (not just EDITABLE_TAG) reports its
  *  ElementInfo via `anglesite:pick-placement` instead of the normal click-to-edit path. Entered
  *  only via an explicit native call (`window.anglesite._enterPlacementMode()`), never ambient —
- *  outside this mode, ordinary click-to-edit behavior (`attachClickToEdit`) is unaffected. */
+ *  outside this mode, ordinary click-to-edit behavior (`attachClickToEdit`) is unaffected.
+ *
+ *  `active` is closure-local and resets to `false` whenever this script re-runs, which any real
+ *  navigation (HMR reload, route change, ⌘R) causes. The native side can't see that happen, so it
+ *  watches its own `WKNavigationDelegate` instead: `PreviewView.onPreviewNavigated` cancels an
+ *  in-flight pick rather than leaving a HUD armed over a listener that no longer exists
+ *  (#768 final review, Finding 8). Nothing here re-arms itself on load — arming is always an
+ *  explicit native call. */
 export function installPlacementPickMode(win: Window & typeof globalThis = window): PlacementPickControls {
   let active = false;
 

--- a/Sources/AnglesiteApp/EffectPlacementController.swift
+++ b/Sources/AnglesiteApp/EffectPlacementController.swift
@@ -21,7 +21,18 @@ public final class EffectPlacementController {
 
     public private(set) var state: State = .idle
 
-    private let path: String
+    /// Which side of the clicked element an `inline` effect lands on — bound to the placement
+    /// HUD's before/after toggle (``EffectPlacementHUD``), which the design spec §3 calls for and
+    /// which nothing threaded through until now (#768 final review, Finding 6). Ignored by
+    /// `background` placements. Persists across picks so an owner placing several effects doesn't
+    /// have to re-choose each time.
+    public var inlinePosition: PlacementMatcher.InlinePosition = .after
+
+    /// The project-relative `.astro` page source this controller places into — resolved from the
+    /// live preview's route by ``PageSourcePath`` before construction, never a raw route (the
+    /// sidecar rejects those; #768 final review, Finding 1). Readable so callers and tests can
+    /// verify the target without re-deriving it.
+    public let path: String
     private let pageModelClient: PageModelClient
     private let editRouter: any EditRouter
     private var exitOverlayMode: (() -> Void)?
@@ -80,7 +91,9 @@ public final class EffectPlacementController {
 
         do {
             let model = try await pageModelClient.fetch(path: path)
-            switch PlacementMatcher.resolve(element: message.element, in: model, placement: placement) {
+            switch PlacementMatcher.resolve(
+                element: message.element, in: model, placement: placement,
+                inlinePosition: inlinePosition) {
             case .success(let insertion):
                 let edit = ComponentStructureEditBuilder.insertBlock(
                     id: UUID().uuidString, path: path, baseVersion: model.version,

--- a/Sources/AnglesiteApp/EffectPlacementHUD.swift
+++ b/Sources/AnglesiteApp/EffectPlacementHUD.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import AnglesiteCore
+
+/// The click-to-place HUD for the Effects gallery (#768): "Click where to place this effect",
+/// the `inline` before/after toggle, Cancel, and the transient success/failure banner.
+///
+/// **Why this lives on the site window, not in `EffectsGalleryView`.** The gallery is presented as
+/// a `.sheet`, and a macOS sheet is *window-modal*: it blocks input to its parent window's content
+/// — which is exactly where the live preview the owner is being asked to click lives. A HUD
+/// rendered inside the sheet therefore asked for a click on a surface the sheet itself was
+/// blocking (#768 final review, Finding 4). "Apply to Page…" now dismisses the gallery and this
+/// HUD takes over on the main window, over a genuinely clickable preview.
+///
+/// Rendered as a bottom-aligned `.overlay` on the site window's content, so it occupies only the
+/// capsule's own bounds — everything around it stays hit-testable, and an idle HUD is an
+/// `EmptyView` that takes no space at all. It stays mounted (rather than being wrapped in an `if`
+/// at the call site) because it owns the transient-banner timing below.
+struct EffectPlacementHUD: View {
+    @Bindable var controller: EffectPlacementController
+
+    /// Controls the transient success/failure banner: set true when `controller.state` becomes
+    /// `.succeeded`/`.failed`, then cleared after a short delay so the banner fades away. Once the
+    /// banner is cleared, `controller.acknowledge()` returns the controller to `.idle` — until
+    /// then "Apply to Page…" stays disabled (see `EffectPlacementController`'s `.idle` guard on
+    /// `startPlacement`), which is the point: no second pick can start while this one's result is
+    /// still on screen.
+    @State private var showTransientBanner = false
+
+    var body: some View {
+        content
+            .onChange(of: controller.state) { _, newState in
+                switch newState {
+                case .succeeded, .failed:
+                    showTransientBanner = true
+                    Task {
+                        try? await Task.sleep(for: .seconds(2.5))
+                        showTransientBanner = false
+                        controller.acknowledge()
+                    }
+                default:
+                    showTransientBanner = false
+                }
+            }
+    }
+
+    @ViewBuilder private var content: some View {
+        switch controller.state {
+        case .picking(let entry):
+            banner(message: "Click where to place this effect", tint: .accentColor) {
+                if entry.placement?.kind == .inline {
+                    inlinePositionPicker
+                }
+                Button("Cancel") { controller.cancel() }
+                    // Esc, without needing the gallery sheet (which by now is dismissed) to carry
+                    // an `.onExitCommand` for it.
+                    .keyboardShortcut(.cancelAction)
+            }
+        case .applying:
+            banner(message: "Applying…", tint: .accentColor) { EmptyView() }
+        case .succeeded where showTransientBanner:
+            banner(message: "Effect placed.", tint: .green) { EmptyView() }
+        case .failed(let message) where showTransientBanner:
+            banner(message: message, tint: .red) { EmptyView() }
+        default:
+            EmptyView()
+        }
+    }
+
+    /// Before/after choice for `inline` placements, required by the design spec §3 (the placement
+    /// HUD's "small before/after toggle") — `PlacementMatcher.resolve` used to hardcode "after"
+    /// with no way to say otherwise (#768 final review, Finding 6).
+    private var inlinePositionPicker: some View {
+        Picker("Place", selection: $controller.inlinePosition) {
+            Text("Before").tag(PlacementMatcher.InlinePosition.before)
+            Text("After").tag(PlacementMatcher.InlinePosition.after)
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .fixedSize()
+        .accessibilityLabel("Place the effect before or after the element you click")
+    }
+
+    private func banner<Accessory: View>(
+        message: String, tint: Color, @ViewBuilder accessory: () -> Accessory
+    ) -> some View {
+        HStack(spacing: 12) {
+            Text(message)
+            accessory()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.regularMaterial, in: Capsule())
+        .overlay(Capsule().stroke(tint, lineWidth: 1))
+        .padding(.bottom, 24)
+        .transition(.opacity)
+        .animation(.default, value: showTransientBanner)
+    }
+}

--- a/Sources/AnglesiteApp/EffectsGalleryView.swift
+++ b/Sources/AnglesiteApp/EffectsGalleryView.swift
@@ -55,6 +55,11 @@ final class EffectsGalleryModel {
 /// `controller`, `enterOverlayMode`, and `exitOverlayMode` are injected by the caller (Task 12:
 /// `SiteWindow`/`SiteWindowModel`, which own the live preview's `WKWebView` and construct the
 /// per-window `EffectPlacementController`) — this view has no WKWebView dependency of its own.
+///
+/// Once a placement starts, this sheet is out of the picture: it dismisses itself and the
+/// placement HUD (``EffectPlacementHUD``, rendered on the site window) takes over. A sheet is
+/// window-modal, so leaving it up would block clicks to the live preview the owner is being asked
+/// to click (#768 final review, Finding 4).
 struct EffectsGalleryView: View {
     @State private var model = EffectsGalleryModel()
     let controller: EffectPlacementController
@@ -62,17 +67,14 @@ struct EffectsGalleryView: View {
     let exitOverlayMode: () -> Void
     @Environment(\.dismiss) private var dismiss
 
-    /// Controls the transient success/failure banner: set true when `controller.state` becomes
-    /// `.succeeded`/`.failed`, then cleared after a short delay so the banner fades away. Once the
-    /// banner is cleared, `controller.acknowledge()` returns the controller to `.idle` — until
-    /// then "Apply to Page…" stays disabled (see `EffectPlacementController`'s `.idle` guard on
-    /// `startPlacement`), which is the point: no second pick can start while this one's result is
-    /// still on screen.
-    @State private var showTransientBanner = false
+    /// Set by ``startPlacement(for:)`` immediately before dismissing this sheet, so `onDisappear`
+    /// can tell "the owner closed the gallery" from "the gallery handed off to the placement HUD".
+    /// Without it, the hand-off's own dismissal would cancel the pick it just started.
+    @State private var didHandOffToPlacement = false
 
     var body: some View {
         NavigationStack {
-            content
+            galleryContent
                 .navigationTitle("Effects")
                 .toolbar {
                     ToolbarItem(placement: .confirmationAction) {
@@ -82,27 +84,28 @@ struct EffectsGalleryView: View {
         }
         .frame(minWidth: 760, minHeight: 520)
         .task { model.load() }
-        .onExitCommand { controller.cancel() }
-        .onChange(of: controller.state) { _, newState in
-            switch newState {
-            case .succeeded, .failed:
-                showTransientBanner = true
-                Task {
-                    try? await Task.sleep(for: .seconds(2.5))
-                    showTransientBanner = false
-                    controller.acknowledge()
-                }
-            default:
-                showTransientBanner = false
-            }
+        // Any dismissal that isn't a placement hand-off cancels an in-progress pick (#768 final
+        // review, Finding 2). `.onExitCommand` alone covered Esc but not Done — or a click on the
+        // dimmed parent, or a programmatic dismiss — each of which used to leave the controller
+        // `.picking` and the overlay's click-capture listener live, so the owner's next unrelated
+        // click on the preview was silently swallowed and applied as an insert. `cancel()` is a
+        // no-op when nothing is in progress, so the non-placement case costs nothing.
+        .onDisappear {
+            guard !didHandOffToPlacement else { return }
+            controller.cancel()
         }
     }
 
-    @ViewBuilder private var content: some View {
-        ZStack {
-            galleryContent
-            placementHUD
-        }
+    /// Starts a pick and gets out of the way: the gallery is a window-modal sheet, so it has to be
+    /// dismissed before the owner can click the live preview underneath it at all (#768 final
+    /// review, Finding 4). From here on the placement HUD on the site window
+    /// (``EffectPlacementHUD``, presented by `SiteWindow`) owns the interaction — including Cancel
+    /// and Esc — so cancelling never means reopening this sheet.
+    private func startPlacement(for entry: EffectCatalogEntry) {
+        didHandOffToPlacement = true
+        controller.startPlacement(
+            for: entry, enterOverlayMode: enterOverlayMode, exitOverlayMode: exitOverlayMode)
+        dismiss()
     }
 
     @ViewBuilder private var galleryContent: some View {
@@ -120,8 +123,7 @@ struct EffectsGalleryView: View {
                         entry: entry,
                         demoURL: model.demoURL(for: entry),
                         controller: controller,
-                        enterOverlayMode: enterOverlayMode,
-                        exitOverlayMode: exitOverlayMode)
+                        startPlacement: { startPlacement(for: $0) })
                 } else {
                     ContentUnavailableView(
                         "No Component Selected",
@@ -132,43 +134,6 @@ struct EffectsGalleryView: View {
             ProgressView("Loading effects…")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-    }
-
-    /// Click-to-place HUD: the persistent "pick a spot" / "applying" states, plus a transient
-    /// banner for the terminal `.succeeded`/`.failed` states (see `showTransientBanner`).
-    @ViewBuilder private var placementHUD: some View {
-        switch controller.state {
-        case .picking:
-            placementBanner(message: "Click where to place this effect", tint: .accentColor, showCancelButton: true)
-        case .applying:
-            placementBanner(message: "Applying…", tint: .accentColor, showCancelButton: false)
-        case .succeeded where showTransientBanner:
-            placementBanner(message: "Effect placed.", tint: .green, showCancelButton: false)
-        case .failed(let message) where showTransientBanner:
-            placementBanner(message: message, tint: .red, showCancelButton: false)
-        default:
-            EmptyView()
-        }
-    }
-
-    private func placementBanner(message: String, tint: Color, showCancelButton: Bool) -> some View {
-        VStack {
-            Spacer()
-            HStack(spacing: 12) {
-                Text(message)
-                if showCancelButton {
-                    Button("Cancel") { controller.cancel() }
-                }
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
-            .background(.regularMaterial, in: Capsule())
-            .overlay(Capsule().stroke(tint, lineWidth: 1))
-            .padding(.bottom, 24)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .transition(.opacity)
-        .animation(.default, value: showTransientBanner)
     }
 
     /// Sidebar list, grouped under two contiguous headings. `EffectCategory` cases are ordered by
@@ -231,8 +196,9 @@ private struct EffectDetailView: View {
     let entry: EffectCatalogEntry
     let demoURL: URL?
     @Bindable var controller: EffectPlacementController
-    let enterOverlayMode: () -> Void
-    let exitOverlayMode: () -> Void
+    /// Hands the entry back to `EffectsGalleryView.startPlacement(for:)`, which arms the
+    /// controller *and* dismisses the gallery so the live preview is clickable.
+    let startPlacement: (EffectCatalogEntry) -> Void
     @State private var didCopy = false
 
     var body: some View {
@@ -263,8 +229,7 @@ private struct EffectDetailView: View {
 
                 if entry.placement != nil {
                     Button {
-                        controller.startPlacement(
-                            for: entry, enterOverlayMode: enterOverlayMode, exitOverlayMode: exitOverlayMode)
+                        startPlacement(entry)
                     } label: {
                         Label("Apply to Page…", systemImage: "hand.tap")
                     }

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -361,6 +361,9 @@
     "Add" : {
 
     },
+    "Add ${effect} to ${site}" : {
+
+    },
     "Add Agent…" : {
 
     },
@@ -452,6 +455,9 @@
 
     },
     "Advanced" : {
+
+    },
+    "After" : {
 
     },
     "Agent Readiness" : {
@@ -711,6 +717,9 @@
 
     },
     "Base styles" : {
+
+    },
+    "Before" : {
 
     },
     "Before your first publish, pick what license covers your content. \"All rights reserved\" is a valid choice — Anglesite just never picks it for you silently." : {
@@ -2747,6 +2756,12 @@
 
     },
     "Pick a color scheme" : {
+
+    },
+    "Place" : {
+
+    },
+    "Place the effect before or after the element you click" : {
 
     },
     "Plan social media for ${site}" : {

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -258,11 +258,18 @@ final class PreviewModel {
         // would be enabled during the dispatch gap and could race the opening boot.
         let token = markDevServerCommandInFlight()
         let router = self.editRouter
+        // `PageModelClient` mirrors `editRouter`'s `mcpClient` getter — a fresh lookup per call
+        // rather than a value pinned at construction, so it keeps working across a dev-server
+        // restart that swaps out `runtime`'s underlying MCP connection.
+        let pageModelClient = PageModelClient(mcpClient: { [weak self] in await self?.runtime.mcpClient })
         Task {
             // Register before starting the runtime so a Siri edit fired during dev-server boot
             // hits the router (and gets an "MCP not running" failure reply) rather than
-            // returning the bridge's no-router fallback message.
+            // returning the bridge's no-router fallback message. `PageModelClientRegistry` is
+            // registered alongside it so `AddEffectIntent` (#768) can fetch a page's model for
+            // the same site the same way `EditContentIntent` reaches its edit router.
             await EditRouterRegistry.shared.register(router, for: siteID)
+            await PageModelClientRegistry.shared.register(pageModelClient, for: siteID)
             await runtime.start(siteID: siteID, siteDirectory: siteDirectory)
             // #587: pull any visitor submissions staged since the site was last open and commit
             // them into the git working copy. No-ops for sites without inbox capture configured
@@ -309,6 +316,7 @@ final class PreviewModel {
         Task {
             if let previousSiteID {
                 await EditRouterRegistry.shared.unregister(siteID: previousSiteID)
+                await PageModelClientRegistry.shared.unregister(siteID: previousSiteID)
             }
             await runtime.suspend()
         }

--- a/Sources/AnglesiteApp/PreviewView.swift
+++ b/Sources/AnglesiteApp/PreviewView.swift
@@ -37,6 +37,13 @@ struct PreviewView: NSViewRepresentable {
     /// doc comment. Defaults to a no-op for callers (e.g. tests) that don't need it.
     var onPlacementPick: AnglesiteScriptHandler.PlacementPickHandler = { _ in }
 
+    /// Called every time a navigation finishes in the preview — an HMR reload, a route change, ⌘R.
+    /// The overlay's placement-pick mode is closure-local JS state that a real navigation wipes
+    /// (the `WKUserScript` re-runs and comes back inactive), so anything holding "we're waiting for
+    /// a placement click" on the native side has to hear about it or it waits forever on a
+    /// listener that no longer exists (#768 final review, Finding 8).
+    var onPreviewNavigated: () -> Void = {}
+
     /// Called with the `WKWebView` once it's created, so the owning `PreviewModel` can hold a weak
     /// reference and drive the View-menu preview commands (reload/history/zoom).
     /// Defaults to a no-op for callers (e.g. tests) that don't need it.
@@ -95,6 +102,7 @@ struct PreviewView: NSViewRepresentable {
         // final-review round 2, Finding B). Assigning it before `load(_:)` below means it's live
         // for this very first navigation too, not just later ones.
         webView.navigationDelegate = context.coordinator
+        context.coordinator.onNavigated = onPreviewNavigated
         webView.load(URLRequest(url: url))
         context.coordinator.loadedURL = url
         // Stashed on the coordinator because `dismantleNSView` is static — it has no access to
@@ -124,6 +132,7 @@ struct PreviewView: NSViewRepresentable {
 
     func updateNSView(_ webView: WKWebView, context: Context) {
         context.coordinator.onDismantle = onWebViewDismantled
+        context.coordinator.onNavigated = onPreviewNavigated
 
         // `makeNSView` only ever registers the WYSIWYG handler / mounts the JS engine once, at
         // construction — a `PreviewView` whose `wysiwygTransport` flips from nil to non-nil (Site ▸
@@ -214,7 +223,13 @@ struct PreviewView: NSViewRepresentable {
         /// repeat calls idempotent rather than stacking two live engine instances on one page.
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             wysiwygController?.mountEngine()
+            onNavigated?()
         }
+
+        /// Set from `makeNSView`/`updateNSView` (the represented view's `onPreviewNavigated`), so
+        /// a finished navigation can tell the native side that all page-injected JS state — the
+        /// overlay's placement-pick mode included — has just been discarded.
+        var onNavigated: (() -> Void)?
     }
 }
 

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -1076,6 +1076,13 @@ struct SiteWindow: View {
             model.quickCaptureURL = urlString
             model.quickCapturePresented = true
         }
+        // The click-to-place HUD lives here, on the site window itself — NOT inside the Effects
+        // gallery sheet, which is window-modal and therefore blocks input to the very preview it
+        // asks the owner to click (#768 final review, Finding 4). Bottom-aligned so it occupies
+        // only the capsule's own bounds; idle, it renders as an `EmptyView`.
+        .overlay(alignment: .bottom) {
+            EffectPlacementHUD(controller: model.effectPlacementController)
+        }
         .sheet(isPresented: $bindableModel.effectsPresented) {
             EffectsGalleryView(
                 controller: model.effectPlacementController,
@@ -1192,6 +1199,14 @@ struct SiteWindow: View {
                 wysiwygTransport: model.preview.wysiwygCanvas,
                 onPlacementPick: { message in
                     await model.effectPlacementController.handlePick(message)
+                },
+                // A finished navigation means the page's injected JS — including the overlay's
+                // placement-pick listener — was just thrown away and came back inactive. Cancel
+                // rather than silently re-arm: the page may be a different page entirely now, and
+                // an armed HUD over a listener that no longer exists waits forever (#768 final
+                // review, Finding 8). `cancel()` is a no-op unless a pick is actually in flight.
+                onPreviewNavigated: {
+                    model.effectPlacementController.cancel()
                 },
                 onWebView: { [preview = model.preview] webView in
                     preview.webView = webView

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -1608,8 +1608,22 @@ final class SiteWindowModel {
     }
 
     /// Backing cache for `effectPlacementController` below — see that property's doc comment for
-    /// the route-staleness fix this pair implements.
+    /// the route-staleness fix this pair implements. `@ObservationIgnored` because
+    /// `effectPlacementController` is read from a view body (`SiteWindow`'s placement-HUD overlay)
+    /// and writes this cache as a side effect — an observation-tracked write during a view update
+    /// is exactly the invalidate-while-rendering shape SwiftUI warns about. Nothing observes the
+    /// cache itself: the HUD tracks the returned controller's own `@Observable` state, and a route
+    /// change re-evaluates the reading body anyway (via `preview.activeRoute`).
+    @ObservationIgnored
     private var cachedEffectPlacementController: (path: String, controller: EffectPlacementController)?
+
+    /// Main-actor snapshot of this site's scanned pages, refreshed alongside every
+    /// `SiteContentGraph` rescan. `SiteContentGraph` is an actor, so a synchronous computed
+    /// property (`effectPlacementController`) can't read it — but it needs the route → source-file
+    /// mapping to hand `PageModelClient`/`insertBlock` a real `.astro` path rather than a route
+    /// (#768 final review, Finding 1). Empty until the first rescan lands, which
+    /// ``PageSourcePath/resolve(route:pages:)`` covers with its naming-convention fallback.
+    private var scannedPages: [SiteContentGraph.Page] = []
 
     /// The click-to-place controller for the Effects gallery sheet (Website ▸ Effects…, #768).
     /// `EffectPlacementController` captures its target `path` once at construction (`path` is a
@@ -1626,7 +1640,7 @@ final class SiteWindowModel {
     /// under itself — only an idle cached controller is eligible for a route-triggered rebuild, so
     /// an in-progress pick always resolves against the path it actually started against.
     var effectPlacementController: EffectPlacementController {
-        let path = preview.activeRoute ?? "/"
+        let path = PageSourcePath.resolve(route: preview.activeRoute, pages: scannedPages)
         if let cached = cachedEffectPlacementController,
            cached.path == path || cached.controller.state != .idle {
             return cached.controller
@@ -1647,14 +1661,41 @@ final class SiteWindowModel {
         )
     }
 
-    /// Ensures the site's `blocks.manifest.json` has entries for every shipped placeable effect.
-    /// Fire-and-forget-safe (idempotent, cheap JSON merge) — called once per site attach, not on
-    /// every gallery open.
-    private func syncBlockManifest(site: SiteStore.Site) {
-        guard let templateDirectory = TemplateRuntime.resolve().url else { return }
+    /// Ensures the site's `blocks.manifest.json` has entries for every shipped placeable effect —
+    /// and that the component files those entries point at actually exist in the site. Idempotent
+    /// and cheap (a JSON merge plus, on a pre-feature site, a handful of file copies), so it runs
+    /// once per site attach rather than on every gallery open.
+    ///
+    /// Failures are logged, not swallowed: `BlockManifestSync.sync` throws `.corruptSiteManifest`
+    /// instead of overwriting a manifest it can't parse *specifically* so the failure is visible,
+    /// which a bare `try?` at the only call site quietly undid (#768 final review, Finding 9).
+    private func syncBlockManifest(site: SiteStore.Site) async {
+        guard let templateDirectory = TemplateRuntime.resolve().url else {
+            await LogCenter.shared.append(
+                source: "effects", stream: .stderr,
+                text: "Skipped placeable-effect sync: the website template isn't available.")
+            return
+        }
         let templateManifest = templateDirectory.appendingPathComponent("blocks.manifest.json")
         let siteManifest = site.sourceDirectory.appendingPathComponent("blocks.manifest.json")
-        try? BlockManifestSync.sync(templateBlocksManifest: templateManifest, siteBlocksManifest: siteManifest)
+        do {
+            let outcome = try BlockManifestSync.sync(
+                templateBlocksManifest: templateManifest, siteBlocksManifest: siteManifest)
+            if !outcome.addedPaths.isEmpty || !outcome.copiedComponentPaths.isEmpty {
+                await LogCenter.shared.append(
+                    source: "effects", stream: .stdout,
+                    text: "Registered \(outcome.addedPaths.count) placeable effect(s); copied \(outcome.copiedComponentPaths.count) component file(s) into the site.")
+            }
+            if !outcome.skippedMissingComponentPaths.isEmpty {
+                await LogCenter.shared.append(
+                    source: "effects", stream: .stderr,
+                    text: "Left \(outcome.skippedMissingComponentPaths.count) effect(s) unregistered — their component files are missing from the template: \(outcome.skippedMissingComponentPaths.joined(separator: ", "))")
+            }
+        } catch {
+            await LogCenter.shared.append(
+                source: "effects", stream: .stderr,
+                text: "Couldn't sync placeable effects into blocks.manifest.json: \(error)")
+        }
     }
 
     /// (Re)builds the hoisted component editor for the active editor file when it is an `.astro`
@@ -2135,6 +2176,9 @@ final class SiteWindowModel {
     /// after the first content create/delete (#660).
     func refreshContentGraph(siteID: String, sourceDirectory: URL) async {
         await contentGraph.rescan(siteID: siteID, projectRoot: sourceDirectory)
+        // Mirror the freshly-scanned pages into `scannedPages` so the synchronous
+        // `effectPlacementController` can resolve a route to its real source file.
+        scannedPages = await contentGraph.pages(for: siteID)
     }
 
     func loadAndStart(siteID: String?, openSitesWindow: () -> Void, dismissSiteWindow: @escaping () -> Void) async {
@@ -2167,9 +2211,12 @@ final class SiteWindowModel {
         // the previous site's route would be exactly the kind of staleness
         // `effectPlacementController`'s cache is meant to avoid.
         cachedEffectPlacementController = nil
+        // Same reasoning for the page snapshot the controller's path is resolved from: it belongs
+        // to whichever site was attached before, and `refreshContentGraph` below repopulates it.
+        scannedPages = []
         // Idempotent per-site setup (#768): merges the template's placeable-effect entries into
         // this site's `blocks.manifest.json` once per attach, not on every Effects gallery open.
-        syncBlockManifest(site: resolved)
+        await syncBlockManifest(site: resolved)
         // Constructed once and threaded into every child model below instead of each one
         // separately re-deriving `id`/`sourceDirectory`/`packageURL`/`configDirectory` from
         // `resolved` at its own call site (#822) — see `CurrentSite`'s own doc comment.

--- a/Sources/AnglesiteBridgeCore/AnglesiteMessageDispatcher.swift
+++ b/Sources/AnglesiteBridgeCore/AnglesiteMessageDispatcher.swift
@@ -8,7 +8,7 @@ import AnglesiteCore
 /// `DispatchResult` describing what to do next — the adapter's only remaining job is shuttling
 /// bytes in and out of its native webview API.
 ///
-/// Four message types ride this bridge:
+/// Five message types ride this bridge:
 ///
 /// 1. `anglesite:apply-edit` (an `EditMessage`) — routed through the injected `EditRouter`; the
 ///    adapter delivers the reply back to the page (e.g. `window.anglesite?._handleReply?.(...)`

--- a/Sources/AnglesiteCore/BlockManifestSync.swift
+++ b/Sources/AnglesiteCore/BlockManifestSync.swift
@@ -1,22 +1,48 @@
 import Foundation
 
-/// Keeps a site's `blocks.manifest.json` up to date with the app's shipped effect components.
-/// New sites get the template's manifest copied in wholesale by the scaffold script; this covers
-/// sites created before an effect existed. Never touches an entry it didn't write itself — an
-/// owner is free to hand-edit or remove any entry, and a later sync leaves that alone, only
-/// filling in entries genuinely missing by `path`. This is a plain JSON merge, not sidecar code:
-/// `blocks.manifest.json` is a project-root data file the sidecar only *reads*.
+/// Keeps a site's `blocks.manifest.json` — and the component files it points at — up to date with
+/// the app's shipped effect components. New sites get both copied in wholesale by the scaffold
+/// script; this covers sites created before an effect existed. Never touches an entry (or a file)
+/// it didn't write itself — an owner is free to hand-edit or remove any entry, and a later sync
+/// leaves that alone, only filling in what's genuinely missing. This is a plain JSON merge plus a
+/// file copy, not sidecar code: `blocks.manifest.json` is a project-root data file the sidecar only
+/// *reads*.
 public enum BlockManifestSync {
     public enum SyncError: Error {
         case invalidTemplateManifest
         case corruptSiteManifest
     }
 
+    /// What one ``sync(templateBlocksManifest:siteBlocksManifest:)`` call actually did — returned
+    /// rather than logged from in here so the caller (which owns the app's log surface) decides how
+    /// to report it.
+    public struct Outcome: Equatable, Sendable {
+        /// Manifest entries appended to the site's file.
+        public var addedPaths: [String] = []
+        /// Component files copied from the template into the site.
+        public var copiedComponentPaths: [String] = []
+        /// Entries deliberately left unregistered because their component file couldn't be made to
+        /// exist in the site — a dangling manifest entry would make the sidecar write an `import`
+        /// of a file that isn't there, breaking the owner's Astro build.
+        public var skippedMissingComponentPaths: [String] = []
+        /// Whether the site's manifest file was rewritten at all.
+        public var didWriteManifest = false
+    }
+
     /// Merges `templateBlocksManifest`'s `modules` into `siteBlocksManifest`, creating the site
-    /// file if absent, appending only entries whose `path` isn't already present. If the site
-    /// manifest exists but is invalid or malformed, throws `.corruptSiteManifest` rather than
-    /// silently overwriting the owner's file.
-    public static func sync(templateBlocksManifest: URL, siteBlocksManifest: URL) throws {
+    /// file if absent, appending only entries whose `path` isn't already present, and copying each
+    /// appended entry's component file in from the template when the site doesn't have one.
+    ///
+    /// The manifest files sit at the root of the template and the site's `Source/` respectively, so
+    /// their parent directories are the two roots component paths resolve against.
+    ///
+    /// If the site manifest exists but is invalid or malformed, throws `.corruptSiteManifest`
+    /// rather than silently overwriting the owner's file. Writes nothing at all when the merge
+    /// added no entries — this file is git-tracked in the owner's `Source/` tree, and rewriting it
+    /// on every site open would show up as a spurious dirty file for any owner whose JSON
+    /// formatting or key order differs from the canonical serialization.
+    @discardableResult
+    public static func sync(templateBlocksManifest: URL, siteBlocksManifest: URL) throws -> Outcome {
         let templateData = try Data(contentsOf: templateBlocksManifest)
         guard let templateManifest = try JSONSerialization.jsonObject(with: templateData) as? [String: Any],
               let templateModules = templateManifest["modules"] as? [[String: Any]] else {
@@ -44,15 +70,62 @@ public enum BlockManifestSync {
             siteModules = []
         }
 
+        let templateRoot = templateBlocksManifest.deletingLastPathComponent()
+        let siteRoot = siteBlocksManifest.deletingLastPathComponent()
+        var outcome = Outcome()
+
         let existingPaths = Set(siteModules.compactMap { $0["path"] as? String })
         for entry in templateModules {
             guard let path = entry["path"] as? String, !existingPaths.contains(path) else { continue }
+            switch ensureComponentFile(relativePath: path, templateRoot: templateRoot, siteRoot: siteRoot) {
+            case .alreadyPresent:
+                break
+            case .copied:
+                outcome.copiedComponentPaths.append(path)
+            case .unavailable:
+                // Defensive backstop: registering a block whose file doesn't exist would have the
+                // sidecar emit `import X from "…/X.astro"` for a missing file on the owner's page.
+                outcome.skippedMissingComponentPaths.append(path)
+                continue
+            }
             siteModules.append(entry)
+            outcome.addedPaths.append(path)
         }
-        siteManifest["modules"] = siteModules
 
+        guard !outcome.addedPaths.isEmpty else { return outcome }
+
+        siteManifest["modules"] = siteModules
         let output = try JSONSerialization.data(withJSONObject: siteManifest, options: [.prettyPrinted, .sortedKeys])
         try FileManager.default.createDirectory(at: siteBlocksManifest.deletingLastPathComponent(), withIntermediateDirectories: true)
         try output.write(to: siteBlocksManifest, options: .atomic)
+        outcome.didWriteManifest = true
+        return outcome
+    }
+
+    private enum ComponentFileResult {
+        case alreadyPresent
+        case copied
+        case unavailable
+    }
+
+    /// Copies `relativePath` from the template into the site when the site doesn't already have it.
+    /// Never overwrites: a file already at the destination is the owner's (possibly edited) copy
+    /// and always wins — the same discipline `IntegrationScaffolder` applies to every owner-editable
+    /// file it writes. Returns `.unavailable` when the template has no such file or the copy fails,
+    /// so the caller can leave the entry unregistered rather than dangling.
+    private static func ensureComponentFile(relativePath: String, templateRoot: URL, siteRoot: URL) -> ComponentFileResult {
+        let fileManager = FileManager.default
+        let destination = siteRoot.appendingPathComponent(relativePath)
+        if fileManager.fileExists(atPath: destination.path) { return .alreadyPresent }
+        let source = templateRoot.appendingPathComponent(relativePath)
+        guard fileManager.fileExists(atPath: source.path) else { return .unavailable }
+        do {
+            try fileManager.createDirectory(
+                at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try fileManager.copyItem(at: source, to: destination)
+            return .copied
+        } catch {
+            return .unavailable
+        }
     }
 }

--- a/Sources/AnglesiteCore/EffectCatalog.swift
+++ b/Sources/AnglesiteCore/EffectCatalog.swift
@@ -80,6 +80,13 @@ public struct EffectCatalog: Sendable {
     /// gallery's display order, so no re-sorting happens app-side.
     public let entries: [EffectCatalogEntry]
 
+    /// Wraps an already-decoded entry list — mirrors `ThemeCatalog.init(themes:)`. Production
+    /// loads via ``load(templateDirectory:)``; `Bootstrap.swift` uses this directly for the
+    /// empty fallback when the bundled template can't be resolved.
+    public init(entries: [EffectCatalogEntry]) {
+        self.entries = entries
+    }
+
     /// Mirrors the manifest's top-level shape (`{ "version": 2, "components": [...] }`); only
     /// `components` is consumed today.
     private struct ManifestFile: Codable {

--- a/Sources/AnglesiteCore/PageModelClient.swift
+++ b/Sources/AnglesiteCore/PageModelClient.swift
@@ -82,12 +82,17 @@ extension PageModelClient.ModelError {
         case .toolFailed(let reason, let detail):
             switch reason {
             case "read-failed": return "Couldn't read this page: \(detail)"
-            case "invalid-input": return detail
+            // `invalid-input` is the sidecar rejecting the *path* we sent it (e.g. "not a
+            // project-relative .astro path: /"). With `PageSourcePath` resolving every caller's
+            // path this shouldn't reach an owner at all — but it's now HUD text on the
+            // click-to-place failure path, so it gets a sentence written for a person, with the
+            // raw detail kept alongside for the log rather than led with.
+            case "invalid-input": return "Couldn't place the effect here — try a different spot. (\(detail))"
             case "parse-failed": return detail
             default: return "Something went wrong loading this page: \(detail)"
             }
         case .decodeFailed:
-            return "Anglesite couldn't understand the page model returned by the plugin. Try updating the bundled plugin."
+            return "Anglesite couldn't understand the page model returned by the sidecar. Try updating the bundled sidecar."
         }
     }
 }

--- a/Sources/AnglesiteCore/PageModelClientRegistry.swift
+++ b/Sources/AnglesiteCore/PageModelClientRegistry.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Per-siteID registry of live `PageModelClient`s — the `get_page_model` counterpart to
+/// ``EditRouterRegistry``'s `apply_edit` routers.
+///
+/// Each open `SiteWindow`'s `PreviewModel` registers a `PageModelClient` bound to its runtime's
+/// MCP connection here under the site's id, alongside the matching `EditRouterRegistry`
+/// registration (`PreviewModel.open()`/`close()`). Intents that need to read a page's structured
+/// model before building a structural edit (`AddEffectIntent`, #768) read it back the same way
+/// `IntentEditBridge` reads `EditRouterRegistry` — so a Siri-driven placement resolves against the
+/// live page tree while the site's window is open. The registry lives in `AnglesiteCore` so both
+/// layers can see it; `AnglesiteIntents` doesn't need to know about WKWebView or `PreviewModel`.
+///
+/// Single shared instance — `PageModelClientRegistry.shared`. `PageModelClient` is a `Sendable`
+/// value type, so entries are stored by value, not by reference.
+///
+/// Last-writer-wins on duplicate siteID registration, mirroring `EditRouterRegistry`.
+public actor PageModelClientRegistry {
+    /// The single process-wide registry — the only instance production code should touch
+    /// (see `init`'s note on why external construction is blocked).
+    public static let shared = PageModelClientRegistry()
+
+    private var clients: [String: PageModelClient] = [:]
+
+    /// `internal` (not `public`) — production callers go through `.shared`; tests reach in
+    /// via `@testable import AnglesiteCore` to construct isolated instances. Prevents
+    /// accidental external instances from silently routing model fetches to the wrong site.
+    internal init() {}
+
+    /// Registers (or replaces — last-writer-wins, see the type doc) the live client for a site.
+    /// Pair with ``unregister(siteID:)`` around the owner's lifecycle, or the registration
+    /// outlives the window that registered it.
+    public func register(_ client: PageModelClient, for siteID: String) {
+        clients[siteID] = client
+    }
+
+    /// Removes a site's client. Safe to call for an unknown siteID (no-op), so owners can
+    /// unregister unconditionally on teardown.
+    public func unregister(siteID: String) {
+        clients.removeValue(forKey: siteID)
+    }
+
+    /// The live client for a site, or `nil` when no window has that site open — callers
+    /// (intents) treat `nil` as "site not open" and tell the user, rather than falling back
+    /// to a client that couldn't reach the preview anyway.
+    public func pageModelClient(for siteID: String) -> PageModelClient? {
+        clients[siteID]
+    }
+
+    /// All currently-registered siteIDs. Surfaced for tests + diagnostics; production callers
+    /// always know the siteID they're asking about.
+    public func knownSiteIDs() -> Set<String> {
+        Set(clients.keys)
+    }
+}

--- a/Sources/AnglesiteCore/PageSourcePath.swift
+++ b/Sources/AnglesiteCore/PageSourcePath.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Resolves a live-preview *route* (`/`, `/about`, what `PreviewModel.activeRoute` holds) to the
+/// *project-relative page source path* (`src/pages/index.astro`) the sidecar's page tools require.
+///
+/// This mapping is load-bearing, not cosmetic: `get_page_model`'s `validPagePath`
+/// (`server/page-model.mjs`) and `component-structure-edit.mjs`'s own path validation both reject
+/// anything that isn't a project-relative path ending in `.astro` — a route like `/` fails
+/// immediately with `invalid-input: not a project-relative .astro path: /`. Every caller that
+/// feeds ``PageModelClient/fetch(path:)`` or `ComponentStructureEditBuilder.insertBlock`'s
+/// `component.path` from a route has to come through here first (#768 final review, Finding 1).
+///
+/// Resolution order:
+///
+/// 1. The site's scanned pages (``SiteContentGraph/Page``), matched on `route` — the authoritative
+///    answer, since it comes from the actual filesystem walk (`ContentScanner.scanPages`) and
+///    handles directory-index pages (`/blog` → `src/pages/blog/index.astro`) that no naming
+///    convention can infer.
+/// 2. Failing that (graph not populated yet — it fills in asynchronously after a site opens), the
+///    Astro naming convention, matching `ContentScaffold.pageRelativePath(normalizedRoute:)`.
+///
+/// The return value is always a project-relative `.astro` path, never a route: a page that exists
+/// only as `.md`/`.mdx` resolves to the conventional `.astro` sibling, which the sidecar then
+/// reports as an ordinary read failure. That's deliberate — a structural `insertBlock` has nothing
+/// to insert into on a Markdown page, and "couldn't read this page" is a truer answer than
+/// "invalid input".
+public enum PageSourcePath {
+    /// The home page's source path — the fallback target for front doors with no page picker
+    /// (Siri's `AddEffectIntent`) and for a preview sitting on the site root.
+    public static let homePage = "src/pages/index.astro"
+
+    /// Resolves `route` against `pages`, falling back to the Astro naming convention. `nil` or an
+    /// empty route means the site root.
+    public static func resolve(route: String?, pages: [SiteContentGraph.Page]) -> String {
+        let normalized = normalize(route)
+        if let match = pages.first(where: { normalize($0.route) == normalized && isAstro($0.filePath) }) {
+            return match.filePath
+        }
+        return conventionalPath(forNormalizedRoute: normalized)
+    }
+
+    /// Whether `path` satisfies the sidecar's project-relative-`.astro` contract. Exposed so
+    /// callers (and tests pinning production wiring) can assert it without duplicating the rule.
+    public static func isValidPageSourcePath(_ path: String) -> Bool {
+        !path.hasPrefix("/") && !path.hasPrefix("../") && isAstro(path)
+    }
+
+    /// `/` → `src/pages/index.astro`, `/about` → `src/pages/about.astro`. Expects an already
+    /// normalized route.
+    static func conventionalPath(forNormalizedRoute route: String) -> String {
+        let trimmed = route.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return trimmed.isEmpty ? homePage : "src/pages/\(trimmed).astro"
+    }
+
+    /// Leading slash, no trailing slash (except the root), no query or fragment — the shape
+    /// `ContentScanner.routeFromPagePath` produces, so graph routes and preview routes compare
+    /// equal.
+    static func normalize(_ route: String?) -> String {
+        guard var value = route, !value.isEmpty else { return "/" }
+        if let cut = value.firstIndex(where: { $0 == "?" || $0 == "#" }) {
+            value = String(value[value.startIndex..<cut])
+        }
+        while value.hasSuffix("/"), value.count > 1 { value.removeLast() }
+        if !value.hasPrefix("/") { value = "/" + value }
+        return value.isEmpty ? "/" : value
+    }
+
+    private static func isAstro(_ path: String) -> Bool {
+        path.lowercased().hasSuffix(".astro")
+    }
+}

--- a/Sources/AnglesiteCore/PlacementMatcher.swift
+++ b/Sources/AnglesiteCore/PlacementMatcher.swift
@@ -8,6 +8,26 @@ import Foundation
 /// match here would resolve to the same element `selector.mjs` would pick for a page-level
 /// selector op — deliberately duplicated (in Swift, not called into the sidecar) because this
 /// resolution happens client-side against an already-fetched tree, with no extra round trip.
+///
+/// Matching runs in two tiers, following `selector.mjs`'s own priority order:
+///
+/// 1. **Identity attributes** — `data-anglesite-id`, then `data-testid`, then `#id`. Any one of
+///    these is meant to be unique, so a single hit resolves immediately with no positional
+///    reasoning at all. These are the highest-value signals the overlay collects and they were
+///    previously ignored entirely (#768 final review, Finding 5).
+/// 2. **Positional fallback** — tag + `nth-child` position among element siblings + (when the
+///    catalog entry constrains it) the immediate parent's tag.
+///
+/// **Known follow-up:** `selector.mjs`'s remaining priorities — `role`/`aria-label` and
+/// `tag.stableClasses` — and full ancestor-chain disambiguation (`ElementInfo.ancestors` is
+/// decoded but unused here) are not implemented. Tier 2 can still report `.ambiguous` on a page
+/// where the same tag sits at the same sibling position under two different ancestors; walking the
+/// ancestor chain would resolve many of those. Deliberately deferred out of this fix wave.
+///
+/// **Known follow-up (confirm-before-apply):** the design's risk table calls for highlighting the
+/// matched target in the WKWebView before committing the insert. That needs new Swift→JS bridge
+/// messaging; the `inline` before/after toggle threaded through ``resolve(element:in:placement:inlinePosition:)``
+/// is this round's mitigation instead.
 public enum PlacementMatcher {
     public struct Insertion: Equatable {
         public let parentId: String
@@ -19,6 +39,13 @@ public enum PlacementMatcher {
         }
     }
 
+    /// Which side of the clicked element an `inline` effect goes on. The placement HUD's
+    /// before/after toggle writes this; `background` placements ignore it.
+    public enum InlinePosition: String, Sendable, Equatable, CaseIterable {
+        case before
+        case after
+    }
+
     public enum MatchError: Error, Equatable {
         /// No node in the tree matches the clicked element's tag + position + ancestry.
         case noMatch
@@ -26,22 +53,76 @@ public enum PlacementMatcher {
         case ambiguous
     }
 
+    /// One candidate node plus the addressing `insertBlock` needs for it.
+    private typealias Match = (node: PageModel.Node, parentId: String, indexInParent: Int)
+
     /// Finds the node matching `element` in `model.tree`, then computes the insertion point per
-    /// `placement.kind`: `.inline` inserts immediately after the matched node (same parent,
-    /// index + 1); `.background` inserts as the first child (index 0) of the matched node's
-    /// *parent* — behind it, not adjacent. `placement.allowedParents`, when non-nil, restricts
-    /// matches to nodes whose immediate parent's tag is in the list.
-    public static func resolve(element: ElementInfo, in model: PageModel, placement: EffectCatalogEntry.Placement) -> Result<Insertion, MatchError> {
-        var matches: [(node: PageModel.Node, parentId: String, indexInParent: Int)] = []
-        collectMatches(node: model.tree, parentId: nil, element: element, allowedParents: placement.allowedParents, into: &matches)
+    /// `placement.kind`: `.inline` inserts immediately before or after the matched node (same
+    /// parent), per `inlinePosition`; `.background` inserts as the first child (index 0) of the
+    /// matched node's *parent* — behind it, not adjacent. `placement.allowedParents`, when
+    /// non-nil, restricts matches to nodes whose immediate parent's tag is in the list.
+    public static func resolve(
+        element: ElementInfo, in model: PageModel, placement: EffectCatalogEntry.Placement,
+        inlinePosition: InlinePosition = .after
+    ) -> Result<Insertion, MatchError> {
+        let allowedParents = placement.allowedParents
+
+        // Tier 1: identity attributes, in `selector.mjs`'s priority order. A single hit is an
+        // unambiguous answer — no tag/nth-child reasoning needed. An attribute the tree doesn't
+        // carry at all (e.g. one a client-side script added after render) simply falls through to
+        // the next signal, and finally to the positional match.
+        for (attribute, value) in [
+            ("data-anglesite-id", element.dataAnglesiteId),
+            ("data-testid", element.dataTestId),
+            ("id", element.id),
+        ] {
+            guard let value, !value.isEmpty else { continue }
+            var hits: [Match] = []
+            collectByAttribute(
+                node: model.tree, attribute: attribute, value: value,
+                allowedParents: allowedParents, into: &hits)
+            if hits.count == 1 { return .success(insertion(for: hits[0], placement: placement, inlinePosition: inlinePosition)) }
+            if hits.count > 1 { return .failure(.ambiguous) }
+        }
+
+        // Tier 2: positional match.
+        var matches: [Match] = []
+        collectMatches(node: model.tree, parentId: nil, element: element, allowedParents: allowedParents, into: &matches)
         guard !matches.isEmpty else { return .failure(.noMatch) }
         guard matches.count == 1 else { return .failure(.ambiguous) }
-        let match = matches[0]
+        return .success(insertion(for: matches[0], placement: placement, inlinePosition: inlinePosition))
+    }
+
+    /// Turns a matched node into an insertion point per the effect's placement kind.
+    private static func insertion(for match: Match, placement: EffectCatalogEntry.Placement, inlinePosition: InlinePosition) -> Insertion {
         switch placement.kind {
         case .inline:
-            return .success(Insertion(parentId: match.parentId, index: match.indexInParent + 1))
+            return Insertion(
+                parentId: match.parentId,
+                index: inlinePosition == .after ? match.indexInParent + 1 : match.indexInParent)
         case .background:
-            return .success(Insertion(parentId: match.parentId, index: 0))
+            // Known follow-up: a `background` effect is absolutely positioned, so its containing
+            // block needs `position: relative` on the parent. The app has no CSS-injection
+            // mechanism yet, so this isn't guaranteed here — tracked as a separate piece of work.
+            return Insertion(parentId: match.parentId, index: 0)
+        }
+    }
+
+    /// Depth-first walk collecting every child node carrying `attribute` == `value`. The root is
+    /// never a candidate (it has no parent to address an insertion against), matching
+    /// `collectMatches` below.
+    private static func collectByAttribute(
+        node: PageModel.Node, attribute: String, value: String,
+        allowedParents: [String]?, into matches: inout [Match]
+    ) {
+        for (index, child) in node.children.enumerated() {
+            let carries = child.attrs.contains { $0.name.lowercased() == attribute && $0.value == value }
+            if carries, parentIsAllowed(node, allowedParents: allowedParents) {
+                matches.append((child, node.id, index))
+            }
+            collectByAttribute(
+                node: child, attribute: attribute, value: value,
+                allowedParents: allowedParents, into: &matches)
         }
     }
 
@@ -51,13 +132,13 @@ public enum PlacementMatcher {
     /// mixed with non-element siblings like `.text` or `.expression` nodes).
     private static func collectMatches(
         node: PageModel.Node, parentId: String?, element: ElementInfo, allowedParents: [String]?,
-        into matches: inout [(node: PageModel.Node, parentId: String, indexInParent: Int)]
+        into matches: inout [Match]
     ) {
         let elementSiblings = node.children.filter { $0.kind == .element || $0.kind == .component }
         for (index, child) in elementSiblings.enumerated() {
             let position = index + 1 // 1-based, matches CSS :nth-child / the overlay's nthChild
             if child.tag?.uppercased() == element.tag.uppercased(), position == element.nthChild {
-                if allowedParents == nil || allowedParents?.map({ $0.uppercased() }).contains(node.tag?.uppercased() ?? "") ?? true {
+                if parentIsAllowed(node, allowedParents: allowedParents) {
                     // Find the child's actual index in the full children array (not filtered)
                     if let fullIndex = node.children.firstIndex(where: { $0.id == child.id }) {
                         matches.append((child, node.id, fullIndex))
@@ -68,5 +149,11 @@ public enum PlacementMatcher {
         for child in node.children {
             collectMatches(node: child, parentId: node.id, element: element, allowedParents: allowedParents, into: &matches)
         }
+    }
+
+    /// Whether `parent` satisfies the catalog entry's `allowedParents` tag allowlist (`nil` = any).
+    private static func parentIsAllowed(_ parent: PageModel.Node, allowedParents: [String]?) -> Bool {
+        guard let allowedParents else { return true }
+        return allowedParents.map { $0.uppercased() }.contains(parent.tag?.uppercased() ?? "")
     }
 }

--- a/Sources/AnglesiteIntents/AddEffectIntentOverride.swift
+++ b/Sources/AnglesiteIntents/AddEffectIntentOverride.swift
@@ -1,20 +1,17 @@
 import AnglesiteCore
 
-/// Test-only escape hatch for ``AddEffectIntent``, bundling everything production resolves via a
-/// live template read plus the site's registries: the effect catalog (normally
-/// `EffectCatalog.load(templateDirectory:)` against the bundled template) and the site's
-/// `PageModelClient`/`EditRouter` pair (normally read from `PageModelClientRegistry`/
-/// `EditRouterRegistry`, which only have entries while a site window is open). Under `swift test`
-/// there is no bundled template and no open window, so tests bind this instead of relying on
-/// `@Dependency` resolution or the live registries.
+/// Test-only escape hatch for the site connectivity ``AddEffectIntent`` normally resolves from
+/// `PageModelClientRegistry`/`EditRouterRegistry` — registries populated by `PreviewModel.open()`/
+/// `close()` that only have entries while a site window is open. `swift test` has no open window,
+/// so tests bind this instead of relying on the live registries.
 ///
-/// A bound value also skips `requestConfirmation`, mirroring `ThemeCatalogOverride` /
-/// `IntegrationOperationsOverride` elsewhere in this file's sibling intents — Siri's confirmation
-/// dialog isn't introspectable under `swift test`, so tests short-circuit it rather than exercise
-/// it.
-public struct AddEffectIntentFakes: Sendable {
-    /// The catalog `AddEffectIntent` looks the chosen effect up in.
-    public let catalog: EffectCatalog
+/// Unlike ``EffectCatalogOverride`` (which pairs with a `@Dependency`, matching every other
+/// catalog/service override in this file's sibling intents), there's no single existing
+/// `@Dependency`-backed type these two registry lookups collapse into — production always looks
+/// them up as a pair via `PageModelClientRegistry.shared`/`EditRouterRegistry.shared` directly,
+/// not through `@Dependency`. So this stays a small dedicated bundle rather than forcing a
+/// mismatched single-`@Dependency` shape onto a pair of registry lookups that don't have one.
+public struct AddEffectSiteConnection: Sendable {
     /// The site's page-model source, or `nil` to simulate "site not open in Anglesite."
     public let pageModelClient: PageModelClient?
     /// The site's edit router, or `nil` to simulate "site not open in Anglesite." Independent of
@@ -23,17 +20,15 @@ public struct AddEffectIntentFakes: Sendable {
     /// but the intent still checks both explicitly rather than assuming they travel in lockstep.
     public let editRouter: EditRouter?
 
-    public init(catalog: EffectCatalog, pageModelClient: PageModelClient?, editRouter: EditRouter?) {
-        self.catalog = catalog
+    public init(pageModelClient: PageModelClient?, editRouter: EditRouter?) {
         self.pageModelClient = pageModelClient
         self.editRouter = editRouter
     }
 }
 
-/// `@TaskLocal` binding point for ``AddEffectIntentFakes``. `AddEffectIntent` reads
-/// `AddEffectIntentOverride.scoped` first; a bound value wins over the live template/registry
-/// lookups and also signals "under test," so `requestConfirmation` is skipped. Always `nil` in
-/// production.
-public enum AddEffectIntentOverride {
-    @TaskLocal public static var scoped: AddEffectIntentFakes?
+/// `@TaskLocal` binding point for ``AddEffectSiteConnection``. `AddEffectIntent` reads
+/// `AddEffectSiteConnectionOverride.scoped` first; a bound value wins over the live registry
+/// lookups. Always `nil` in production.
+public enum AddEffectSiteConnectionOverride {
+    @TaskLocal public static var scoped: AddEffectSiteConnection?
 }

--- a/Sources/AnglesiteIntents/AddEffectIntentOverride.swift
+++ b/Sources/AnglesiteIntents/AddEffectIntentOverride.swift
@@ -1,0 +1,39 @@
+import AnglesiteCore
+
+/// Test-only escape hatch for ``AddEffectIntent``, bundling everything production resolves via a
+/// live template read plus the site's registries: the effect catalog (normally
+/// `EffectCatalog.load(templateDirectory:)` against the bundled template) and the site's
+/// `PageModelClient`/`EditRouter` pair (normally read from `PageModelClientRegistry`/
+/// `EditRouterRegistry`, which only have entries while a site window is open). Under `swift test`
+/// there is no bundled template and no open window, so tests bind this instead of relying on
+/// `@Dependency` resolution or the live registries.
+///
+/// A bound value also skips `requestConfirmation`, mirroring `ThemeCatalogOverride` /
+/// `IntegrationOperationsOverride` elsewhere in this file's sibling intents — Siri's confirmation
+/// dialog isn't introspectable under `swift test`, so tests short-circuit it rather than exercise
+/// it.
+public struct AddEffectIntentFakes: Sendable {
+    /// The catalog `AddEffectIntent` looks the chosen effect up in.
+    public let catalog: EffectCatalog
+    /// The site's page-model source, or `nil` to simulate "site not open in Anglesite."
+    public let pageModelClient: PageModelClient?
+    /// The site's edit router, or `nil` to simulate "site not open in Anglesite." Independent of
+    /// `pageModelClient` so a test can exercise the case where only one of the pair is missing —
+    /// production always registers/unregisters both together (`PreviewModel.open()`/`close()`),
+    /// but the intent still checks both explicitly rather than assuming they travel in lockstep.
+    public let editRouter: EditRouter?
+
+    public init(catalog: EffectCatalog, pageModelClient: PageModelClient?, editRouter: EditRouter?) {
+        self.catalog = catalog
+        self.pageModelClient = pageModelClient
+        self.editRouter = editRouter
+    }
+}
+
+/// `@TaskLocal` binding point for ``AddEffectIntentFakes``. `AddEffectIntent` reads
+/// `AddEffectIntentOverride.scoped` first; a bound value wins over the live template/registry
+/// lookups and also signals "under test," so `requestConfirmation` is skipped. Always `nil` in
+/// production.
+public enum AddEffectIntentOverride {
+    @TaskLocal public static var scoped: AddEffectIntentFakes?
+}

--- a/Sources/AnglesiteIntents/Bootstrap.swift
+++ b/Sources/AnglesiteIntents/Bootstrap.swift
@@ -88,6 +88,19 @@ public enum AnglesiteIntents {
             themeCatalog = ThemeCatalog(themes: [])
         }
         AppDependencyManager.shared.add { () -> ThemeCatalog in themeCatalog }
+        // `AddEffectIntent` (EffectIntents.swift, #768) resolves `@Dependency private var catalog:
+        // EffectCatalog` against whatever is registered here — same shape and same
+        // load-once/fall-back-to-empty handling as `ThemeCatalog` just above, and it shares
+        // `themeResolution` since both read the same bundled template. `perform()` already has an
+        // "I don't recognize that effect" reply path for an empty/mismatched catalog.
+        let effectCatalog: EffectCatalog
+        if let templateURL = themeResolution.url, let loaded = try? EffectCatalog.load(templateDirectory: templateURL) {
+            effectCatalog = loaded
+        } else {
+            log.error("EffectCatalog load failed at bootstrap; AddEffectIntent will report no effects available")
+            effectCatalog = EffectCatalog(entries: [])
+        }
+        AppDependencyManager.shared.add { () -> EffectCatalog in effectCatalog }
         // `EditContentIntent` (B.5 / #149) routes natural-language edits through
         // `IntentEditBridge`, which asks `EditRouterRegistry.shared` for the live edit router of
         // the requested site. The registry is populated by `PreviewModel.open()` and cleared by

--- a/Sources/AnglesiteIntents/EffectCatalogOverride.swift
+++ b/Sources/AnglesiteIntents/EffectCatalogOverride.swift
@@ -1,0 +1,12 @@
+import AnglesiteCore
+
+/// Test-only escape hatch around `@Dependency` resolution of `EffectCatalog`, mirroring
+/// `ThemeCatalogOverride`. `@Dependency` is gated to the AppIntents perform flow; direct
+/// `intent.perform()` calls from unit tests crash without it. Tests bind this `@TaskLocal` to a
+/// fake catalog before invoking `AddEffectIntent`, which reads
+/// `EffectCatalogOverride.scoped ?? self.catalog`, so production flows through `@Dependency`.
+public enum EffectCatalogOverride {
+    /// The task-scoped fake catalog. Always `nil` in production; a bound value also signals
+    /// "under test" to ``AddEffectIntent``, which then skips its `requestConfirmation` gate.
+    @TaskLocal public static var scoped: EffectCatalog?
+}

--- a/Sources/AnglesiteIntents/EffectIntents.swift
+++ b/Sources/AnglesiteIntents/EffectIntents.swift
@@ -76,6 +76,7 @@ public struct AddEffectIntent: AppIntent {
     @Parameter(title: "Site") public var site: SiteEntity
     /// The catalog effect to add.
     @Parameter(title: "Effect") public var effect: EffectAppEnum
+    @Dependency private var catalog: EffectCatalog
 
     /// AppIntents requires a parameterless initializer; the framework populates `@Parameter`s
     /// after construction.
@@ -94,32 +95,26 @@ public struct AddEffectIntent: AppIntent {
     /// confirms, applies. Shared by `perform()` and `performForTesting()` so the two stay in
     /// lockstep — same shape as `AddStoreIntent.resolvedRoute()` / `confirmAndApplyForTesting()`.
     private func run() async throws -> String {
-        let fakes = AddEffectIntentOverride.scoped
+        // Tests bind EffectCatalogOverride.scoped; production goes through @Dependency —
+        // mirrors ApplyThemeIntent's `ThemeCatalogOverride.scoped ?? catalog` exactly
+        // (ThemeIntents.swift). A bound override also signals "under test" below, so
+        // `requestConfirmation` is skipped.
+        let effectCatalog = EffectCatalogOverride.scoped ?? catalog
 
-        let catalog: EffectCatalog
-        if let fakes {
-            catalog = fakes.catalog
-        } else {
-            let resolution = TemplateRuntime.resolve()
-            guard let templateDirectory = resolution.url,
-                  let loaded = try? EffectCatalog.load(templateDirectory: templateDirectory) else {
-                return EffectDialogs.catalogUnavailable()
-            }
-            catalog = loaded
-        }
-
-        guard let entry = catalog.entries.first(where: { $0.title == effect.rawValue }) else {
+        guard let entry = effectCatalog.entries.first(where: { $0.title == effect.rawValue }) else {
             return EffectDialogs.unknownEffect(title: effect.rawValue)
         }
         guard entry.placement != nil else {
             return EffectDialogs.notPlaceable(effectTitle: entry.title)
         }
 
+        // Tests bind AddEffectSiteConnectionOverride.scoped; production reads the live
+        // per-siteID registries (populated only while the site's window is open).
         let pageModelClient: PageModelClient?
         let editRouter: EditRouter?
-        if let fakes {
-            pageModelClient = fakes.pageModelClient
-            editRouter = fakes.editRouter
+        if let connection = AddEffectSiteConnectionOverride.scoped {
+            pageModelClient = connection.pageModelClient
+            editRouter = connection.editRouter
         } else {
             pageModelClient = await PageModelClientRegistry.shared.pageModelClient(for: site.id)
             editRouter = await EditRouterRegistry.shared.router(for: site.id)
@@ -146,9 +141,12 @@ public struct AddEffectIntent: AppIntent {
         // Confirm only once the plan is known-good, mirroring `AddStoreIntent`
         // (`IntegrationIntents.swift`): planning happens *before* the confirmation so a
         // placement failure above reaches the user without them confirming an apply that could
-        // never run. Skipped under test (`fakes != nil`) -- `requestConfirmation` needs the live
-        // Siri/Shortcuts runtime, which `swift test` doesn't have.
-        if fakes == nil {
+        // never run. Skipped under test (`EffectCatalogOverride.scoped != nil`), same signal
+        // `ApplyThemeIntent` reads off `ThemeCatalogOverride.scoped` -- `requestConfirmation`
+        // needs the live Siri/Shortcuts runtime, which `swift test` doesn't have. Every `run()`
+        // path that reaches this point has already required a bound `EffectCatalogOverride` under
+        // test (the entry lookup above depends on it), so this one signal covers the whole method.
+        if EffectCatalogOverride.scoped == nil {
             try await requestConfirmation(dialog: "Add \(entry.title) to \(site.displayName)?")
         }
 
@@ -199,10 +197,11 @@ public struct AddEffectIntent: AppIntent {
 
 extension AddEffectIntent {
     /// Drives `run()`'s plan → confirm → apply logic directly, bypassing the AppIntents
-    /// `requestConfirmation` gate. Only callable when `AddEffectIntentOverride.scoped` is bound.
+    /// `requestConfirmation` gate (skipped whenever `EffectCatalogOverride.scoped` is bound — see
+    /// `run()`). Only callable when `EffectCatalogOverride.scoped` is bound.
     func performForTesting() async throws -> String {
-        guard AddEffectIntentOverride.scoped != nil else {
-            fatalError("performForTesting requires a bound AddEffectIntentOverride.scoped")
+        guard EffectCatalogOverride.scoped != nil else {
+            fatalError("performForTesting requires a bound EffectCatalogOverride.scoped")
         }
         return try await run()
     }

--- a/Sources/AnglesiteIntents/EffectIntents.swift
+++ b/Sources/AnglesiteIntents/EffectIntents.swift
@@ -1,0 +1,237 @@
+import AppIntents
+import AnglesiteCore
+import Foundation
+
+// MARK: - Dialog formatting (pure, unit-testable)
+
+/// Pure dialog strings for ``AddEffectIntent``. No AppIntents types, so these are fully
+/// unit-testable without the AppIntents runtime — same convention as `IntegrationDialogs`
+/// (`IntegrationIntents.swift`) and `ContentDialogs` (`EditContentIntent.swift`).
+public enum EffectDialogs {
+    /// The chosen `EffectAppEnum` case doesn't match any catalog entry's title. Shouldn't happen
+    /// at runtime (the enum's cases are meant to track the catalog), but the catalog is loaded
+    /// from a file on disk, so a stale enum/manifest pairing is a well-defined failure, not a trap.
+    public static func unknownEffect(title: String) -> String {
+        "I don't recognize \"\(title)\" as an effect."
+    }
+    /// The template (and therefore the effects catalog) couldn't be resolved/decoded at all.
+    public static func catalogUnavailable() -> String {
+        "The effects catalog isn't available right now."
+    }
+    /// The matched entry has no `placement` (a legacy `@astroanimate/core` micro-animation,
+    /// copy-paste only) — there's nothing for click-to-place/`insertBlock` to do with it.
+    public static func notPlaceable(effectTitle: String) -> String {
+        "\(effectTitle) can't be placed automatically — open it from the Effects gallery in Anglesite instead."
+    }
+    /// Neither a `PageModelClient` nor an `EditRouter` is registered for the site — its window
+    /// isn't open, so there's no live MCP connection to fetch a page model or apply an edit
+    /// through (mirrors `EditContentIntent`'s `siteUnavailable` wording).
+    public static func siteNotOpen(siteName: String) -> String {
+        "Open \(siteName) in Anglesite first, then try adding this effect again."
+    }
+    /// `get_page_model` failed; `reason` is `PageModelClient.ModelError.friendlyMessage`.
+    public static func modelLoadFailed(siteName: String, reason: String) -> String {
+        "Couldn't load \(siteName)'s home page: \(reason)"
+    }
+    /// `defaultInsertion` found no `<body>`/`allowedParents` match to insert against.
+    public static func noPlacementFound(effectTitle: String, siteName: String) -> String {
+        "I couldn't find a spot for \(effectTitle) on \(siteName)'s home page."
+    }
+    /// Success dialog once `EditRouter.apply` reports `.applied`.
+    public static func applied(effectTitle: String, siteName: String) -> String {
+        "Added \(effectTitle) to \(siteName)."
+    }
+    /// Failure dialog for an apply-stage `.failed`/`.ambiguous`/`.preview` reply; `reason` carries
+    /// whichever message the router surfaced.
+    public static func failed(effectTitle: String, siteName: String, reason: String) -> String {
+        "Couldn't add \(effectTitle) to \(siteName): \(reason)"
+    }
+}
+
+// MARK: - Add Effect
+
+/// Adds a catalog effect to a site via Siri/Shortcuts, mirroring `AddStoreIntent`'s router
+/// pattern (`IntegrationIntents.swift`): plan before confirm, so a missing/ambiguous placement
+/// reprompts rather than false-confirming. No live-preview click is available from this front
+/// door, so placement is computed deterministically from `entry.placement.kind` via
+/// ``defaultInsertion(for:in:)``, then applied through the same fetch → match → `insertBlock` →
+/// apply shape `EffectPlacementController` (the in-app click-to-place flow for this same
+/// feature, Task 12) uses for a real click.
+///
+/// Reaching the site's live MCP connection re-uses `EditContentIntent`'s established mechanism —
+/// a per-siteID registry populated by `PreviewModel.open()`/`close()` while the site's window is
+/// open (`EditRouterRegistry`) — extended here with a `PageModelClient` counterpart
+/// (`PageModelClientRegistry`, `AnglesiteCore/PageModelClientRegistry.swift`) since `insertBlock`
+/// needs a freshly-fetched `PageModel` for its `baseVersion`/`parentId`/`index`, not just a
+/// router to apply the edit through. Like `EditContentIntent`, this means the effect only applies
+/// while the target site's window is open — a Siri/Shortcuts invocation while it's closed gets
+/// ``EffectDialogs/siteNotOpen(siteName:)`` rather than silently failing.
+public struct AddEffectIntent: AppIntent {
+    /// Display name in the Shortcuts action library and Siri disambiguation.
+    public static let title: LocalizedStringResource = "Add Effect"
+    /// Longer explanation shown under the action in the Shortcuts editor.
+    public static let description = IntentDescription("Add a visual effect to a site's home page.")
+
+    /// The target site, resolved from the recents registry via ``SiteEntity``'s query.
+    @Parameter(title: "Site") public var site: SiteEntity
+    /// The catalog effect to add.
+    @Parameter(title: "Effect") public var effect: EffectAppEnum
+
+    /// AppIntents requires a parameterless initializer; the framework populates `@Parameter`s
+    /// after construction.
+    public init() {}
+
+    /// Shortcuts-editor sentence: "Add (effect) to (site)".
+    public static var parameterSummary: some ParameterSummary {
+        Summary("Add \(\.$effect) to \(\.$site)")
+    }
+
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        .result(dialog: IntentDialog(stringLiteral: try await run()))
+    }
+
+    /// Pure(ish) core: resolves the catalog entry, fetches the page model, plans the insertion,
+    /// confirms, applies. Shared by `perform()` and `performForTesting()` so the two stay in
+    /// lockstep — same shape as `AddStoreIntent.resolvedRoute()` / `confirmAndApplyForTesting()`.
+    private func run() async throws -> String {
+        let fakes = AddEffectIntentOverride.scoped
+
+        let catalog: EffectCatalog
+        if let fakes {
+            catalog = fakes.catalog
+        } else {
+            let resolution = TemplateRuntime.resolve()
+            guard let templateDirectory = resolution.url,
+                  let loaded = try? EffectCatalog.load(templateDirectory: templateDirectory) else {
+                return EffectDialogs.catalogUnavailable()
+            }
+            catalog = loaded
+        }
+
+        guard let entry = catalog.entries.first(where: { $0.title == effect.rawValue }) else {
+            return EffectDialogs.unknownEffect(title: effect.rawValue)
+        }
+        guard entry.placement != nil else {
+            return EffectDialogs.notPlaceable(effectTitle: entry.title)
+        }
+
+        let pageModelClient: PageModelClient?
+        let editRouter: EditRouter?
+        if let fakes {
+            pageModelClient = fakes.pageModelClient
+            editRouter = fakes.editRouter
+        } else {
+            pageModelClient = await PageModelClientRegistry.shared.pageModelClient(for: site.id)
+            editRouter = await EditRouterRegistry.shared.router(for: site.id)
+        }
+        guard let pageModelClient, let editRouter else {
+            return EffectDialogs.siteNotOpen(siteName: site.displayName)
+        }
+
+        // No page picker on this front door (v1) -- the home page route, matching
+        // `EffectPlacementController`'s own `preview.activeRoute ?? "/"` default when no route is
+        // active.
+        let path = "/"
+        let model: PageModel
+        do {
+            model = try await pageModelClient.fetch(path: path)
+        } catch let error as PageModelClient.ModelError {
+            return EffectDialogs.modelLoadFailed(siteName: site.displayName, reason: error.friendlyMessage)
+        }
+
+        guard let insertion = Self.defaultInsertion(for: entry, in: model) else {
+            return EffectDialogs.noPlacementFound(effectTitle: entry.title, siteName: site.displayName)
+        }
+
+        // Confirm only once the plan is known-good, mirroring `AddStoreIntent`
+        // (`IntegrationIntents.swift`): planning happens *before* the confirmation so a
+        // placement failure above reaches the user without them confirming an apply that could
+        // never run. Skipped under test (`fakes != nil`) -- `requestConfirmation` needs the live
+        // Siri/Shortcuts runtime, which `swift test` doesn't have.
+        if fakes == nil {
+            try await requestConfirmation(dialog: "Add \(entry.title) to \(site.displayName)?")
+        }
+
+        let edit = ComponentStructureEditBuilder.insertBlock(
+            id: UUID().uuidString, path: path, baseVersion: model.version,
+            parentId: insertion.parentId, index: insertion.index, manifestBlock: entry.title)
+        let reply = await editRouter.apply(edit)
+        switch reply.status {
+        case .applied:
+            return EffectDialogs.applied(effectTitle: entry.title, siteName: site.displayName)
+        case .failed, .ambiguous, .preview:
+            return EffectDialogs.failed(
+                effectTitle: entry.title, siteName: site.displayName,
+                reason: reply.message ?? "the edit was refused.")
+        }
+    }
+
+    /// Computes a default `{parentId, index}` for an effect with no click to resolve against.
+    /// `.background` inserts as the last child of `<body>` (or the tree root if no `<body>` is
+    /// found — an unusual page, but insertion should still succeed rather than refuse).
+    /// `.inline` inserts as the first child of the first node matching `allowedParents` (or the
+    /// tree root when `allowedParents` is nil).
+    public static func defaultInsertion(for entry: EffectCatalogEntry, in model: PageModel) -> PlacementMatcher.Insertion? {
+        guard let placement = entry.placement else { return nil }
+        switch placement.kind {
+        case .background:
+            let body = findNode(tagged: "BODY", in: model.tree) ?? model.tree
+            return PlacementMatcher.Insertion(parentId: body.id, index: body.children.count)
+        case .inline:
+            if let allowedParents = placement.allowedParents,
+               let match = allowedParents.lazy.compactMap({ findNode(tagged: $0, in: model.tree) }).first {
+                return PlacementMatcher.Insertion(parentId: match.id, index: 0)
+            }
+            return PlacementMatcher.Insertion(parentId: model.tree.id, index: model.tree.children.count)
+        }
+    }
+
+    private static func findNode(tagged tag: String, in node: PageModel.Node) -> PageModel.Node? {
+        if node.tag?.uppercased() == tag.uppercased() { return node }
+        for child in node.children {
+            if let found = findNode(tagged: tag, in: child) { return found }
+        }
+        return nil
+    }
+}
+
+// MARK: - Test-only helpers
+
+extension AddEffectIntent {
+    /// Drives `run()`'s plan → confirm → apply logic directly, bypassing the AppIntents
+    /// `requestConfirmation` gate. Only callable when `AddEffectIntentOverride.scoped` is bound.
+    func performForTesting() async throws -> String {
+        guard AddEffectIntentOverride.scoped != nil else {
+            fatalError("performForTesting requires a bound AddEffectIntentOverride.scoped")
+        }
+        return try await run()
+    }
+}
+
+// MARK: - EffectAppEnum
+
+/// `AppEnum` over the catalog's placeable effect ids, for Siri's parameter picker. Raw values
+/// (and display representations) are the catalog entries' `title` strings, not their `component`
+/// ids — `AddEffectIntent.run()` looks entries up by title.
+public enum EffectAppEnum: String, AppEnum {
+    case particleField = "Particle Field"
+    case auroraGradient = "Aurora Gradient"
+    case grainOverlay = "Grain Overlay"
+    case magneticButton = "Magnetic Button"
+    case cursorGlow = "Cursor Glow"
+    case tiltCard = "Tilt Card"
+    case parallaxLayers = "Parallax Layers"
+    case revealMask = "Reveal Mask"
+    case scrollProgressTrace = "Scroll Progress Trace"
+    case blobMorph = "Blob Morph"
+    case meshGradient = "Mesh Gradient"
+    case dotGridPulse = "Dot Grid Pulse"
+
+    public static var typeDisplayRepresentation: TypeDisplayRepresentation = "Effect"
+    public static var caseDisplayRepresentations: [EffectAppEnum: DisplayRepresentation] = [
+        .particleField: "Particle Field", .auroraGradient: "Aurora Gradient", .grainOverlay: "Grain Overlay",
+        .magneticButton: "Magnetic Button", .cursorGlow: "Cursor Glow", .tiltCard: "Tilt Card",
+        .parallaxLayers: "Parallax Layers", .revealMask: "Reveal Mask", .scrollProgressTrace: "Scroll Progress Trace",
+        .blobMorph: "Blob Morph", .meshGradient: "Mesh Gradient", .dotGridPulse: "Dot Grid Pulse",
+    ]
+}

--- a/Sources/AnglesiteIntents/EffectIntents.swift
+++ b/Sources/AnglesiteIntents/EffectIntents.swift
@@ -123,10 +123,12 @@ public struct AddEffectIntent: AppIntent {
             return EffectDialogs.siteNotOpen(siteName: site.displayName)
         }
 
-        // No page picker on this front door (v1) -- the home page route, matching
-        // `EffectPlacementController`'s own `preview.activeRoute ?? "/"` default when no route is
-        // active.
-        let path = "/"
+        // No page picker on this front door (v1) -- the home page's *source file*, matching what
+        // `SiteWindowModel` resolves for a preview sitting on `/`. It has to be the project-
+        // relative `.astro` path, not the route: `get_page_model`'s `validPagePath` and
+        // `insertBlock`'s own path check both reject a route outright (#768 final review,
+        // Finding 1).
+        let path = PageSourcePath.homePage
         let model: PageModel
         do {
             model = try await pageModelClient.fetch(path: path)

--- a/Tests/AnglesiteAppTests/EffectPlacementControllerTests.swift
+++ b/Tests/AnglesiteAppTests/EffectPlacementControllerTests.swift
@@ -77,6 +77,40 @@ import AnglesiteCore
         #expect(controller.state == .idle)
     }
 
+    /// The placement HUD's before/after toggle has to actually reach `PlacementMatcher`
+    /// (#768 final review, Finding 6) — `resolve` hardcoded "after" before this.
+    @Test func inlinePositionReachesTheResolvedInsertionIndex() async {
+        let inlineEntry = EffectCatalogEntry(
+            component: "MagneticButton", title: "Magnetic Button", ownerDescription: "d",
+            category: .cursorReactive, keyProps: [:], snippet: "s",
+            placement: .init(kind: .inline, allowedParents: nil))
+        let click = PlacementPickMessage(
+            path: "/", element: .init(tag: "SECTION", id: nil, classes: ["hero"], nthChild: 1, ancestors: [], dataAnglesiteId: nil, dataTestId: nil, role: nil, ariaLabel: nil, textContent: nil))
+
+        func indexApplied(for position: PlacementMatcher.InlinePosition) async -> Int? {
+            var applied: Int?
+            let controller = EffectPlacementController(
+                path: "src/pages/index.astro",
+                pageModelClient: PageModelClient { _, _ in
+                    MCPClient.ToolCallResult(content: [.init(type: "text", text: Self.modelJSON)], isError: false)
+                },
+                editRouter: TestEditRouter { message in
+                    if case .object(let component)? = message.component, case .int(let index)? = component["index"] {
+                        applied = index
+                    }
+                    return EditReply(id: message.id, status: .applied, message: nil)
+                })
+            controller.inlinePosition = position
+            controller.startPlacement(for: inlineEntry, enterOverlayMode: {}, exitOverlayMode: {})
+            await controller.handlePick(click)
+            return applied
+        }
+
+        // The clicked SECTION is `<body>`'s only child (index 0 in the fixture tree).
+        #expect(await indexApplied(for: .after) == 1)
+        #expect(await indexApplied(for: .before) == 0)
+    }
+
     // MARK: - acknowledge()
 
     @Test func acknowledgeReturnsToIdleFromSucceeded() async {

--- a/Tests/AnglesiteAppTests/SiteWindowModelEffectPlacementPathTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelEffectPlacementPathTests.swift
@@ -1,0 +1,58 @@
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+/// Pins what the *production* wiring hands `PageModelClient`/`insertBlock` — the gap every other
+/// click-to-place test left open by supplying a correct `src/pages/….astro` path by hand
+/// (#768 final review, Finding 1). `SiteWindowModel.effectPlacementController` used to pass
+/// `preview.activeRoute ?? "/"` straight through, which the sidecar rejects outright with
+/// `invalid-input: not a project-relative .astro path: /`.
+@Suite("SiteWindowModel effect-placement path")
+@MainActor
+struct SiteWindowModelEffectPlacementPathTests {
+    private func makeModel(contentGraph: SiteContentGraph = SiteContentGraph()) -> SiteWindowModel {
+        SiteWindowModel(
+            contentGraph: contentGraph,
+            knowledgeIndex: SiteKnowledgeIndex(),
+            semanticRanker: nil,
+            conventionsEngine: ProjectConventionsEngine(),
+            runtimeFactory: NeverStartedSiteRuntimeFactory(),
+            contentIndexerStore: ContentIndexerStore()
+        )
+    }
+
+    @Test("targets the home page source with no active route")
+    func noRouteTargetsHomePageSource() {
+        let path = makeModel().effectPlacementController.path
+        #expect(path == "src/pages/index.astro")
+        #expect(PageSourcePath.isValidPageSourcePath(path))
+    }
+
+    @Test("targets the active route's page source, never the route itself")
+    func activeRouteResolvesToAPageSourcePath() {
+        let model = makeModel()
+        model.preview.navigate(toRoute: "/about")
+        let path = model.effectPlacementController.path
+        #expect(!path.hasPrefix("/"))
+        #expect(path.hasSuffix(".astro"))
+        #expect(path == "src/pages/about.astro")
+    }
+
+    @Test("prefers the scanned page's real source path over the naming convention")
+    func usesTheContentGraphsFilePath() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("effect-placement-path-\(UUID().uuidString)")
+        let pagesDir = root.appendingPathComponent("src/pages/blog")
+        try FileManager.default.createDirectory(at: pagesDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try Data("<h1>Blog</h1>".utf8).write(to: pagesDir.appendingPathComponent("index.astro"))
+
+        let model = makeModel()
+        await model.refreshContentGraph(siteID: "s1", sourceDirectory: root)
+        model.preview.navigate(toRoute: "/blog")
+
+        // The convention alone would guess `src/pages/blog.astro` — a file that doesn't exist.
+        #expect(model.effectPlacementController.path == "src/pages/blog/index.astro")
+    }
+}

--- a/Tests/AnglesiteCoreTests/BlockManifestSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/BlockManifestSyncTests.swift
@@ -3,34 +3,56 @@ import Foundation
 @testable import AnglesiteCore
 
 @Suite struct BlockManifestSyncTests {
-    private func write(_ json: String, to url: URL) throws {
+    private func write(_ contents: String, to url: URL) throws {
         try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try json.write(to: url, atomically: true, encoding: .utf8)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
     }
 
-    @Test func createsManifestWhenSiteHasNone() throws {
+    /// A throwaway (template root, site root) pair. Component paths resolve against these, since
+    /// the manifest sits at each root.
+    private func makeRoots() -> (template: URL, site: URL) {
         let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        let templateManifest = tmp.appendingPathComponent("template/blocks.manifest.json")
-        let siteManifest = tmp.appendingPathComponent("site/blocks.manifest.json")
-        let templateJSON = "{\"schemaVersion\":\"anglesite-block-manifest/1\",\"modules\":[{\"path\":\"src/components/effects/ParticleField.astro\",\"export\":\"ParticleField\",\"kind\":\"astro\",\"name\":\"Particle Field\",\"description\":\"d\",\"icon\":null,\"propEditors\":[],\"slots\":[]}]}"
-        try write(templateJSON, to: templateManifest)
+        return (tmp.appendingPathComponent("template"), tmp.appendingPathComponent("site"))
+    }
 
-        try BlockManifestSync.sync(templateBlocksManifest: templateManifest, siteBlocksManifest: siteManifest)
+    private func manifestJSON(_ paths: [String]) -> String {
+        let modules = paths.map { path -> String in
+            let name = (path as NSString).deletingPathExtension.components(separatedBy: "/").last ?? path
+            return "{\"path\":\"\(path)\",\"export\":\"\(name)\",\"kind\":\"astro\",\"name\":\"\(name)\",\"description\":\"d\",\"icon\":null,\"propEditors\":[],\"slots\":[]}"
+        }
+        return "{\"schemaVersion\":\"anglesite-block-manifest/1\",\"modules\":[\(modules.joined(separator: ","))]}"
+    }
 
-        let written = try String(contentsOf: siteManifest, encoding: .utf8)
+    private static let particleField = "src/components/effects/ParticleField.astro"
+    private static let auroraGradient = "src/components/effects/AuroraGradient.astro"
+
+    @Test func createsManifestWhenSiteHasNone() throws {
+        let roots = makeRoots()
+        try write(manifestJSON([Self.particleField]), to: roots.template.appendingPathComponent("blocks.manifest.json"))
+        try write("<canvas />", to: roots.template.appendingPathComponent(Self.particleField))
+
+        let outcome = try BlockManifestSync.sync(
+            templateBlocksManifest: roots.template.appendingPathComponent("blocks.manifest.json"),
+            siteBlocksManifest: roots.site.appendingPathComponent("blocks.manifest.json"))
+
+        let written = try String(contentsOf: roots.site.appendingPathComponent("blocks.manifest.json"), encoding: .utf8)
         #expect(written.contains("ParticleField"))
+        #expect(outcome.didWriteManifest)
+        #expect(outcome.addedPaths == [Self.particleField])
     }
 
     @Test func appendsOnlyMissingEntriesByPath() throws {
-        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        let templateManifest = tmp.appendingPathComponent("template/blocks.manifest.json")
-        let siteManifest = tmp.appendingPathComponent("site/blocks.manifest.json")
-        let templateJSON = "{\"schemaVersion\":\"anglesite-block-manifest/1\",\"modules\":[{\"path\":\"src/components/effects/ParticleField.astro\",\"export\":\"ParticleField\",\"kind\":\"astro\",\"name\":\"Particle Field\",\"description\":\"d\",\"icon\":null,\"propEditors\":[],\"slots\":[]},{\"path\":\"src/components/effects/AuroraGradient.astro\",\"export\":\"AuroraGradient\",\"kind\":\"astro\",\"name\":\"Aurora Gradient\",\"description\":\"d\",\"icon\":null,\"propEditors\":[],\"slots\":[]}]}"
-        try write(templateJSON, to: templateManifest)
-        let siteJSON = "{\"schemaVersion\":\"anglesite-block-manifest/1\",\"modules\":[{\"path\":\"src/components/effects/ParticleField.astro\",\"export\":\"ParticleField\",\"kind\":\"astro\",\"name\":\"CUSTOMIZED BY OWNER\",\"description\":\"d\",\"icon\":null,\"propEditors\":[],\"slots\":[]}]}"
+        let roots = makeRoots()
+        try write(manifestJSON([Self.particleField, Self.auroraGradient]), to: roots.template.appendingPathComponent("blocks.manifest.json"))
+        try write("<canvas />", to: roots.template.appendingPathComponent(Self.particleField))
+        try write("<canvas />", to: roots.template.appendingPathComponent(Self.auroraGradient))
+        let siteManifest = roots.site.appendingPathComponent("blocks.manifest.json")
+        let siteJSON = "{\"schemaVersion\":\"anglesite-block-manifest/1\",\"modules\":[{\"path\":\"\(Self.particleField)\",\"export\":\"ParticleField\",\"kind\":\"astro\",\"name\":\"CUSTOMIZED BY OWNER\",\"description\":\"d\",\"icon\":null,\"propEditors\":[],\"slots\":[]}]}"
         try write(siteJSON, to: siteManifest)
 
-        try BlockManifestSync.sync(templateBlocksManifest: templateManifest, siteBlocksManifest: siteManifest)
+        try BlockManifestSync.sync(
+            templateBlocksManifest: roots.template.appendingPathComponent("blocks.manifest.json"),
+            siteBlocksManifest: siteManifest)
 
         let written = try String(contentsOf: siteManifest, encoding: .utf8)
         #expect(written.contains("CUSTOMIZED BY OWNER")) // untouched
@@ -41,12 +63,10 @@ import Foundation
     }
 
     @Test func throwsOnCorruptSiteManifest() throws {
-        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        let templateManifest = tmp.appendingPathComponent("template/blocks.manifest.json")
-        let siteManifest = tmp.appendingPathComponent("site/blocks.manifest.json")
-
-        let templateJSON = "{\"schemaVersion\":\"anglesite-block-manifest/1\",\"modules\":[]}"
-        try write(templateJSON, to: templateManifest)
+        let roots = makeRoots()
+        let templateManifest = roots.template.appendingPathComponent("blocks.manifest.json")
+        let siteManifest = roots.site.appendingPathComponent("blocks.manifest.json")
+        try write(manifestJSON([]), to: templateManifest)
 
         // Test case 1: valid JSON but missing "modules" key
         let corruptJSON1 = "{\"schemaVersion\":\"anglesite-block-manifest/1\"}"
@@ -71,5 +91,88 @@ import Foundation
         // Verify original corrupt file is untouched
         let stillThere2 = try String(contentsOf: siteManifest, encoding: .utf8)
         #expect(stillThere2 == corruptJSON2)
+    }
+
+    // MARK: - Component files (#768 final review, Finding 3)
+
+    @Test func copiesMissingComponentFilesIntoTheSite() throws {
+        let roots = makeRoots()
+        try write(manifestJSON([Self.particleField]), to: roots.template.appendingPathComponent("blocks.manifest.json"))
+        try write("<canvas data-particle-field />", to: roots.template.appendingPathComponent(Self.particleField))
+
+        let outcome = try BlockManifestSync.sync(
+            templateBlocksManifest: roots.template.appendingPathComponent("blocks.manifest.json"),
+            siteBlocksManifest: roots.site.appendingPathComponent("blocks.manifest.json"))
+
+        let copied = roots.site.appendingPathComponent(Self.particleField)
+        #expect(FileManager.default.fileExists(atPath: copied.path))
+        #expect(try String(contentsOf: copied, encoding: .utf8) == "<canvas data-particle-field />")
+        #expect(outcome.copiedComponentPaths == [Self.particleField])
+    }
+
+    @Test func neverOverwritesAComponentTheOwnerAlreadyEdited() throws {
+        let roots = makeRoots()
+        try write(manifestJSON([Self.particleField]), to: roots.template.appendingPathComponent("blocks.manifest.json"))
+        try write("<canvas />", to: roots.template.appendingPathComponent(Self.particleField))
+        try write("MY OWN VERSION", to: roots.site.appendingPathComponent(Self.particleField))
+
+        let outcome = try BlockManifestSync.sync(
+            templateBlocksManifest: roots.template.appendingPathComponent("blocks.manifest.json"),
+            siteBlocksManifest: roots.site.appendingPathComponent("blocks.manifest.json"))
+
+        #expect(try String(contentsOf: roots.site.appendingPathComponent(Self.particleField), encoding: .utf8) == "MY OWN VERSION")
+        #expect(outcome.copiedComponentPaths.isEmpty)
+        #expect(outcome.addedPaths == [Self.particleField]) // still registered — the file is there
+    }
+
+    @Test func skipsRegisteringAnEntryWhoseComponentFileCantBeMadeToExist() throws {
+        let roots = makeRoots()
+        // Template manifest lists two effects but only ships one component file.
+        try write(manifestJSON([Self.particleField, Self.auroraGradient]), to: roots.template.appendingPathComponent("blocks.manifest.json"))
+        try write("<canvas />", to: roots.template.appendingPathComponent(Self.particleField))
+
+        let outcome = try BlockManifestSync.sync(
+            templateBlocksManifest: roots.template.appendingPathComponent("blocks.manifest.json"),
+            siteBlocksManifest: roots.site.appendingPathComponent("blocks.manifest.json"))
+
+        let written = try String(contentsOf: roots.site.appendingPathComponent("blocks.manifest.json"), encoding: .utf8)
+        #expect(written.contains("ParticleField"))
+        // A dangling entry would make the sidecar import a file that doesn't exist, breaking the
+        // owner's Astro build — better unregistered than dangling.
+        #expect(!written.contains("AuroraGradient"))
+        #expect(outcome.skippedMissingComponentPaths == [Self.auroraGradient])
+    }
+
+    // MARK: - No-op writes (#768 final review, Finding 7)
+
+    @Test func leavesTheOwnersManifestByteIdenticalWhenNothingIsMissing() throws {
+        let roots = makeRoots()
+        try write(manifestJSON([Self.particleField]), to: roots.template.appendingPathComponent("blocks.manifest.json"))
+        try write("<canvas />", to: roots.template.appendingPathComponent(Self.particleField))
+        try write("<canvas />", to: roots.site.appendingPathComponent(Self.particleField))
+        let siteManifest = roots.site.appendingPathComponent("blocks.manifest.json")
+        // Deliberately hand-formatted: different key order and indentation from what
+        // `JSONSerialization` would emit, i.e. exactly the shape a rewrite would churn.
+        let ownersFormatting = """
+        {
+          "modules": [
+            { "export": "ParticleField", "path": "\(Self.particleField)", "kind": "astro", "name": "Particle Field", "description": "d", "propEditors": [], "slots": [] }
+          ],
+          "schemaVersion": "anglesite-block-manifest/1"
+        }
+        """
+        try write(ownersFormatting, to: siteManifest)
+        let before = try Data(contentsOf: siteManifest)
+        let modifiedBefore = try FileManager.default.attributesOfItem(atPath: siteManifest.path)[.modificationDate] as? Date
+
+        let outcome = try BlockManifestSync.sync(
+            templateBlocksManifest: roots.template.appendingPathComponent("blocks.manifest.json"),
+            siteBlocksManifest: siteManifest)
+
+        #expect(!outcome.didWriteManifest)
+        #expect(outcome.addedPaths.isEmpty)
+        #expect(try Data(contentsOf: siteManifest) == before)
+        let modifiedAfter = try FileManager.default.attributesOfItem(atPath: siteManifest.path)[.modificationDate] as? Date
+        #expect(modifiedAfter == modifiedBefore)
     }
 }

--- a/Tests/AnglesiteCoreTests/PageModelClientRegistryTests.swift
+++ b/Tests/AnglesiteCoreTests/PageModelClientRegistryTests.swift
@@ -1,0 +1,73 @@
+import Testing
+@testable import AnglesiteCore
+
+/// Covers `PageModelClientRegistry`'s acceptance criteria: register / unregister / lookup, plus
+/// the last-writer-wins overwrite — the `get_page_model` counterpart to
+/// `EditRouterRegistryTests`. Tests use a private actor instance (not `.shared`) so they don't
+/// bleed across the suite.
+struct PageModelClientRegistryTests {
+    /// Builds a `PageModelClient` whose `fetch(path:)` always returns a one-node model tagged
+    /// with `label`, so a test can tell which registered client actually answered.
+    private func stubClient(_ label: String) -> PageModelClient {
+        PageModelClient(toolCaller: { name, _ in
+            #expect(name == "get_page_model")
+            let text = """
+            {"version":"v1","path":"/","tree":{"id":"n1","kind":"element","tag":"\(label)","attrs":[],"span":[0,0],"children":[]}}
+            """
+            return MCPClient.ToolCallResult(content: [.init(type: "text", text: text)], isError: false)
+        })
+    }
+
+    @Test("Lookup returns nil for an unregistered siteID")
+    func lookup_returnsNilForUnknown() async {
+        let registry = PageModelClientRegistry()
+        let client = await registry.pageModelClient(for: "missing")
+        #expect(client == nil)
+    }
+
+    @Test("Register then lookup returns the same client")
+    func register_lookup_roundTrips() async throws {
+        let registry = PageModelClientRegistry()
+        await registry.register(stubClient("a"), for: "s1")
+        let found = await registry.pageModelClient(for: "s1")
+        let model = try await found?.fetch(path: "/")
+        #expect(model?.tree.tag == "a")
+    }
+
+    @Test("Last writer wins on duplicate siteID")
+    func register_lastWriterWins() async throws {
+        let registry = PageModelClientRegistry()
+        await registry.register(stubClient("first"), for: "s1")
+        await registry.register(stubClient("second"), for: "s1")
+        let found = await registry.pageModelClient(for: "s1")
+        let model = try await found?.fetch(path: "/")
+        #expect(model?.tree.tag == "second")
+    }
+
+    @Test("Unregister removes the client")
+    func unregister_removes() async {
+        let registry = PageModelClientRegistry()
+        await registry.register(stubClient("a"), for: "s1")
+        await registry.unregister(siteID: "s1")
+        let found = await registry.pageModelClient(for: "s1")
+        #expect(found == nil)
+    }
+
+    @Test("Unregistering an unknown siteID is a silent no-op")
+    func unregister_unknown_silent() async {
+        let registry = PageModelClientRegistry()
+        await registry.unregister(siteID: "missing")
+        // No throw, no crash; the registry is just still empty.
+        #expect(await registry.knownSiteIDs().isEmpty)
+    }
+
+    @Test("knownSiteIDs reflects current registrations across sites")
+    func knownSiteIDs_reflectsRegistrations() async {
+        let registry = PageModelClientRegistry()
+        await registry.register(stubClient("a"), for: "s1")
+        await registry.register(stubClient("b"), for: "s2")
+        await registry.register(stubClient("c"), for: "s3")
+        await registry.unregister(siteID: "s2")
+        #expect(await registry.knownSiteIDs() == ["s1", "s3"])
+    }
+}

--- a/Tests/AnglesiteCoreTests/PageModelClientTests.swift
+++ b/Tests/AnglesiteCoreTests/PageModelClientTests.swift
@@ -34,4 +34,17 @@ import Foundation
             _ = try await client.fetch(path: "src/pages/index.astro")
         }
     }
+
+    /// These strings are owner-facing HUD text on the click-to-place failure path, so they have to
+    /// read like the rest of the app: "sidecar", not "plugin", and a sentence a person can act on
+    /// rather than a raw validator message (#768 final review, Finding 10).
+    @Test func friendlyMessagesAreWrittenForOwnersNotForTheWire() {
+        let decodeFailed = PageModelClient.ModelError.decodeFailed("keyNotFound(...)").friendlyMessage
+        #expect(decodeFailed.contains("sidecar"))
+        #expect(!decodeFailed.lowercased().contains("plugin"))
+
+        let invalidInput = PageModelClient.ModelError
+            .toolFailed(reason: "invalid-input", detail: "not a project-relative .astro path: /").friendlyMessage
+        #expect(invalidInput.hasPrefix("Couldn't place the effect here"))
+    }
 }

--- a/Tests/AnglesiteCoreTests/PageSourcePathTests.swift
+++ b/Tests/AnglesiteCoreTests/PageSourcePathTests.swift
@@ -1,0 +1,57 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Pins the route → page-source-path mapping every click-to-place caller depends on (#768 final
+/// review, Finding 1): the sidecar rejects a route (`/`) outright, so this resolution is what
+/// stands between a placement and `invalid-input: not a project-relative .astro path: /`.
+@Suite struct PageSourcePathTests {
+    private static func page(route: String, filePath: String) -> SiteContentGraph.Page {
+        SiteContentGraph.Page(
+            id: "s:page:\(route)", siteID: "s", route: route, filePath: filePath,
+            title: nil, lastModified: .distantPast)
+    }
+
+    @Test func rootRouteResolvesToTheHomePageSource() {
+        #expect(PageSourcePath.resolve(route: "/", pages: []) == "src/pages/index.astro")
+        #expect(PageSourcePath.resolve(route: nil, pages: []) == "src/pages/index.astro")
+    }
+
+    @Test func prefersTheScannedPageForTheRoute() {
+        let pages = [Self.page(route: "/blog", filePath: "src/pages/blog/index.astro")]
+        // The naming convention alone would guess `src/pages/blog.astro`; the graph knows better.
+        #expect(PageSourcePath.resolve(route: "/blog", pages: pages) == "src/pages/blog/index.astro")
+    }
+
+    @Test func fallsBackToTheAstroNamingConvention() {
+        #expect(PageSourcePath.resolve(route: "/about", pages: []) == "src/pages/about.astro")
+    }
+
+    @Test func normalizesTrailingSlashQueryAndFragment() {
+        let pages = [Self.page(route: "/about", filePath: "src/pages/about.astro")]
+        #expect(PageSourcePath.resolve(route: "/about/", pages: pages) == "src/pages/about.astro")
+        #expect(PageSourcePath.resolve(route: "/about?x=1", pages: pages) == "src/pages/about.astro")
+        #expect(PageSourcePath.resolve(route: "/about#top", pages: pages) == "src/pages/about.astro")
+    }
+
+    @Test func skipsNonAstroPagesRatherThanHandingTheSidecarAPathItRejects() {
+        let pages = [Self.page(route: "/about", filePath: "src/pages/about.md")]
+        let resolved = PageSourcePath.resolve(route: "/about", pages: pages)
+        #expect(resolved == "src/pages/about.astro")
+        #expect(PageSourcePath.isValidPageSourcePath(resolved))
+    }
+
+    @Test func everyResolutionSatisfiesTheSidecarsPathContract() {
+        for route in ["/", "", "/about", "/blog/", "/deep/nested/page", "//", "/x?y=1"] {
+            let resolved = PageSourcePath.resolve(route: route, pages: [])
+            #expect(PageSourcePath.isValidPageSourcePath(resolved), "route \(route) → \(resolved)")
+        }
+    }
+
+    @Test func routesAreNotValidPageSourcePaths() {
+        #expect(!PageSourcePath.isValidPageSourcePath("/"))
+        #expect(!PageSourcePath.isValidPageSourcePath("/about"))
+        #expect(!PageSourcePath.isValidPageSourcePath("src/pages/about.md"))
+        #expect(PageSourcePath.isValidPageSourcePath("src/pages/about.astro"))
+    }
+}

--- a/Tests/AnglesiteCoreTests/PlacementMatcherTests.swift
+++ b/Tests/AnglesiteCoreTests/PlacementMatcherTests.swift
@@ -117,4 +117,150 @@ import Testing
         let result = PlacementMatcher.resolve(element: element, in: Self.fixtureModelAmbiguous(), placement: placement)
         #expect(result == .failure(.ambiguous))
     }
+
+    // MARK: - Before/after toggle (#768 final review, Finding 6)
+
+    @Test func inlinePlacementCanInsertBeforeTheMatchedNode() {
+        let element = Self.elementInfo(tag: "SECTION", classes: ["hero"], nthChild: 2, ancestorTags: [("BODY", "body")])
+        let placement = EffectCatalogEntry.Placement(kind: .inline, allowedParents: nil)
+        let result = PlacementMatcher.resolve(
+            element: element, in: Self.fixtureModel(), placement: placement, inlinePosition: .before)
+        guard case .success(let insertion) = result else {
+            Issue.record("expected a match")
+            return
+        }
+        #expect(insertion.parentId == "n1")
+        #expect(insertion.index == 1) // at n3's own slot, pushing it down — i.e. before it
+    }
+
+    @Test func inlinePositionIsIgnoredByBackgroundPlacements() {
+        let element = Self.elementInfo(tag: "SECTION", classes: ["hero"], nthChild: 2, ancestorTags: [("BODY", "body")])
+        let placement = EffectCatalogEntry.Placement(kind: .background, allowedParents: nil)
+        let before = PlacementMatcher.resolve(element: element, in: Self.fixtureModel(), placement: placement, inlinePosition: .before)
+        let after = PlacementMatcher.resolve(element: element, in: Self.fixtureModel(), placement: placement, inlinePosition: .after)
+        #expect(before == after)
+    }
+
+    // MARK: - Identity-attribute priority (#768 final review, Finding 5)
+
+    /// `<body><div><span id="pick" data-testid="t" data-anglesite-id="a"/></div><div><span/></div></body>`
+    /// — the identity attributes sit on a node the positional matcher would call `.ambiguous`
+    /// (two SPANs, both first-in-parent, both under a DIV).
+    static func fixtureModelWithIdentityAttributes(
+        onTarget attrs: [PageModel.Attr]
+    ) -> PageModel {
+        func node(_ id: String, kind: PageModel.Node.Kind, tag: String?, attrs: [PageModel.Attr] = [], children: [PageModel.Node] = []) -> PageModel.Node {
+            PageModel.Node(id: id, kind: kind, tag: tag, attrs: attrs, span: .init(start: nil, end: nil), loc: nil, text: nil, children: children, block: nil)
+        }
+        let target = node("target", kind: .element, tag: "SPAN", attrs: attrs)
+        let decoy = node("decoy", kind: .element, tag: "SPAN")
+        let root = node("n0", kind: .fragment, tag: nil, children: [
+            node("d1", kind: .element, tag: "DIV", children: [target]),
+            node("d2", kind: .element, tag: "DIV", children: [decoy]),
+        ])
+        return PageModel(version: "v1", path: "src/pages/index.astro", tree: root)
+    }
+
+    static func elementInfoWithIdentity(id: String? = nil, dataTestId: String? = nil, dataAnglesiteId: String? = nil) -> ElementInfo {
+        ElementInfo(
+            tag: "SPAN", id: id, classes: [], nthChild: 1, ancestors: [],
+            dataAnglesiteId: dataAnglesiteId, dataTestId: dataTestId, role: nil, ariaLabel: nil, textContent: nil)
+    }
+
+    @Test func dataAnglesiteIdResolvesAnOtherwiseAmbiguousClick() {
+        let model = Self.fixtureModelWithIdentityAttributes(onTarget: [.init(name: "data-anglesite-id", value: "a1")])
+        let placement = EffectCatalogEntry.Placement(kind: .inline, allowedParents: nil)
+
+        // Without the identity signal this exact click is ambiguous…
+        #expect(PlacementMatcher.resolve(element: Self.elementInfoWithIdentity(), in: model, placement: placement) == .failure(.ambiguous))
+
+        // …and with it, it resolves to the one node carrying the attribute.
+        let result = PlacementMatcher.resolve(
+            element: Self.elementInfoWithIdentity(dataAnglesiteId: "a1"), in: model, placement: placement)
+        guard case .success(let insertion) = result else {
+            Issue.record("expected the data-anglesite-id match")
+            return
+        }
+        #expect(insertion.parentId == "d1")
+        #expect(insertion.index == 1)
+    }
+
+    @Test func dataTestIdResolvesAnOtherwiseAmbiguousClick() {
+        let model = Self.fixtureModelWithIdentityAttributes(onTarget: [.init(name: "data-testid", value: "t1")])
+        let result = PlacementMatcher.resolve(
+            element: Self.elementInfoWithIdentity(dataTestId: "t1"), in: model,
+            placement: .init(kind: .inline, allowedParents: nil))
+        guard case .success(let insertion) = result else {
+            Issue.record("expected the data-testid match")
+            return
+        }
+        #expect(insertion.parentId == "d1")
+    }
+
+    @Test func idResolvesAnOtherwiseAmbiguousClick() {
+        let model = Self.fixtureModelWithIdentityAttributes(onTarget: [.init(name: "id", value: "pick")])
+        let result = PlacementMatcher.resolve(
+            element: Self.elementInfoWithIdentity(id: "pick"), in: model,
+            placement: .init(kind: .inline, allowedParents: nil))
+        guard case .success(let insertion) = result else {
+            Issue.record("expected the #id match")
+            return
+        }
+        #expect(insertion.parentId == "d1")
+    }
+
+    @Test func dataAnglesiteIdWinsOverDataTestIdAndId() {
+        func node(_ id: String, attrs: [PageModel.Attr]) -> PageModel.Node {
+            PageModel.Node(id: id, kind: .element, tag: "SPAN", attrs: attrs, span: .init(start: nil, end: nil), loc: nil, text: nil, children: [], block: nil)
+        }
+        let root = PageModel.Node(
+            id: "n0", kind: .fragment, tag: nil, attrs: [], span: .init(start: nil, end: nil), loc: nil, text: nil,
+            children: [
+                node("byAnglesiteId", attrs: [.init(name: "data-anglesite-id", value: "a1")]),
+                node("byTestId", attrs: [.init(name: "data-testid", value: "t1")]),
+                node("byId", attrs: [.init(name: "id", value: "pick")]),
+            ], block: nil)
+        let model = PageModel(version: "v1", path: "src/pages/index.astro", tree: root)
+        let element = ElementInfo(
+            tag: "SPAN", id: "pick", classes: [], nthChild: 1, ancestors: [],
+            dataAnglesiteId: "a1", dataTestId: "t1", role: nil, ariaLabel: nil, textContent: nil)
+
+        let result = PlacementMatcher.resolve(element: element, in: model, placement: .init(kind: .inline, allowedParents: nil))
+        guard case .success(let insertion) = result else {
+            Issue.record("expected a match")
+            return
+        }
+        #expect(insertion.parentId == "n0")
+        #expect(insertion.index == 1) // after `byAnglesiteId` (index 0) — the highest-priority hit
+    }
+
+    @Test func anIdentityAttributeTheTreeDoesntCarryFallsBackToPositionalMatching() {
+        // The overlay reports an id (e.g. one a client-side script added at runtime) that the
+        // source tree has no trace of — the positional match must still get its turn.
+        let element = ElementInfo(
+            tag: "SECTION", id: "added-at-runtime", classes: ["hero"], nthChild: 2, ancestors: [],
+            dataAnglesiteId: nil, dataTestId: nil, role: nil, ariaLabel: nil, textContent: nil)
+        let result = PlacementMatcher.resolve(
+            element: element, in: Self.fixtureModel(), placement: .init(kind: .inline, allowedParents: nil))
+        guard case .success(let insertion) = result else {
+            Issue.record("expected the positional fallback to match")
+            return
+        }
+        #expect(insertion.parentId == "n1")
+        #expect(insertion.index == 2)
+    }
+
+    @Test func duplicatedIdentityAttributesAreAmbiguousRatherThanAGuess() {
+        func node(_ id: String) -> PageModel.Node {
+            PageModel.Node(id: id, kind: .element, tag: "SPAN", attrs: [.init(name: "id", value: "dupe")], span: .init(start: nil, end: nil), loc: nil, text: nil, children: [], block: nil)
+        }
+        let root = PageModel.Node(
+            id: "n0", kind: .fragment, tag: nil, attrs: [], span: .init(start: nil, end: nil), loc: nil, text: nil,
+            children: [node("a"), node("b")], block: nil)
+        let model = PageModel(version: "v1", path: "src/pages/index.astro", tree: root)
+        let result = PlacementMatcher.resolve(
+            element: Self.elementInfoWithIdentity(id: "dupe"), in: model,
+            placement: .init(kind: .inline, allowedParents: nil))
+        #expect(result == .failure(.ambiguous))
+    }
 }

--- a/Tests/AnglesiteIntentsTests/EffectIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/EffectIntentsTests.swift
@@ -198,6 +198,56 @@ import Foundation
         #expect(dialog.contains("Dot Grid Pulse"))
     }
 
+    /// The one thing every other `run()` test took for granted: the path this front door actually
+    /// hands the sidecar. `get_page_model`'s `validPagePath` and `insertBlock`'s own path check
+    /// both reject a route, so a hardcoded `"/"` here failed 100% of real invocations with
+    /// `invalid-input: not a project-relative .astro path: /` (#768 final review, Finding 1).
+    @Test func fetchesAndEditsTheHomePageSourcePathNotARoute() async throws {
+        let recorder = PathRecorder()
+        let model = Self.fixtureModelWithBody()
+        let client = PageModelClient(toolCaller: { name, arguments in
+            #expect(name == "get_page_model")
+            if case .object(let object) = arguments, case .string(let path)? = object["path"] {
+                await recorder.recordFetch(path)
+            }
+            let data = try JSONEncoder().encode(model)
+            return MCPClient.ToolCallResult(content: [.init(type: "text", text: String(data: data, encoding: .utf8)!)], isError: false)
+        })
+        let router = RecordingRouter()
+
+        let intent = AddEffectIntent()
+        intent.site = SiteEntity(id: "s1", name: "Acme", creationDate: nil, modificationDate: nil)
+        intent.effect = .particleField
+        _ = try await Self.runForTesting(
+            intent, catalog: EffectCatalog(entries: [Self.particleFieldEntry()]),
+            pageModelClient: client, editRouter: router)
+
+        let fetched = await recorder.fetchedPath
+        #expect(fetched == "src/pages/index.astro")
+        #expect(PageSourcePath.isValidPageSourcePath(fetched ?? "/"))
+
+        let editedPath = await router.lastComponentPath
+        #expect(editedPath == "src/pages/index.astro")
+        #expect(PageSourcePath.isValidPageSourcePath(editedPath ?? "/"))
+    }
+
+    /// Records the `path` argument `AddEffectIntent` sends to `get_page_model`.
+    actor PathRecorder {
+        private(set) var fetchedPath: String?
+        func recordFetch(_ path: String) { fetchedPath = path }
+    }
+
+    /// Applies successfully while capturing the `component.path` of the `insertBlock` edit.
+    actor RecordingRouter: EditRouter {
+        private(set) var lastComponentPath: String?
+        func apply(_ message: EditMessage) async -> EditReply {
+            if case .object(let component)? = message.component, case .string(let path)? = component["path"] {
+                lastComponentPath = path
+            }
+            return EditReply(id: message.id, status: .applied, message: nil)
+        }
+    }
+
     @Test func reportsAFriendlyMessageWhenTheModelFailsToLoad() async throws {
         let intent = AddEffectIntent()
         intent.site = SiteEntity(id: "s1", name: "Acme", creationDate: nil, modificationDate: nil)

--- a/Tests/AnglesiteIntentsTests/EffectIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/EffectIntentsTests.swift
@@ -5,8 +5,9 @@ import Foundation
 
 /// Covers `AddEffectIntent`: the pure `defaultInsertion` placement math (Step 2 of the task
 /// brief), the pure `EffectDialogs` strings, and `run()`'s plan → confirm → apply flow driven
-/// through `performForTesting()` with `AddEffectIntentOverride` fakes standing in for the
-/// template-backed catalog and the site's `PageModelClient`/`EditRouter` registries.
+/// through `performForTesting()` with `EffectCatalogOverride` (mirrors `ThemeCatalogOverride`)
+/// and `AddEffectSiteConnectionOverride` standing in for the `@Dependency`-resolved catalog and
+/// the site's `PageModelClient`/`EditRouter` registries, respectively.
 @Suite struct EffectIntentsTests {
     // MARK: - Fixtures
 
@@ -63,6 +64,23 @@ import Foundation
             component: "ParticleField", title: "Particle Field", ownerDescription: "d",
             category: .canvasBackground, keyProps: [:], snippet: "s",
             placement: .init(kind: kind, allowedParents: allowedParents))
+    }
+
+    /// Binds both `AddEffectIntent` overrides (catalog + site connection) around
+    /// `intent.performForTesting()`, since `run()` needs both bound to skip
+    /// `requestConfirmation` and to resolve without a live registry/template. Nesting the two
+    /// separate `@TaskLocal`s here keeps individual tests focused on what varies.
+    static func runForTesting(
+        _ intent: AddEffectIntent, catalog: EffectCatalog,
+        pageModelClient: PageModelClient?, editRouter: EditRouter?
+    ) async throws -> String {
+        try await EffectCatalogOverride.$scoped.withValue(catalog) {
+            try await AddEffectSiteConnectionOverride.$scoped.withValue(
+                AddEffectSiteConnection(pageModelClient: pageModelClient, editRouter: editRouter)
+            ) {
+                try await intent.performForTesting()
+            }
+        }
     }
 
     // MARK: - defaultInsertion (Step 2 of the task brief)
@@ -125,13 +143,10 @@ import Foundation
         let intent = AddEffectIntent()
         intent.site = SiteEntity(id: "s1", name: "Acme", creationDate: nil, modificationDate: nil)
         intent.effect = .particleField
-        let fakes = AddEffectIntentFakes(
-            catalog: EffectCatalog(entries: [Self.particleFieldEntry()]),
+        let dialog = try await Self.runForTesting(
+            intent, catalog: EffectCatalog(entries: [Self.particleFieldEntry()]),
             pageModelClient: Self.fakePageModelClient(returning: Self.fixtureModelWithBody()),
             editRouter: StubRouter(status: .applied))
-        let dialog = try await AddEffectIntentOverride.$scoped.withValue(fakes) {
-            try await intent.performForTesting()
-        }
         #expect(dialog == "Added Particle Field to Acme.")
     }
 
@@ -139,13 +154,10 @@ import Foundation
         let intent = AddEffectIntent()
         intent.site = SiteEntity(id: "s1", name: "Acme", creationDate: nil, modificationDate: nil)
         intent.effect = .particleField
-        let fakes = AddEffectIntentFakes(
-            catalog: EffectCatalog(entries: [Self.particleFieldEntry()]),
+        let dialog = try await Self.runForTesting(
+            intent, catalog: EffectCatalog(entries: [Self.particleFieldEntry()]),
             pageModelClient: Self.fakePageModelClient(returning: Self.fixtureModelWithBody()),
             editRouter: StubRouter(status: .failed, message: "stale version"))
-        let dialog = try await AddEffectIntentOverride.$scoped.withValue(fakes) {
-            try await intent.performForTesting()
-        }
         #expect(dialog.contains("stale version"))
         #expect(dialog.contains("Acme"))
     }
@@ -154,13 +166,9 @@ import Foundation
         let intent = AddEffectIntent()
         intent.site = SiteEntity(id: "s1", name: "Acme", creationDate: nil, modificationDate: nil)
         intent.effect = .particleField
-        let fakes = AddEffectIntentFakes(
-            catalog: EffectCatalog(entries: [Self.particleFieldEntry()]),
-            pageModelClient: nil,
-            editRouter: nil)
-        let dialog = try await AddEffectIntentOverride.$scoped.withValue(fakes) {
-            try await intent.performForTesting()
-        }
+        let dialog = try await Self.runForTesting(
+            intent, catalog: EffectCatalog(entries: [Self.particleFieldEntry()]),
+            pageModelClient: nil, editRouter: nil)
         #expect(dialog == "Open Acme in Anglesite first, then try adding this effect again.")
     }
 
@@ -171,13 +179,10 @@ import Foundation
         let legacyEntry = EffectCatalogEntry(
             component: "ParticleField", title: "Particle Field", ownerDescription: "d",
             category: .canvasBackground, keyProps: [:], snippet: "s", placement: nil)
-        let fakes = AddEffectIntentFakes(
-            catalog: EffectCatalog(entries: [legacyEntry]),
+        let dialog = try await Self.runForTesting(
+            intent, catalog: EffectCatalog(entries: [legacyEntry]),
             pageModelClient: Self.fakePageModelClient(returning: Self.fixtureModelWithBody()),
             editRouter: StubRouter(status: .applied))
-        let dialog = try await AddEffectIntentOverride.$scoped.withValue(fakes) {
-            try await intent.performForTesting()
-        }
         #expect(dialog.contains("Particle Field"))
         #expect(dialog.contains("Effects gallery"))
     }
@@ -186,13 +191,10 @@ import Foundation
         let intent = AddEffectIntent()
         intent.site = SiteEntity(id: "s1", name: "Acme", creationDate: nil, modificationDate: nil)
         intent.effect = .dotGridPulse
-        let fakes = AddEffectIntentFakes(
-            catalog: EffectCatalog(entries: [Self.particleFieldEntry()]), // no "Dot Grid Pulse" entry
+        let dialog = try await Self.runForTesting(
+            intent, catalog: EffectCatalog(entries: [Self.particleFieldEntry()]), // no "Dot Grid Pulse" entry
             pageModelClient: Self.fakePageModelClient(returning: Self.fixtureModelWithBody()),
             editRouter: StubRouter(status: .applied))
-        let dialog = try await AddEffectIntentOverride.$scoped.withValue(fakes) {
-            try await intent.performForTesting()
-        }
         #expect(dialog.contains("Dot Grid Pulse"))
     }
 
@@ -203,13 +205,9 @@ import Foundation
         let notConnectedClient = PageModelClient(toolCaller: { _, _ in
             throw PageModelClient.ModelError.notConnected
         })
-        let fakes = AddEffectIntentFakes(
-            catalog: EffectCatalog(entries: [Self.particleFieldEntry()]),
-            pageModelClient: notConnectedClient,
-            editRouter: StubRouter(status: .applied))
-        let dialog = try await AddEffectIntentOverride.$scoped.withValue(fakes) {
-            try await intent.performForTesting()
-        }
+        let dialog = try await Self.runForTesting(
+            intent, catalog: EffectCatalog(entries: [Self.particleFieldEntry()]),
+            pageModelClient: notConnectedClient, editRouter: StubRouter(status: .applied))
         #expect(dialog.contains("Acme"))
         #expect(dialog.contains("not running"))
     }

--- a/Tests/AnglesiteIntentsTests/EffectIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/EffectIntentsTests.swift
@@ -1,0 +1,216 @@
+import Testing
+import Foundation
+@testable import AnglesiteIntents
+@testable import AnglesiteCore
+
+/// Covers `AddEffectIntent`: the pure `defaultInsertion` placement math (Step 2 of the task
+/// brief), the pure `EffectDialogs` strings, and `run()`'s plan → confirm → apply flow driven
+/// through `performForTesting()` with `AddEffectIntentOverride` fakes standing in for the
+/// template-backed catalog and the site's `PageModelClient`/`EditRouter` registries.
+@Suite struct EffectIntentsTests {
+    // MARK: - Fixtures
+
+    /// Local duplicate of `PlacementMatcherTests.fixtureModel()` (Task 7,
+    /// `Tests/AnglesiteCoreTests/PlacementMatcherTests.swift`) — test targets don't depend on
+    /// each other, so this is intentionally re-declared here rather than imported.
+    /// `<body>` with three element children: HEADER, SECTION (class "hero"), FOOTER.
+    static func fixtureModelWithBody() -> PageModel {
+        func node(_ id: String, kind: PageModel.Node.Kind, tag: String?, attrs: [PageModel.Attr] = [], children: [PageModel.Node] = []) -> PageModel.Node {
+            PageModel.Node(id: id, kind: kind, tag: tag, attrs: attrs, span: .init(start: nil, end: nil), loc: nil, text: nil, children: children, block: nil)
+        }
+        let body = node("n1", kind: .element, tag: "BODY", attrs: [.init(name: "id", value: "body")], children: [
+            node("n2", kind: .element, tag: "HEADER"),
+            node("n3", kind: .element, tag: "SECTION", attrs: [.init(name: "class", value: "hero")]),
+            node("n4", kind: .element, tag: "FOOTER"),
+        ])
+        let root = node("n0", kind: .fragment, tag: nil, children: [body])
+        return PageModel(version: "v1", path: "src/pages/index.astro", tree: root)
+    }
+
+    /// A tree with no `<body>` anywhere, to exercise `defaultInsertion`'s tree-root fallback.
+    static func fixtureModelWithoutBody() -> PageModel {
+        func node(_ id: String, kind: PageModel.Node.Kind, tag: String?, children: [PageModel.Node] = []) -> PageModel.Node {
+            PageModel.Node(id: id, kind: kind, tag: tag, attrs: [], span: .init(start: nil, end: nil), loc: nil, text: nil, children: children, block: nil)
+        }
+        let root = node("n0", kind: .fragment, tag: nil, children: [node("n1", kind: .element, tag: "MAIN")])
+        return PageModel(version: "v1", path: "src/pages/index.astro", tree: root)
+    }
+
+    /// A `PageModelClient` whose `fetch(path:)` always succeeds with `model`.
+    static func fakePageModelClient(returning model: PageModel) -> PageModelClient {
+        PageModelClient(toolCaller: { name, _ in
+            #expect(name == "get_page_model")
+            let data = try JSONEncoder().encode(model)
+            return MCPClient.ToolCallResult(content: [.init(type: "text", text: String(data: data, encoding: .utf8)!)], isError: false)
+        })
+    }
+
+    /// A fixed-outcome `EditRouter`, echoing the originating message's id.
+    actor StubRouter: EditRouter {
+        let status: EditReply.Status
+        let message: String?
+        init(status: EditReply.Status, message: String? = nil) {
+            self.status = status
+            self.message = message
+        }
+        func apply(_ message: EditMessage) async -> EditReply {
+            EditReply(id: message.id, status: status, message: self.message)
+        }
+    }
+
+    static func particleFieldEntry(kind: EffectCatalogEntry.Placement.Kind = .background, allowedParents: [String]? = nil) -> EffectCatalogEntry {
+        EffectCatalogEntry(
+            component: "ParticleField", title: "Particle Field", ownerDescription: "d",
+            category: .canvasBackground, keyProps: [:], snippet: "s",
+            placement: .init(kind: kind, allowedParents: allowedParents))
+    }
+
+    // MARK: - defaultInsertion (Step 2 of the task brief)
+
+    @Test func backgroundPlacementDefaultsToEndOfBody() {
+        let entry = Self.particleFieldEntry(kind: .background)
+        let model = Self.fixtureModelWithBody()
+        let insertion = AddEffectIntent.defaultInsertion(for: entry, in: model)
+        #expect(insertion?.parentId == model.tree.children.first?.id)
+        #expect(insertion?.index == model.tree.children.first?.children.count) // end of <body>'s 3 children
+    }
+
+    @Test func backgroundPlacementFallsBackToTreeRootWhenNoBodyExists() {
+        let entry = Self.particleFieldEntry(kind: .background)
+        let model = Self.fixtureModelWithoutBody()
+        let insertion = AddEffectIntent.defaultInsertion(for: entry, in: model)
+        #expect(insertion?.parentId == model.tree.id)
+        #expect(insertion?.index == model.tree.children.count)
+    }
+
+    @Test func inlinePlacementWithAllowedParentsDefaultsToFirstChildOfMatch() {
+        let entry = Self.particleFieldEntry(kind: .inline, allowedParents: ["FOOTER"])
+        let model = Self.fixtureModelWithBody()
+        let insertion = AddEffectIntent.defaultInsertion(for: entry, in: model)
+        let footerID = model.tree.children.first?.children.last?.id
+        #expect(insertion?.parentId == footerID)
+        #expect(insertion?.index == 0)
+    }
+
+    @Test func inlinePlacementWithUnmatchedAllowedParentsFallsBackToFragmentRoot() {
+        let entry = Self.particleFieldEntry(kind: .inline, allowedParents: ["MAIN"]) // no MAIN in the fixture
+        let model = Self.fixtureModelWithBody()
+        let insertion = AddEffectIntent.defaultInsertion(for: entry, in: model)
+        #expect(insertion?.parentId == model.tree.id)
+        #expect(insertion?.index == model.tree.children.count)
+    }
+
+    @Test func inlinePlacementWithNoAllowedParentsDefaultsToFragmentRoot() {
+        let entry = Self.particleFieldEntry(kind: .inline, allowedParents: nil)
+        let model = Self.fixtureModelWithBody()
+        let insertion = AddEffectIntent.defaultInsertion(for: entry, in: model)
+        #expect(insertion?.parentId == model.tree.id)
+        #expect(insertion?.index == model.tree.children.count)
+    }
+
+    // MARK: - EffectDialogs (pure)
+
+    @Test func dialogsCoverSuccessAndFailure() {
+        #expect(EffectDialogs.applied(effectTitle: "Particle Field", siteName: "Acme").contains("Acme"))
+        #expect(EffectDialogs.applied(effectTitle: "Particle Field", siteName: "Acme").contains("Particle Field"))
+        #expect(EffectDialogs.failed(effectTitle: "Particle Field", siteName: "Acme", reason: "nope").contains("nope"))
+        #expect(EffectDialogs.siteNotOpen(siteName: "Acme").contains("Acme"))
+        #expect(EffectDialogs.notPlaceable(effectTitle: "Fade-in text").contains("Fade-in text"))
+        #expect(EffectDialogs.unknownEffect(title: "Nope").contains("Nope"))
+    }
+
+    // MARK: - run() via performForTesting()
+
+    @Test func appliesTheEffectAndReportsSuccess() async throws {
+        let intent = AddEffectIntent()
+        intent.site = SiteEntity(id: "s1", name: "Acme", creationDate: nil, modificationDate: nil)
+        intent.effect = .particleField
+        let fakes = AddEffectIntentFakes(
+            catalog: EffectCatalog(entries: [Self.particleFieldEntry()]),
+            pageModelClient: Self.fakePageModelClient(returning: Self.fixtureModelWithBody()),
+            editRouter: StubRouter(status: .applied))
+        let dialog = try await AddEffectIntentOverride.$scoped.withValue(fakes) {
+            try await intent.performForTesting()
+        }
+        #expect(dialog == "Added Particle Field to Acme.")
+    }
+
+    @Test func reportsFailureWhenTheRouterRefuses() async throws {
+        let intent = AddEffectIntent()
+        intent.site = SiteEntity(id: "s1", name: "Acme", creationDate: nil, modificationDate: nil)
+        intent.effect = .particleField
+        let fakes = AddEffectIntentFakes(
+            catalog: EffectCatalog(entries: [Self.particleFieldEntry()]),
+            pageModelClient: Self.fakePageModelClient(returning: Self.fixtureModelWithBody()),
+            editRouter: StubRouter(status: .failed, message: "stale version"))
+        let dialog = try await AddEffectIntentOverride.$scoped.withValue(fakes) {
+            try await intent.performForTesting()
+        }
+        #expect(dialog.contains("stale version"))
+        #expect(dialog.contains("Acme"))
+    }
+
+    @Test func repromptsWithoutConfirmingWhenTheSiteIsntOpen() async throws {
+        let intent = AddEffectIntent()
+        intent.site = SiteEntity(id: "s1", name: "Acme", creationDate: nil, modificationDate: nil)
+        intent.effect = .particleField
+        let fakes = AddEffectIntentFakes(
+            catalog: EffectCatalog(entries: [Self.particleFieldEntry()]),
+            pageModelClient: nil,
+            editRouter: nil)
+        let dialog = try await AddEffectIntentOverride.$scoped.withValue(fakes) {
+            try await intent.performForTesting()
+        }
+        #expect(dialog == "Open Acme in Anglesite first, then try adding this effect again.")
+    }
+
+    @Test func repromptsWhenTheMatchedEntryHasNoPlacement() async throws {
+        let intent = AddEffectIntent()
+        intent.site = SiteEntity(id: "s1", name: "Acme", creationDate: nil, modificationDate: nil)
+        intent.effect = .particleField
+        let legacyEntry = EffectCatalogEntry(
+            component: "ParticleField", title: "Particle Field", ownerDescription: "d",
+            category: .canvasBackground, keyProps: [:], snippet: "s", placement: nil)
+        let fakes = AddEffectIntentFakes(
+            catalog: EffectCatalog(entries: [legacyEntry]),
+            pageModelClient: Self.fakePageModelClient(returning: Self.fixtureModelWithBody()),
+            editRouter: StubRouter(status: .applied))
+        let dialog = try await AddEffectIntentOverride.$scoped.withValue(fakes) {
+            try await intent.performForTesting()
+        }
+        #expect(dialog.contains("Particle Field"))
+        #expect(dialog.contains("Effects gallery"))
+    }
+
+    @Test func repromptsWhenTheEffectIsntInTheCatalog() async throws {
+        let intent = AddEffectIntent()
+        intent.site = SiteEntity(id: "s1", name: "Acme", creationDate: nil, modificationDate: nil)
+        intent.effect = .dotGridPulse
+        let fakes = AddEffectIntentFakes(
+            catalog: EffectCatalog(entries: [Self.particleFieldEntry()]), // no "Dot Grid Pulse" entry
+            pageModelClient: Self.fakePageModelClient(returning: Self.fixtureModelWithBody()),
+            editRouter: StubRouter(status: .applied))
+        let dialog = try await AddEffectIntentOverride.$scoped.withValue(fakes) {
+            try await intent.performForTesting()
+        }
+        #expect(dialog.contains("Dot Grid Pulse"))
+    }
+
+    @Test func reportsAFriendlyMessageWhenTheModelFailsToLoad() async throws {
+        let intent = AddEffectIntent()
+        intent.site = SiteEntity(id: "s1", name: "Acme", creationDate: nil, modificationDate: nil)
+        intent.effect = .particleField
+        let notConnectedClient = PageModelClient(toolCaller: { _, _ in
+            throw PageModelClient.ModelError.notConnected
+        })
+        let fakes = AddEffectIntentFakes(
+            catalog: EffectCatalog(entries: [Self.particleFieldEntry()]),
+            pageModelClient: notConnectedClient,
+            editRouter: StubRouter(status: .applied))
+        let dialog = try await AddEffectIntentOverride.$scoped.withValue(fakes) {
+            try await intent.performForTesting()
+        }
+        #expect(dialog.contains("Acme"))
+        #expect(dialog.contains("not running"))
+    }
+}


### PR DESCRIPTION
Part of #768 — not a closing PR. The follow-up PR that lands the remaining effect content (Tasks 14-17) will close #768.

## Summary

- Adds `AddEffectIntent` (Siri/Shortcuts front door for the Effects gallery, Task 13 of the effects-gallery plan), including `@Dependency`-wired `EffectCatalog` resolution matching `ApplyThemeIntent`'s established pattern.
- Fixes four Critical bugs found in a final whole-branch review of the click-to-place plumbing merged in #1553 — the feature could not actually place an effect in production before this PR, despite every task passing its own scoped review, because the integration between tasks had bugs no single task's tests could see:
  - **Wrong path format sent to the sidecar.** A URL route (e.g. `"/"`) was passed to `PageModelClient`/`insertBlock` where the sidecar requires a project-relative `.astro` path — every real placement failed with `invalid-input`. New `PageSourcePath` resolves route → file path via the site's content graph, used in both `SiteWindowModel` and `AddEffectIntent`.
  - **Dismissing the gallery left the overlay armed.** Closing the gallery sheet via Done (not just Esc) didn't cancel an in-progress pick, so the owner's next unrelated click on the preview would silently apply an insert.
  - **Existing sites got manifest entries with no matching component files.** `blocks.manifest.json` was backfilled onto pre-feature sites, but the actual `src/components/effects/*.astro` files never were — applying an effect would write a broken import. `BlockManifestSync` now also copies missing component files (never overwriting an owner's).
  - **The gallery is a modal sheet that blocked the very click it asked for.** The HUD is now extracted (`EffectPlacementHUD`) and rendered over the actual clickable window content once the sheet dismisses on "Apply to Page…".
- Also: `PlacementMatcher` now checks `id`/`data-anglesite-id`/`data-testid` before falling back to positional matching; adds the spec's before/after placement toggle; `BlockManifestSync` skips writing when nothing changed (avoids spurious dirty files in the owner's repo); placement-pick mode cancels itself on a preview reload; the swallowed `BlockManifestSync` sync error is now logged; and a couple of user-visible strings still said "plugin" instead of "sidecar".

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite passed (verified independently during code review, including a scoped filter across `PageSourcePathTests`, `SiteWindowModelEffectPlacementPathTests`, `EffectPlacementControllerTests`, `PlacementMatcherTests`, `BlockManifestSyncTests`, `EffectIntentsTests`, `PageModelClientRegistryTests`).
- [x] `swift build --package-path .` — clean.
- [ ] Manual smoke: the SwiftUI wiring for dismiss-cancels-pick, HUD-over-clickable-preview, and reload-cancels-pick has no unit-test seam and wants one manual pass in a running app (apply → gallery closes, HUD over clickable preview; Done mid-pick cancels; reload mid-pick cancels) before considering it fully verified.

This PR contains no placeable effect *content* yet (the 12 hand-authored visual effects, plan Tasks 14-17) — that's a separate follow-up PR, since three follow-up issues (#1557, #1558, #1559) and one merged PR (#1562, closing #1560) were independently filed and dispatched for that content while this work was in flight; the follow-up PR reconciles with that.