### PR TITLE
feat(#1568): Worker read gate — IndieAuth-gated permalinks + private h-feed

### DIFF
--- a/Resources/Template/worker/gated-content.test.ts
+++ b/Resources/Template/worker/gated-content.test.ts
@@ -1,0 +1,276 @@
+import { env } from "cloudflare:workers";
+import { createMicropubStore, type PostRecord } from "@dwk/micropub";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  forbidden,
+  handleGatedFallback,
+  handlePrivateFeed,
+  looksLikePostPermalink,
+  renderGatedPermalink,
+  renderPrivateFeed,
+  requireReaderSession,
+  type GatedContentEnv,
+} from "./gated-content.ts";
+import { READER_SESSION_COOKIE, createReaderSessionToken } from "./reader-session.ts";
+import { normalizeReaderIdentity } from "./reader-identity.ts";
+
+const testEnv = env as unknown as GatedContentEnv;
+
+beforeEach(async () => {
+  await createMicropubStore({ MICROPUB_DB: testEnv.MICROPUB_DB! }).init();
+});
+
+describe("looksLikePostPermalink", () => {
+  it("matches a bare top-level slug", () => {
+    expect(looksLikePostPermalink("/hello-world")).toBe(true);
+  });
+
+  it("matches a known-collection + slug", () => {
+    expect(looksLikePostPermalink("/notes/hello-world")).toBe(true);
+    expect(looksLikePostPermalink("/photos/abc123")).toBe(true);
+  });
+
+  it("rejects an unknown collection", () => {
+    expect(looksLikePostPermalink("/blog/hello-world")).toBe(false);
+  });
+
+  it("rejects paths deeper than two segments", () => {
+    expect(looksLikePostPermalink("/notes/2026/hello-world")).toBe(false);
+  });
+
+  it("rejects a slug with disallowed characters (e.g. a file extension)", () => {
+    expect(looksLikePostPermalink("/styles.css")).toBe(false);
+    expect(looksLikePostPermalink("/notes/hello_world")).toBe(false);
+  });
+
+  it("rejects the bare root", () => {
+    expect(looksLikePostPermalink("/")).toBe(false);
+  });
+});
+
+async function sessionCookieFor(me: string): Promise<string> {
+  const token = await createReaderSessionToken(normalizeReaderIdentity(me), testEnv.TOKEN_SIGNING_KEY);
+  return `${READER_SESSION_COOKIE}=${token}`;
+}
+
+describe("requireReaderSession", () => {
+  it("returns the normalized identity for a valid session cookie", async () => {
+    const cookie = await sessionCookieFor("https://alice.example/");
+    const request = new Request("https://site.example/notes/hello", { headers: { Cookie: cookie } });
+    expect(await requireReaderSession(request, testEnv)).toBe("alice.example");
+  });
+
+  it("returns null when there is no cookie", async () => {
+    const request = new Request("https://site.example/notes/hello");
+    expect(await requireReaderSession(request, testEnv)).toBeNull();
+  });
+
+  it("returns null for a tampered cookie", async () => {
+    const request = new Request("https://site.example/notes/hello", {
+      headers: { Cookie: `${READER_SESSION_COOKIE}=garbage` },
+    });
+    expect(await requireReaderSession(request, testEnv)).toBeNull();
+  });
+});
+
+describe("forbidden", () => {
+  it("returns a 403 with a sign-in link echoing the requester's own path", async () => {
+    const request = new Request("https://site.example/notes/secret?x=1");
+    const response = forbidden(request);
+    expect(response.status).toBe(403);
+    const body = await response.text();
+    expect(body).toContain(`/contacts/signin?redirect=${encodeURIComponent("/notes/secret?x=1")}`);
+  });
+
+  it("returns no body for a HEAD request", async () => {
+    const request = new Request("https://site.example/notes/secret", { method: "HEAD" });
+    const response = forbidden(request);
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe("");
+  });
+});
+
+interface MakeRecordOptions {
+  url?: string;
+  deleted?: boolean;
+  name?: unknown[];
+  content?: unknown[];
+  published?: unknown[];
+  category?: unknown[];
+  photo?: unknown[];
+  visibility?: unknown[];
+}
+
+function makeRecord(overrides: MakeRecordOptions = {}): PostRecord {
+  const { url, deleted, ...properties } = overrides;
+  return {
+    url: url ?? "https://site.example/notes/hello",
+    type: "h-entry",
+    properties: {
+      name: ["Hello"],
+      content: [{ html: "<p>Hi there</p>" }],
+      published: ["2026-08-18T12:00:00Z"],
+      category: ["indieweb"],
+      visibility: ["contacts"],
+      ...properties,
+    },
+    deleted: deleted ?? false,
+    createdAt: 1_000,
+    updatedAt: 1_000,
+  };
+}
+
+describe("renderGatedPermalink", () => {
+  it("renders h-entry markup with name, content, permalink, and categories", async () => {
+    const response = renderGatedPermalink(makeRecord(), "GET");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    const body = await response.text();
+    expect(body).toContain('<article class="h-entry">');
+    expect(body).toContain('<h1 class="p-name">Hello</h1>');
+    expect(body).toContain('<div class="e-content"><p>Hi there</p></div>');
+    expect(body).toContain('<a class="u-url" href="https://site.example/notes/hello">');
+    expect(body).toContain('class="dt-published" datetime="2026-08-18T12:00:00Z"');
+    expect(body).toContain('<a class="p-category">indieweb</a>');
+  });
+
+  it("renders photos as u-photo images", async () => {
+    const response = renderGatedPermalink(
+      makeRecord({ photo: [{ value: "https://site.example/media/1.jpg", alt: "a cat" }] }),
+      "GET",
+    );
+    const body = await response.text();
+    expect(body).toContain('<img class="u-photo" src="https://site.example/media/1.jpg" alt="a cat">');
+  });
+
+  it("omits the body for a HEAD request", async () => {
+    const response = renderGatedPermalink(makeRecord(), "HEAD");
+    expect(await response.text()).toBe("");
+  });
+});
+
+describe("renderPrivateFeed", () => {
+  it("renders an h-feed wrapping each post", async () => {
+    const response = renderPrivateFeed([makeRecord(), makeRecord({ url: "https://site.example/notes/second", name: ["Second"] })], "GET");
+    const body = await response.text();
+    expect(body).toContain('<div class="h-feed">');
+    expect(body).toContain('<h1 class="p-name">Private feed</h1>');
+    expect(body).toContain('<h2 class="p-name">Hello</h2>');
+    expect(body).toContain('<h2 class="p-name">Second</h2>');
+  });
+
+  it("renders an empty-state message with no posts", async () => {
+    const response = renderPrivateFeed([], "GET");
+    expect(await response.text()).toContain("No restricted posts yet.");
+  });
+});
+
+describe("handleGatedFallback", () => {
+  it("returns null for a non-GET/HEAD method", async () => {
+    const request = new Request("https://site.example/notes/hello", { method: "POST" });
+    expect(await handleGatedFallback(request, testEnv, "/notes/hello")).toBeNull();
+  });
+
+  it("returns null for a path that doesn't look like a post permalink", async () => {
+    const request = new Request("https://site.example/favicon.ico");
+    expect(await handleGatedFallback(request, testEnv, "/favicon.ico")).toBeNull();
+  });
+
+  it("returns null when MICROPUB_DB isn't bound", async () => {
+    const request = new Request("https://site.example/notes/hello");
+    const { MICROPUB_DB: _unused, ...envWithoutDB } = testEnv;
+    expect(await handleGatedFallback(request, envWithoutDB, "/notes/hello")).toBeNull();
+  });
+
+  it("returns 403 with no session, without ever touching the store", async () => {
+    const request = new Request("https://site.example/notes/does-not-exist");
+    const response = await handleGatedFallback(request, testEnv, "/notes/does-not-exist");
+    expect(response?.status).toBe(403);
+  });
+
+  it("returns null when the session is valid but no such post exists", async () => {
+    const cookie = await sessionCookieFor("https://alice.example/");
+    const request = new Request("https://site.example/notes/does-not-exist", { headers: { Cookie: cookie } });
+    expect(await handleGatedFallback(request, testEnv, "/notes/does-not-exist")).toBeNull();
+  });
+
+  it("returns null when the session is valid but the post is public (not contacts)", async () => {
+    const store = createMicropubStore({ MICROPUB_DB: testEnv.MICROPUB_DB! });
+    await store.insertPost({
+      url: "https://site.example/notes/public-post",
+      type: "h-entry",
+      properties: { name: ["Public"], visibility: ["public"] },
+      now: 1_000,
+    });
+    const cookie = await sessionCookieFor("https://alice.example/");
+    const request = new Request("https://site.example/notes/public-post", { headers: { Cookie: cookie } });
+    expect(await handleGatedFallback(request, testEnv, "/notes/public-post")).toBeNull();
+  });
+
+  it("returns null when the post is soft-deleted", async () => {
+    const store = createMicropubStore({ MICROPUB_DB: testEnv.MICROPUB_DB! });
+    await store.insertPost({
+      url: "https://site.example/notes/deleted-post",
+      type: "h-entry",
+      properties: { name: ["Gone"], visibility: ["contacts"] },
+      now: 1_000,
+    });
+    await store.setDeleted("https://site.example/notes/deleted-post", true, 2_000);
+    const cookie = await sessionCookieFor("https://alice.example/");
+    const request = new Request("https://site.example/notes/deleted-post", { headers: { Cookie: cookie } });
+    expect(await handleGatedFallback(request, testEnv, "/notes/deleted-post")).toBeNull();
+  });
+
+  it("renders the post for an authorized, allowlisted reader", async () => {
+    const store = createMicropubStore({ MICROPUB_DB: testEnv.MICROPUB_DB! });
+    await store.insertPost({
+      url: "https://site.example/notes/restricted-post",
+      type: "h-entry",
+      properties: { name: ["Restricted"], visibility: ["contacts"] },
+      now: 1_000,
+    });
+    const cookie = await sessionCookieFor("https://alice.example/");
+    const request = new Request("https://site.example/notes/restricted-post", { headers: { Cookie: cookie } });
+    const response = await handleGatedFallback(request, testEnv, "/notes/restricted-post");
+    expect(response?.status).toBe(200);
+    expect(await response!.text()).toContain('<h1 class="p-name">Restricted</h1>');
+  });
+});
+
+describe("handlePrivateFeed", () => {
+  it("returns 503 when MICROPUB_DB isn't bound", async () => {
+    const request = new Request("https://site.example/contacts/feed");
+    const { MICROPUB_DB: _unused, ...envWithoutDB } = testEnv;
+    const response = await handlePrivateFeed(request, envWithoutDB);
+    expect(response.status).toBe(503);
+  });
+
+  it("returns 403 with no session", async () => {
+    const request = new Request("https://site.example/contacts/feed");
+    const response = await handlePrivateFeed(request, testEnv);
+    expect(response.status).toBe(403);
+  });
+
+  it("lists only contacts-visibility posts for an authorized reader", async () => {
+    const store = createMicropubStore({ MICROPUB_DB: testEnv.MICROPUB_DB! });
+    await store.insertPost({
+      url: "https://site.example/notes/feed-public",
+      type: "h-entry",
+      properties: { name: ["Feed Public"], visibility: ["public"] },
+      now: 1_000,
+    });
+    await store.insertPost({
+      url: "https://site.example/notes/feed-restricted",
+      type: "h-entry",
+      properties: { name: ["Feed Restricted"], visibility: ["contacts"] },
+      now: 2_000,
+    });
+    const cookie = await sessionCookieFor("https://alice.example/");
+    const request = new Request("https://site.example/contacts/feed", { headers: { Cookie: cookie } });
+    const response = await handlePrivateFeed(request, testEnv);
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("Feed Restricted");
+    expect(body).not.toContain("Feed Public");
+  });
+});

--- a/Resources/Template/worker/gated-content.ts
+++ b/Resources/Template/worker/gated-content.ts
@@ -1,0 +1,197 @@
+/**
+ * The read gate itself (#1568): which asset-404'd paths might be a restricted post, the
+ * session→allowlist check, and the hand-rolled microformats2 rendering for a gated permalink and
+ * the private h-feed.
+ *
+ * @see docs/superpowers/specs/2026-08-18-worker-read-gate-design.md §6, §7, §8
+ */
+
+import { createMicropubStore, type PostRecord } from "@dwk/micropub";
+import { escapeHTML, extractMf2ContentString, extractMf2Photos } from "./render-utils.ts";
+import { readReaderSessionCookie, verifyReaderSessionToken } from "./reader-session.ts";
+
+/** Bindings this module needs. */
+export interface GatedContentEnv {
+  readonly TOKEN_SIGNING_KEY: string;
+  readonly MICROPUB_DB?: D1Database;
+}
+
+const SLUG = /^[a-z0-9-]{1,80}$/;
+const KNOWN_COLLECTIONS = new Set([
+  "notes", "articles", "photos", "albums",
+  "bookmarks", "likes", "replies", "events", "reviews",
+]);
+
+/**
+ * Whether `pathname` is shaped like a post permalink `generatePostUrl` (`worker.ts`) could have
+ * produced — either `/<slug>` or `/<known-collection>/<slug>`. Scopes the read gate to exactly the
+ * URL space real posts occupy, so an unrelated 404 (an asset, a typo, a deep path) is untouched.
+ */
+export function looksLikePostPermalink(pathname: string): boolean {
+  const segments = pathname.split("/").filter((segment) => segment.length > 0);
+  if (segments.length === 1) return SLUG.test(segments[0] as string);
+  if (segments.length === 2) {
+    return KNOWN_COLLECTIONS.has(segments[0] as string) && SLUG.test(segments[1] as string);
+  }
+  return false;
+}
+
+/** The verified, allowlisted reader's normalized identity, or `null` if there is no valid session. */
+export async function requireReaderSession(
+  request: Request,
+  env: Pick<GatedContentEnv, "TOKEN_SIGNING_KEY">,
+): Promise<string | null> {
+  const cookie = readReaderSessionCookie(request);
+  if (cookie === null) return null;
+  const session = await verifyReaderSessionToken(cookie, env.TOKEN_SIGNING_KEY);
+  return session === null ? null : session.me;
+}
+
+const GATED_HEADERS = {
+  "content-type": "text/html; charset=utf-8",
+  "cache-control": "private, no-store",
+  "content-security-policy": "default-src 'none'; img-src https: data:; style-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'",
+  "referrer-policy": "no-referrer",
+  "x-content-type-options": "nosniff",
+} as const;
+
+/**
+ * A static 403 for any GET/HEAD on a plausible post-permalink path without a valid, allowlisted
+ * reader session — identical regardless of whether a real restricted post lives at that path, so
+ * an anonymous/unauthorized visitor can't use response differences to enumerate what exists.
+ *
+ * The one exception isn't a leak: the sign-in link echoes back the *requester's own* path (via
+ * `?redirect=`) so a real person has a way to actually sign in and land back where they started —
+ * that's the visitor's own input reflected to them, not new information about the site.
+ */
+export function forbidden(request: Request): Response {
+  const url = new URL(request.url);
+  const redirect = encodeURIComponent(url.pathname + url.search);
+  const body = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
+<title>Sign in required</title></head><body><main>
+<h1>Sign in required</h1>
+<p>This content is only available to the site owner's contacts.</p>
+<p><a href="/contacts/signin?redirect=${redirect}">Sign in with your site</a></p>
+</main></body></html>`;
+  return new Response(request.method === "HEAD" ? null : body, { status: 403, headers: GATED_HEADERS });
+}
+
+function mf2String(values: readonly unknown[] | undefined): string | undefined {
+  const first = values?.[0];
+  return typeof first === "string" ? first : undefined;
+}
+
+function mf2Strings(values: readonly unknown[] | undefined): string[] {
+  return (values ?? []).filter((value): value is string => typeof value === "string");
+}
+
+/**
+ * Renders one restricted post's core h-entry markup — the same class names the public Astro
+ * rendering uses, so a contact's feed reader parses it identically. Deliberately minimal
+ * compared to `Hentry.astro`: no JSON-LD, cited-embed cards, licensing, syndication links, or
+ * webmention interactions (§8 of the design doc) — none of that is renderable outside the Astro
+ * build, and none of it is required for a private, non-indexed read.
+ */
+export function renderGatedPermalink(record: PostRecord, method: string): Response {
+  const props = record.properties;
+  const name = mf2String(props.name);
+  const content = extractMf2ContentString(props.content?.[0]);
+  const photos = extractMf2Photos(props.photo);
+  const published = mf2String(props.published);
+  const categories = mf2Strings(props.category);
+
+  const body = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
+<title>${name ? escapeHTML(name) : "Post"}</title></head><body><main>
+<article class="h-entry">
+${name ? `<h1 class="p-name">${escapeHTML(name)}</h1>` : ""}
+${photos.map((photo) => `<img class="u-photo" src="${escapeHTML(photo.url)}" alt="${escapeHTML(photo.alt ?? "")}">`).join("\n")}
+<div class="e-content">${content}</div>
+<a class="u-url" href="${escapeHTML(record.url)}">${published ? `<time class="dt-published" datetime="${escapeHTML(published)}">${escapeHTML(published)}</time>` : "Permalink"}</a>
+${categories.length > 0 ? `<ul class="tags">${categories.map((category) => `<li><a class="p-category">${escapeHTML(category)}</a></li>`).join("")}</ul>` : ""}
+</article>
+</main></body></html>`;
+  return new Response(method === "HEAD" ? null : body, { status: 200, headers: GATED_HEADERS });
+}
+
+/** Renders the private h-feed of live restricted posts, newest first. */
+export function renderPrivateFeed(records: readonly PostRecord[], method: string): Response {
+  const items = records
+    .map((record) => {
+      const props = record.properties;
+      const name = mf2String(props.name);
+      const content = extractMf2ContentString(props.content?.[0]);
+      const published = mf2String(props.published);
+      return `<li class="h-entry">
+${name ? `<h2 class="p-name">${escapeHTML(name)}</h2>` : ""}
+<div class="e-content">${content}</div>
+<a class="u-url" href="${escapeHTML(record.url)}">${published ? `<time class="dt-published" datetime="${escapeHTML(published)}">${escapeHTML(published)}</time>` : "Permalink"}</a>
+</li>`;
+    })
+    .join("\n");
+
+  const body = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
+<title>Private feed</title></head><body><main>
+<div class="h-feed">
+<h1 class="p-name">Private feed</h1>
+<ul>
+${items || "<li>No restricted posts yet.</li>"}
+</ul>
+</div>
+</main></body></html>`;
+  return new Response(method === "HEAD" ? null : body, { status: 200, headers: GATED_HEADERS });
+}
+
+/**
+ * The Worker's asset-404 fallback hook: given a path that fell through static-asset serving,
+ * decide whether it's a gated restricted-post permalink. Returns `null` to leave the original
+ * 404 untouched (path doesn't look like a post URL, the feature isn't provisioned, the requester
+ * is authorized but no such post exists) — the caller keeps the plain 404 in every `null` case.
+ */
+export async function handleGatedFallback(
+  request: Request,
+  env: GatedContentEnv,
+  pathname: string,
+): Promise<Response | null> {
+  if (request.method !== "GET" && request.method !== "HEAD") return null;
+  if (!looksLikePostPermalink(pathname)) return null;
+  if (!env.MICROPUB_DB) return null;
+
+  const me = await requireReaderSession(request, env);
+  if (me === null) return forbidden(request);
+
+  const store = createMicropubStore({ MICROPUB_DB: env.MICROPUB_DB });
+  const origin = new URL(request.url).origin;
+  const record = await store.getPost(`${origin}${pathname}`);
+  if (!record || record.deleted) return null;
+  if (record.properties.visibility?.[0] !== "contacts") return null;
+
+  return renderGatedPermalink(record, request.method);
+}
+
+/** `GET /contacts/feed`: the private h-feed, gated the same way as a permalink. */
+export async function handlePrivateFeed(request: Request, env: GatedContentEnv): Promise<Response> {
+  if (!env.MICROPUB_DB) {
+    return new Response("Private feed is not configured", { status: 503 });
+  }
+  const me = await requireReaderSession(request, env);
+  if (me === null) return forbidden(request);
+
+  const store = createMicropubStore({ MICROPUB_DB: env.MICROPUB_DB });
+  const records = await store.listPosts(
+    { limit: 50, offset: 0 },
+    {
+      filters: {
+        order: "desc",
+        postTypes: [],
+        postStatuses: [],
+        visibilities: ["contacts"],
+        propertyExists: [],
+        propertyValues: [],
+      },
+    },
+  );
+  return renderPrivateFeed(records, request.method);
+}

--- a/Resources/Template/worker/reader-auth.test.ts
+++ b/Resources/Template/worker/reader-auth.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleReaderCallback, handleReaderSignin } from "./reader-auth.ts";
+import { createSigninState } from "./reader-session.ts";
+
+const SIGNING_KEY = "test-signing-key";
+
+function kvWith(value: string | null) {
+  return { get: async () => value };
+}
+
+describe("handleReaderSignin", () => {
+  it("renders the sign-in form when no me is given", async () => {
+    const request = new Request("https://site.example/contacts/signin?redirect=/notes/hello");
+    const response = await handleReaderSignin(request, { TOKEN_SIGNING_KEY: SIGNING_KEY });
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain('name="me"');
+    expect(body).toContain('value="/notes/hello"');
+  });
+
+  it("falls back to / for an unsafe redirect target", async () => {
+    const request = new Request("https://site.example/contacts/signin?redirect=https://evil.example/");
+    const response = await handleReaderSignin(request, { TOKEN_SIGNING_KEY: SIGNING_KEY });
+    const body = await response.text();
+    expect(body).toContain('value="/"');
+  });
+
+  it("re-renders the form with an error for an invalid me", async () => {
+    const request = new Request("https://site.example/contacts/signin?me=not-a-url");
+    const response = await handleReaderSignin(request, { TOKEN_SIGNING_KEY: SIGNING_KEY });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("doesn&#39;t look like a valid website address");
+  });
+
+  it("re-renders the form with an error when discovery finds nothing", async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => new Response("<html></html>", { headers: { "content-type": "text/html" } })) as unknown as typeof fetch;
+    try {
+      const request = new Request("https://site.example/contacts/signin?me=https://alice.example/");
+      const response = await handleReaderSignin(request, { TOKEN_SIGNING_KEY: SIGNING_KEY });
+      expect(await response.text()).toContain("Couldn&#39;t find a sign-in endpoint");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("discovers the endpoint and redirects with PKCE + state params", async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () =>
+      new Response('<html><head><link rel="authorization_endpoint" href="https://alice.example/auth"></head></html>', {
+        headers: { "content-type": "text/html" },
+      }),
+    ) as unknown as typeof fetch;
+    try {
+      const request = new Request("https://site.example/contacts/signin?me=https://alice.example/&redirect=/notes/hello");
+      const response = await handleReaderSignin(request, { TOKEN_SIGNING_KEY: SIGNING_KEY });
+      expect(response.status).toBe(302);
+      const location = new URL(response.headers.get("location")!);
+      expect(location.origin + location.pathname).toBe("https://alice.example/auth");
+      expect(location.searchParams.get("response_type")).toBe("code");
+      expect(location.searchParams.get("client_id")).toBe("https://site.example/");
+      expect(location.searchParams.get("redirect_uri")).toBe("https://site.example/contacts/callback");
+      expect(location.searchParams.get("code_challenge_method")).toBe("S256");
+      expect(location.searchParams.get("code_challenge")).toBeTruthy();
+      expect(location.searchParams.get("state")).toBeTruthy();
+      expect(location.searchParams.has("scope")).toBe(false);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});
+
+describe("handleReaderCallback", () => {
+  it("returns an error page when the visited site reports an error", async () => {
+    const request = new Request("https://site.example/contacts/callback?error=access_denied");
+    const response = await handleReaderCallback(request, { TOKEN_SIGNING_KEY: SIGNING_KEY });
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("declined the request");
+  });
+
+  it("returns an error page when code or state is missing", async () => {
+    const request = new Request("https://site.example/contacts/callback?state=abc");
+    const response = await handleReaderCallback(request, { TOKEN_SIGNING_KEY: SIGNING_KEY });
+    expect(response.status).toBe(400);
+  });
+
+  it("returns an error page for an invalid/expired state token", async () => {
+    const request = new Request("https://site.example/contacts/callback?code=abc&state=garbage");
+    const response = await handleReaderCallback(request, { TOKEN_SIGNING_KEY: SIGNING_KEY });
+    expect(await response.text()).toContain("expired");
+  });
+
+  it("returns an error page when the identity endpoint rejects the code", async () => {
+    const state = await createSigninState(
+      { me: "https://alice.example/", redirectTo: "/notes/hello", authorizationEndpoint: "https://alice.example/auth", verifier: "v" },
+      SIGNING_KEY,
+    );
+    const original = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => new Response("bad code", { status: 400 })) as unknown as typeof fetch;
+    try {
+      const request = new Request(`https://site.example/contacts/callback?code=abc&state=${encodeURIComponent(state)}`);
+      const response = await handleReaderCallback(request, { TOKEN_SIGNING_KEY: SIGNING_KEY });
+      expect(await response.text()).toContain("rejected the sign-in code");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("returns an error page when the returned me doesn't match what was claimed", async () => {
+    const state = await createSigninState(
+      { me: "https://alice.example/", redirectTo: "/notes/hello", authorizationEndpoint: "https://alice.example/auth", verifier: "v" },
+      SIGNING_KEY,
+    );
+    const original = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ me: "https://mallory.example/" }), {
+        headers: { "content-type": "application/json" },
+      }),
+    ) as unknown as typeof fetch;
+    try {
+      const request = new Request(`https://site.example/contacts/callback?code=abc&state=${encodeURIComponent(state)}`);
+      const response = await handleReaderCallback(request, { TOKEN_SIGNING_KEY: SIGNING_KEY });
+      expect(await response.text()).toContain("didn&#39;t match");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("returns an error page when the verified identity isn't on the allowlist", async () => {
+    const state = await createSigninState(
+      { me: "https://alice.example/", redirectTo: "/notes/hello", authorizationEndpoint: "https://alice.example/auth", verifier: "v" },
+      SIGNING_KEY,
+    );
+    const original = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ me: "https://alice.example/" }), {
+        headers: { "content-type": "application/json" },
+      }),
+    ) as unknown as typeof fetch;
+    try {
+      const request = new Request(`https://site.example/contacts/callback?code=abc&state=${encodeURIComponent(state)}`);
+      const response = await handleReaderCallback(request, { TOKEN_SIGNING_KEY: SIGNING_KEY, SOCIAL_KV: kvWith(null) });
+      expect(await response.text()).toContain("doesn&#39;t have you as a contact");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("sets a session cookie and redirects when the identity is verified and allowlisted", async () => {
+    const state = await createSigninState(
+      { me: "https://alice.example/", redirectTo: "/notes/hello", authorizationEndpoint: "https://alice.example/auth", verifier: "v" },
+      SIGNING_KEY,
+    );
+    const original = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ me: "https://alice.example/" }), {
+        headers: { "content-type": "application/json" },
+      }),
+    ) as unknown as typeof fetch;
+    try {
+      const request = new Request(`https://site.example/contacts/callback?code=abc&state=${encodeURIComponent(state)}`);
+      const response = await handleReaderCallback(request, {
+        TOKEN_SIGNING_KEY: SIGNING_KEY,
+        SOCIAL_KV: kvWith(JSON.stringify(["alice.example"])),
+      });
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/notes/hello");
+      const cookie = response.headers.get("set-cookie") ?? "";
+      expect(cookie).toContain("__Host-anglesite_reader=");
+      expect(cookie).toContain("HttpOnly");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});

--- a/Resources/Template/worker/reader-auth.ts
+++ b/Resources/Template/worker/reader-auth.ts
@@ -1,0 +1,194 @@
+/**
+ * `/contacts/signin` and `/contacts/callback` — the IndieAuth relying-party flow a visitor uses to
+ * prove "I am https://alice.example/" to this site (#1568).
+ *
+ * Always requests the scope-less "profile exchange" (no access token, no DPoP): the code is
+ * redeemed at the discovered `authorization_endpoint` itself, exactly the flow
+ * `@dwk/indieauth`'s own `handleProfileExchange` implements reciprocally for this site's owner.
+ *
+ * @see docs/superpowers/specs/2026-08-18-worker-read-gate-design.md §2, §9
+ */
+
+import { canonicalizeProfileUrl } from "@dwk/indieauth";
+import { readBodyCapped, safeFetch } from "@dwk/safe-fetch";
+import { escapeHTML } from "./render-utils.ts";
+import { isAllowedReader, normalizeReaderIdentity } from "./reader-identity.ts";
+import { discoverAuthorizationEndpoint } from "./reader-discovery.ts";
+import {
+  createPkcePair,
+  createReaderSessionToken,
+  createSigninState,
+  readerSessionSetCookie,
+  verifySigninState,
+} from "./reader-session.ts";
+
+/** Bindings this module needs. */
+export interface ReaderAuthEnv {
+  readonly TOKEN_SIGNING_KEY: string;
+  readonly SOCIAL_KV?: { get(key: string): Promise<string | null> };
+}
+
+const CALLBACK_PATH = "/contacts/callback";
+
+/** A site-relative path (starts with `/`, never `//` or a backslash) — an open-redirect guard. */
+function safeRedirectPath(candidate: string | null): string {
+  if (candidate && candidate.startsWith("/") && !candidate.startsWith("//") && !candidate.includes("\\")) {
+    return candidate;
+  }
+  return "/";
+}
+
+function pageResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+      "content-security-policy": "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
+      "referrer-policy": "no-referrer",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
+
+function signinForm(redirectTo: string, error?: string): Response {
+  const body = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
+<title>Sign in</title></head><body><main>
+<h1>Sign in with your site</h1>
+${error ? `<p role="alert">${escapeHTML(error)}</p>` : ""}
+<form method="get" action="/contacts/signin">
+<input type="hidden" name="redirect" value="${escapeHTML(redirectTo)}">
+<label>Your website <input name="me" type="url" placeholder="https://you.example/" required autofocus></label>
+<button type="submit">Sign in</button>
+</form></main></body></html>`;
+  return pageResponse(body);
+}
+
+function errorPage(message: string): Response {
+  const body = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
+<title>Sign-in problem</title></head><body><main>
+<h1>Couldn't sign you in</h1>
+<p>${escapeHTML(message)}</p>
+<p><a href="/contacts/signin">Try again</a></p>
+</main></body></html>`;
+  return pageResponse(body, 400);
+}
+
+/**
+ * `GET /contacts/signin`: with no `me`, renders the sign-in form. With `me`, discovers that
+ * site's `authorization_endpoint` and redirects the browser there to start the OAuth dance.
+ *
+ * Deliberately does *not* pre-check the allowlist before discovering/redirecting: doing so would
+ * make this endpoint an oracle for "is this URL one of the owner's private contacts" (the visitor
+ * hasn't proven the identity they typed yet, so a differential response here would leak contact-
+ * list membership to anyone willing to guess URLs). The allowlist check happens only after the
+ * callback verifies the visitor really does own the URL they claimed.
+ */
+export async function handleReaderSignin(request: Request, env: ReaderAuthEnv): Promise<Response> {
+  const url = new URL(request.url);
+  const redirectTo = safeRedirectPath(url.searchParams.get("redirect"));
+  const meParam = url.searchParams.get("me");
+  if (!meParam) return signinForm(redirectTo);
+
+  const me = canonicalizeProfileUrl(meParam);
+  if (me === null) return signinForm(redirectTo, "That doesn't look like a valid website address.");
+
+  const authorizationEndpoint = await discoverAuthorizationEndpoint(me);
+  if (authorizationEndpoint === null) {
+    return signinForm(redirectTo, "Couldn't find a sign-in endpoint for that site.");
+  }
+
+  const { verifier, challenge } = await createPkcePair();
+  const state = await createSigninState(
+    { me, redirectTo, authorizationEndpoint, verifier },
+    env.TOKEN_SIGNING_KEY,
+  );
+
+  const authUrl = new URL(authorizationEndpoint);
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("client_id", `${url.origin}/`);
+  authUrl.searchParams.set("redirect_uri", `${url.origin}${CALLBACK_PATH}`);
+  authUrl.searchParams.set("state", state);
+  authUrl.searchParams.set("code_challenge", challenge);
+  authUrl.searchParams.set("code_challenge_method", "S256");
+  return new Response(null, { status: 302, headers: { location: authUrl.toString() } });
+}
+
+interface ProfileExchangeResponse {
+  readonly me?: unknown;
+}
+
+function isProfileExchangeResponse(value: unknown): value is ProfileExchangeResponse {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * `GET /contacts/callback`: redeem the authorization code at the endpoint discovered for this
+ * sign-in, confirm the returned identity matches what was claimed, check it against the pushed
+ * allowlist, and — only then — start a reader session.
+ */
+export async function handleReaderCallback(request: Request, env: ReaderAuthEnv): Promise<Response> {
+  const url = new URL(request.url);
+  if (url.searchParams.get("error")) {
+    return errorPage("The site you signed in with declined the request.");
+  }
+
+  const code = url.searchParams.get("code");
+  const stateParam = url.searchParams.get("state");
+  if (!code || !stateParam) return errorPage("Missing sign-in parameters.");
+
+  const signin = await verifySigninState(stateParam, env.TOKEN_SIGNING_KEY);
+  if (signin === null) return errorPage("This sign-in link has expired. Please try again.");
+
+  let response: Response;
+  try {
+    const result = await safeFetch(
+      (input, init) => fetch(input, init),
+      signin.authorizationEndpoint,
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded", accept: "application/json" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          client_id: `${url.origin}/`,
+          redirect_uri: `${url.origin}${CALLBACK_PATH}`,
+          code_verifier: signin.verifier,
+        }).toString(),
+      },
+    );
+    response = result.response;
+  } catch {
+    return errorPage("Couldn't reach your site to confirm your identity.");
+  }
+  if (!response.ok) return errorPage("Your site rejected the sign-in code.");
+
+  const body = await readBodyCapped(response);
+  if (body === null) return errorPage("Your site's response was too large to read.");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return errorPage("Your site's response wasn't valid.");
+  }
+  if (!isProfileExchangeResponse(parsed) || typeof parsed.me !== "string") {
+    return errorPage("Your site's response didn't confirm an identity.");
+  }
+
+  const verifiedMe = canonicalizeProfileUrl(parsed.me);
+  if (verifiedMe === null || verifiedMe !== signin.me) {
+    return errorPage("The confirmed identity didn't match the site you signed in with.");
+  }
+
+  if (!(await isAllowedReader(env, verifiedMe))) {
+    return errorPage("You're signed in, but this site doesn't have you as a contact.");
+  }
+
+  const token = await createReaderSessionToken(normalizeReaderIdentity(verifiedMe), env.TOKEN_SIGNING_KEY);
+  return new Response(null, {
+    status: 302,
+    headers: { location: signin.redirectTo, "set-cookie": readerSessionSetCookie(token) },
+  });
+}

--- a/Resources/Template/worker/reader-discovery.test.ts
+++ b/Resources/Template/worker/reader-discovery.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { discoverAuthorizationEndpoint } from "./reader-discovery.ts";
+
+function htmlFetch(html: string, headers: Record<string, string> = {}): typeof fetch {
+  return (async () =>
+    new Response(html, {
+      status: 200,
+      headers: { "content-type": "text/html; charset=utf-8", ...headers },
+    })) as unknown as typeof fetch;
+}
+
+describe("discoverAuthorizationEndpoint", () => {
+  it("discovers via the Link header", async () => {
+    const doFetch = htmlFetch("<html></html>", {
+      link: '<https://alice.example/auth>; rel="authorization_endpoint"',
+    });
+    expect(await discoverAuthorizationEndpoint("https://alice.example/", { fetch: doFetch })).toBe(
+      "https://alice.example/auth",
+    );
+  });
+
+  it("discovers via a <link rel> element when there is no Link header", async () => {
+    const doFetch = htmlFetch(
+      '<html><head><link rel="authorization_endpoint" href="https://alice.example/auth"></head></html>',
+    );
+    expect(await discoverAuthorizationEndpoint("https://alice.example/", { fetch: doFetch })).toBe(
+      "https://alice.example/auth",
+    );
+  });
+
+  it("discovers via an <a rel> element", async () => {
+    const doFetch = htmlFetch(
+      '<html><body><a rel="authorization_endpoint" href="/auth">sign in</a></body></html>',
+    );
+    expect(await discoverAuthorizationEndpoint("https://alice.example/", { fetch: doFetch })).toBe(
+      "https://alice.example/auth",
+    );
+  });
+
+  it("resolves a relative href against the document URL", async () => {
+    const doFetch = htmlFetch(
+      '<html><head><link rel="authorization_endpoint" href="/indieauth/authorize"></head></html>',
+    );
+    expect(await discoverAuthorizationEndpoint("https://alice.example/page", { fetch: doFetch })).toBe(
+      "https://alice.example/indieauth/authorize",
+    );
+  });
+
+  it("resolves against a <base href> when present", async () => {
+    const doFetch = htmlFetch(
+      '<html><head><base href="https://cdn.alice.example/"><link rel="authorization_endpoint" href="auth"></head></html>',
+    );
+    expect(await discoverAuthorizationEndpoint("https://alice.example/", { fetch: doFetch })).toBe(
+      "https://cdn.alice.example/auth",
+    );
+  });
+
+  it("prefers the Link header over an HTML link even when both are present", async () => {
+    const doFetch = htmlFetch(
+      '<html><head><link rel="authorization_endpoint" href="https://alice.example/from-html"></head></html>',
+      { link: '<https://alice.example/from-header>; rel="authorization_endpoint"' },
+    );
+    expect(await discoverAuthorizationEndpoint("https://alice.example/", { fetch: doFetch })).toBe(
+      "https://alice.example/from-header",
+    );
+  });
+
+  it("returns null when no endpoint is declared anywhere", async () => {
+    const doFetch = htmlFetch("<html><head></head><body>hello</body></html>");
+    expect(await discoverAuthorizationEndpoint("https://alice.example/", { fetch: doFetch })).toBeNull();
+  });
+
+  it("returns null for a non-HTML response with no Link header", async () => {
+    const doFetch = (async () =>
+      new Response("{}", { status: 200, headers: { "content-type": "application/json" } })) as unknown as typeof fetch;
+    expect(await discoverAuthorizationEndpoint("https://alice.example/", { fetch: doFetch })).toBeNull();
+  });
+
+  it("returns null (never throws) when the fetch itself fails", async () => {
+    const doFetch = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    expect(await discoverAuthorizationEndpoint("https://alice.example/", { fetch: doFetch })).toBeNull();
+  });
+
+  it("returns null (never throws) when the target host is blocked on SSRF grounds", async () => {
+    expect(await discoverAuthorizationEndpoint("http://127.0.0.1/", {})).toBeNull();
+    expect(await discoverAuthorizationEndpoint("http://169.254.169.254/", {})).toBeNull();
+  });
+
+  it("ignores a rel value that only partially matches (e.g. a distinct token)", async () => {
+    const doFetch = htmlFetch(
+      '<html><head><link rel="not-authorization_endpoint" href="/nope"></head></html>',
+    );
+    expect(await discoverAuthorizationEndpoint("https://alice.example/", { fetch: doFetch })).toBeNull();
+  });
+});

--- a/Resources/Template/worker/reader-discovery.ts
+++ b/Resources/Template/worker/reader-discovery.ts
@@ -1,0 +1,218 @@
+/**
+ * IndieAuth `authorization_endpoint` discovery for a visitor-supplied `me` URL (#1568).
+ *
+ * Mirrors `@dwk/webmention`'s `discoverEndpoint`/`html.ts` shape (fetch through the SSRF-safe
+ * wrapper, check the `Link` header, fall back to scanning `<link>`/`<a>` elements) but that
+ * package's `parseLinkHeader`/`scanElements`/`splitTokens`/`resolveUrl` helpers aren't part of its
+ * public `exports` map, and its own `findWebmentionEndpoint` hardcodes the `webmention` rel — so
+ * this is a small, focused reimplementation for the `authorization_endpoint` rel, the same call
+ * `post-type-discovery.ts` already made for `@dwk/micropub`'s internal slug helpers. `safeFetch`
+ * itself (the actual SSRF-sensitive part) is reused from `@dwk/safe-fetch`, not reimplemented.
+ *
+ * @see docs/superpowers/specs/2026-08-18-worker-read-gate-design.md §3
+ */
+
+import { decodeEntities } from "@dwk/mf2";
+import { readBodyCapped, safeFetch, type FetchLike } from "@dwk/safe-fetch";
+
+const AUTHORIZATION_ENDPOINT_REL = "authorization_endpoint";
+
+/** A parsed `Link` header entry: its target URI and `rel` tokens. */
+interface LinkHeaderEntry {
+  readonly uri: string;
+  readonly rels: readonly string[];
+}
+
+/** Split a whitespace-separated token list (e.g. a `rel` value) into tokens. */
+function splitTokens(value: string | null): string[] {
+  if (value === null) return [];
+  return value.trim().split(/\s+/).filter((token) => token !== "");
+}
+
+/** Split a `Link` header on top-level commas, respecting `<…>` and quoted values. */
+function splitLinks(value: string): string[] {
+  const result: string[] = [];
+  let depth = 0;
+  let inQuotes = false;
+  let current = "";
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i] as string;
+    if (char === "\"" && value[i - 1] !== "\\") {
+      inQuotes = !inQuotes;
+    } else if (!inQuotes && char === "<") {
+      depth++;
+    } else if (!inQuotes && char === ">") {
+      depth--;
+    }
+    if (char === "," && depth === 0 && !inQuotes) {
+      result.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  if (current.trim() !== "") result.push(current);
+  return result;
+}
+
+/** Split a `Link` entry's parameter string on top-level semicolons, respecting quoted values. */
+function splitParams(paramString: string): string[] {
+  const result: string[] = [];
+  let inQuotes = false;
+  let current = "";
+  for (let i = 0; i < paramString.length; i++) {
+    const char = paramString[i] as string;
+    if (char === "\"" && paramString[i - 1] !== "\\") inQuotes = !inQuotes;
+    if (char === ";" && !inQuotes) {
+      result.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  if (current.trim() !== "") result.push(current);
+  return result;
+}
+
+/** Extract the `rel` parameter from a `Link` entry's parameter string. */
+function extractRel(paramString: string): string | null {
+  for (const param of splitParams(paramString)) {
+    const match = /^\s*rel\s*=\s*("([^"]*)"|'([^']*)'|[^;\s]+)\s*$/i.exec(param);
+    if (match !== null) return match[2] ?? match[3] ?? match[1] ?? null;
+  }
+  return null;
+}
+
+/** Parse an HTTP `Link` header into entries, e.g. `<https://a.example/auth>; rel="authorization_endpoint"`. */
+function parseLinkHeader(value: string | null): LinkHeaderEntry[] {
+  if (value === null || value.trim() === "") return [];
+  const entries: LinkHeaderEntry[] = [];
+  for (const part of splitLinks(value)) {
+    const match = /^\s*<([^>]*)>(.*)$/.exec(part);
+    if (match === null) continue;
+    const uri = match[1] ?? "";
+    const rels = splitTokens(extractRel(match[2] ?? ""));
+    if (rels.length > 0) entries.push({ uri, rels });
+  }
+  return entries;
+}
+
+/** Whether a `Content-Type` value names an HTML document. */
+function isHtmlContentType(contentType: string): boolean {
+  const essence = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  return essence === "text/html" || essence === "application/xhtml+xml";
+}
+
+/** Resolve `uri` against `base`, returning a normalized absolute URL or `null`. */
+function resolveUrl(uri: string, base: string): string | null {
+  try {
+    return new URL(uri, base).toString();
+  } catch {
+    return null;
+  }
+}
+
+interface ScannedElement {
+  readonly name: string;
+  readonly attrs: Readonly<Record<string, string | null>>;
+}
+
+/** Scan `html` with the runtime's streaming `HTMLRewriter` for elements matching `selector`. */
+async function scanElements(
+  html: string,
+  selector: string,
+  attrNames: readonly string[],
+): Promise<ScannedElement[]> {
+  const elements: ScannedElement[] = [];
+  const rewriter = new HTMLRewriter().on(selector, {
+    element(el) {
+      const attrs: Record<string, string | null> = {};
+      for (const name of attrNames) {
+        const value = el.getAttribute(name);
+        attrs[name] = value === null ? null : decodeEntities(value);
+      }
+      elements.push({ name: el.tagName, attrs });
+    },
+  });
+  await rewriter.transform(new Response(html)).text();
+  return elements;
+}
+
+/** Find the declared `authorization_endpoint` in a fetched document's `Link` header + HTML. */
+async function findAuthorizationEndpoint(
+  linkHeader: string | null,
+  html: string,
+  documentUrl: string,
+): Promise<string | null> {
+  for (const entry of parseLinkHeader(linkHeader)) {
+    if (entry.rels.includes(AUTHORIZATION_ENDPOINT_REL)) {
+      return resolveUrl(entry.uri, documentUrl);
+    }
+  }
+  if (html === "") return null;
+  const elements = await scanElements(html, "base, link, a", ["rel", "href"]);
+  let documentBase = documentUrl;
+  for (const el of elements) {
+    if (el.name === "base" && el.attrs.href) {
+      documentBase = resolveUrl(el.attrs.href, documentUrl) ?? documentUrl;
+      break;
+    }
+  }
+  for (const el of elements) {
+    if (el.name === "base") continue;
+    if (!splitTokens(el.attrs.rel).includes(AUTHORIZATION_ENDPOINT_REL)) continue;
+    const href = el.attrs.href;
+    if (href === null || href === undefined) continue;
+    return resolveUrl(href, documentBase);
+  }
+  return null;
+}
+
+/** Options for {@link discoverAuthorizationEndpoint}. */
+export interface DiscoverOptions {
+  /** `fetch` implementation to use; defaults to the global `fetch`. */
+  readonly fetch?: FetchLike;
+  /**
+   * Local-dev opt-in passed through to `@dwk/safe-fetch`'s `allowedHosts`. Never enable in a
+   * production composition.
+   */
+  readonly fetchAllowedHosts?: readonly string[];
+}
+
+/**
+ * Fetch `me` (through the SSRF-safe wrapper — the host and every redirect hop are validated
+ * against private/loopback/link-local ranges, redirects capped, the whole call bounded by a
+ * timeout) and discover its declared `authorization_endpoint`. Returns the absolute endpoint URL,
+ * or `null` when discovery finds none, the fetch fails, or it's blocked on SSRF grounds.
+ */
+export async function discoverAuthorizationEndpoint(
+  me: string,
+  options?: DiscoverOptions,
+): Promise<string | null> {
+  const doFetch: FetchLike = options?.fetch ?? ((input, init) => fetch(input, init));
+
+  let response: Response;
+  let base: string;
+  try {
+    const result = await safeFetch(
+      doFetch,
+      me,
+      { method: "GET", headers: { accept: "text/html, */*" } },
+      { allowedHosts: options?.fetchAllowedHosts },
+    );
+    response = result.response;
+    base = result.url;
+  } catch {
+    return null;
+  }
+
+  const fromHeader = await findAuthorizationEndpoint(response.headers.get("link"), "", base);
+  if (fromHeader !== null) return fromHeader;
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!isHtmlContentType(contentType)) return null;
+
+  const html = await readBodyCapped(response);
+  if (html === null) return null;
+  return findAuthorizationEndpoint(null, html, base);
+}

--- a/Resources/Template/worker/reader-identity.test.ts
+++ b/Resources/Template/worker/reader-identity.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { isAllowedReader, normalizeReaderIdentity } from "./reader-identity.ts";
+
+describe("normalizeReaderIdentity", () => {
+  it("drops the scheme, lowercases the host, and trims a trailing slash", () => {
+    expect(normalizeReaderIdentity("https://Alice.example/")).toBe("alice.example");
+  });
+
+  it("treats http and https as equal", () => {
+    expect(normalizeReaderIdentity("http://alice.example/")).toBe(
+      normalizeReaderIdentity("https://alice.example/"),
+    );
+  });
+
+  it("preserves a non-root path without its trailing slash", () => {
+    expect(normalizeReaderIdentity("https://bob.example/blog/")).toBe("bob.example/blog");
+  });
+
+  it("leaves a path with no trailing slash untouched", () => {
+    expect(normalizeReaderIdentity("https://bob.example/blog")).toBe("bob.example/blog");
+  });
+});
+
+function kvWith(value: string | null): { get(key: string): Promise<string | null> } {
+  return { get: async () => value };
+}
+
+describe("isAllowedReader", () => {
+  it("returns true for a normalized match in the pushed allowlist", async () => {
+    const env = { SOCIAL_KV: kvWith(JSON.stringify(["alice.example", "bob.example/blog"])) };
+    expect(await isAllowedReader(env, "https://alice.example/")).toBe(true);
+    expect(await isAllowedReader(env, "https://bob.example/blog/")).toBe(true);
+  });
+
+  it("returns false for a me URL not on the allowlist", async () => {
+    const env = { SOCIAL_KV: kvWith(JSON.stringify(["alice.example"])) };
+    expect(await isAllowedReader(env, "https://mallory.example/")).toBe(false);
+  });
+
+  it("returns false when SOCIAL_KV is unbound", async () => {
+    expect(await isAllowedReader({}, "https://alice.example/")).toBe(false);
+  });
+
+  it("returns false when the key is missing", async () => {
+    const env = { SOCIAL_KV: kvWith(null) };
+    expect(await isAllowedReader(env, "https://alice.example/")).toBe(false);
+  });
+
+  it("returns false for malformed JSON rather than throwing", async () => {
+    const env = { SOCIAL_KV: kvWith("{not json") };
+    expect(await isAllowedReader(env, "https://alice.example/")).toBe(false);
+  });
+
+  it("returns false when the stored value isn't a JSON array", async () => {
+    const env = { SOCIAL_KV: kvWith(JSON.stringify({ not: "an array" })) };
+    expect(await isAllowedReader(env, "https://alice.example/")).toBe(false);
+  });
+
+  it("ignores non-string entries in the array", async () => {
+    const env = { SOCIAL_KV: kvWith(JSON.stringify(["alice.example", 42, null])) };
+    expect(await isAllowedReader(env, "https://alice.example/")).toBe(true);
+  });
+});

--- a/Resources/Template/worker/reader-identity.ts
+++ b/Resources/Template/worker/reader-identity.ts
@@ -1,0 +1,58 @@
+/**
+ * Reader identity normalization + allowlist membership (#1568), reading the
+ * `contacts:allowlist` key #1567 pushes to `SOCIAL_KV`.
+ *
+ * @see docs/superpowers/specs/2026-08-18-worker-read-gate-design.md §5
+ * @see docs/superpowers/specs/2026-08-18-contacts-allowlist-push-design.md
+ */
+
+const ALLOWLIST_KEY = "contacts:allowlist";
+
+/** Minimal KV read surface this module needs (mirrors `worker.ts`'s `InboxKV`). */
+export interface ReaderIdentityEnv {
+  readonly SOCIAL_KV?: { get(key: string): Promise<string | null> };
+}
+
+/**
+ * Normalizes an absolute `me` URL to the same scheme-less `host + path` key
+ * `Contact.swift`'s `normalizedIdentityKey(for:)` produces — lowercased host,
+ * trailing slash trimmed off the path, scheme dropped entirely. Two me-URLs
+ * that only differ by `http`/`https` or a trailing slash must compare equal,
+ * matching how contacts are deduplicated app-side.
+ */
+export function normalizeReaderIdentity(me: string): string {
+  const url = new URL(me);
+  const host = url.hostname.toLowerCase();
+  let path = url.pathname;
+  if (path.endsWith("/")) path = path.slice(0, -1);
+  return host + path;
+}
+
+/**
+ * Parses the bare JSON array of normalized me-URL strings #1567 pushes to
+ * `contacts:allowlist`. Returns an empty set for a missing key or malformed
+ * JSON — never throws, so a KV outage or an unexpected value degrades to
+ * "nobody is allowed" rather than crashing the request.
+ */
+async function readAllowlist(env: ReaderIdentityEnv): Promise<ReadonlySet<string>> {
+  if (!env.SOCIAL_KV) return new Set();
+  const raw = await env.SOCIAL_KV.get(ALLOWLIST_KEY);
+  if (raw === null) return new Set();
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((value): value is string => typeof value === "string"));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Whether `me` (an absolute, already-canonicalized profile URL) is a known
+ * contact per the pushed allowlist. Normalizes `me` the same way the
+ * allowlist entries are normalized before comparing.
+ */
+export async function isAllowedReader(env: ReaderIdentityEnv, me: string): Promise<boolean> {
+  const allowlist = await readAllowlist(env);
+  return allowlist.has(normalizeReaderIdentity(me));
+}

--- a/Resources/Template/worker/reader-session.test.ts
+++ b/Resources/Template/worker/reader-session.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  READER_SESSION_COOKIE,
+  createPkcePair,
+  createReaderSessionToken,
+  createSigninState,
+  readReaderSessionCookie,
+  readerSessionClearCookie,
+  readerSessionSetCookie,
+  verifyReaderSessionToken,
+  verifySigninState,
+} from "./reader-session.ts";
+
+describe("createPkcePair", () => {
+  it("generates a verifier matching RFC 7636's length/alphabet and a matching S256 challenge", async () => {
+    const { verifier, challenge } = await createPkcePair();
+    expect(verifier).toMatch(/^[A-Za-z0-9._~-]{43,128}$/);
+    const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+    const expected = btoa(String.fromCharCode(...new Uint8Array(digest)))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(challenge).toBe(expected);
+  });
+
+  it("generates distinct pairs on each call", async () => {
+    const a = await createPkcePair();
+    const b = await createPkcePair();
+    expect(a.verifier).not.toBe(b.verifier);
+  });
+});
+
+const SIGNING_KEY = "test-signing-key";
+
+describe("createSigninState / verifySigninState", () => {
+  const fields = {
+    me: "https://alice.example/",
+    redirectTo: "/notes/hello",
+    authorizationEndpoint: "https://alice.example/auth",
+    verifier: "a-verifier",
+  };
+
+  it("round-trips a valid state token", async () => {
+    const token = await createSigninState(fields, SIGNING_KEY, 1_000);
+    expect(await verifySigninState(token, SIGNING_KEY, 1_000)).toEqual({ v: 1, exp: 1_600, ...fields });
+  });
+
+  it("rejects an expired token", async () => {
+    const token = await createSigninState(fields, SIGNING_KEY, 1_000);
+    expect(await verifySigninState(token, SIGNING_KEY, 1_601)).toBeNull();
+  });
+
+  it("rejects a token signed with a different key", async () => {
+    const token = await createSigninState(fields, SIGNING_KEY, 1_000);
+    expect(await verifySigninState(token, "other-key", 1_000)).toBeNull();
+  });
+
+  it("rejects garbage input", async () => {
+    expect(await verifySigninState("not-a-token", SIGNING_KEY)).toBeNull();
+  });
+
+  it("is not accepted as a reader session token (independent purposes)", async () => {
+    const token = await createSigninState(fields, SIGNING_KEY, 1_000);
+    expect(await verifyReaderSessionToken(token, SIGNING_KEY, 1_000)).toBeNull();
+  });
+});
+
+describe("createReaderSessionToken / verifyReaderSessionToken", () => {
+  it("round-trips a valid session token", async () => {
+    const token = await createReaderSessionToken("alice.example", SIGNING_KEY, 1_000);
+    expect(await verifyReaderSessionToken(token, SIGNING_KEY, 1_000)).toEqual({
+      v: 1,
+      exp: 1_000 + 2_592_000,
+      me: "alice.example",
+    });
+  });
+
+  it("rejects an expired session token", async () => {
+    const token = await createReaderSessionToken("alice.example", SIGNING_KEY, 1_000);
+    expect(await verifyReaderSessionToken(token, SIGNING_KEY, 1_000 + 2_592_001)).toBeNull();
+  });
+
+  it("rejects a token signed with a different key", async () => {
+    const token = await createReaderSessionToken("alice.example", SIGNING_KEY, 1_000);
+    expect(await verifyReaderSessionToken(token, "other-key", 1_000)).toBeNull();
+  });
+});
+
+describe("cookie helpers", () => {
+  it("readerSessionSetCookie produces a __Host- cookie with the expected attributes", () => {
+    const value = readerSessionSetCookie("the-token");
+    expect(value).toContain(`${READER_SESSION_COOKIE}=the-token`);
+    expect(value).toContain("Path=/");
+    expect(value).toContain("Secure");
+    expect(value).toContain("HttpOnly");
+    expect(value).toContain("SameSite=Lax");
+    expect(value).toContain("Max-Age=2592000");
+  });
+
+  it("readerSessionClearCookie expires the cookie immediately", () => {
+    expect(readerSessionClearCookie()).toContain("Max-Age=0");
+  });
+
+  it("readReaderSessionCookie extracts the value among other cookies", () => {
+    const request = new Request("https://example.com/", {
+      headers: { Cookie: `foo=bar; ${READER_SESSION_COOKIE}=the-token; baz=qux` },
+    });
+    expect(readReaderSessionCookie(request)).toBe("the-token");
+  });
+
+  it("readReaderSessionCookie returns null when absent", () => {
+    const request = new Request("https://example.com/", { headers: { Cookie: "foo=bar" } });
+    expect(readReaderSessionCookie(request)).toBeNull();
+  });
+
+  it("readReaderSessionCookie returns null when there is no Cookie header at all", () => {
+    const request = new Request("https://example.com/");
+    expect(readReaderSessionCookie(request)).toBeNull();
+  });
+});

--- a/Resources/Template/worker/reader-session.ts
+++ b/Resources/Template/worker/reader-session.ts
@@ -1,0 +1,134 @@
+/**
+ * PKCE, sign-in state token, and reader session cookie for the Worker read gate (#1568).
+ *
+ * @see docs/superpowers/specs/2026-08-18-worker-read-gate-design.md §4
+ */
+
+import { base64url, signPayload, verifyPayload } from "./token-signing.ts";
+
+const SIGNIN_STATE_PURPOSE = "reader-signin-state";
+const SIGNIN_STATE_TTL_SECONDS = 600;
+const READER_SESSION_PURPOSE = "reader-session";
+const READER_SESSION_TTL_SECONDS = 2_592_000; // 30 days
+
+/** The reader session cookie's name. `__Host-` requires exactly `Path=/`, `Secure`, no `Domain`. */
+export const READER_SESSION_COOKIE = "__Host-anglesite_reader";
+
+/** A PKCE (RFC 7636) verifier/challenge pair, `S256` method. */
+export interface PkcePair {
+  readonly verifier: string;
+  readonly challenge: string;
+}
+
+/** Generates a random `code_verifier` (RFC 7636 §4.1, unreserved-character alphabet) and its `S256` challenge. */
+export async function createPkcePair(): Promise<PkcePair> {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  const verifier = base64url(bytes);
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  return { verifier, challenge: base64url(new Uint8Array(digest)) };
+}
+
+/** The in-flight sign-in request, round-tripped through the visited site as the OAuth `state`. */
+export interface SigninState {
+  readonly v: 1;
+  readonly exp: number;
+  /** Canonicalized, claimed (not yet verified) identity. */
+  readonly me: string;
+  /** Site-relative path to return the browser to on success. */
+  readonly redirectTo: string;
+  /** Discovered once at sign-in start; the callback reuses it rather than re-discovering. */
+  readonly authorizationEndpoint: string;
+  readonly verifier: string;
+}
+
+function isSigninState(value: unknown): value is SigninState {
+  if (typeof value !== "object" || value === null) return false;
+  const state = value as Record<string, unknown>;
+  return (
+    state.v === 1 &&
+    typeof state.exp === "number" &&
+    typeof state.me === "string" &&
+    typeof state.redirectTo === "string" &&
+    typeof state.authorizationEndpoint === "string" &&
+    typeof state.verifier === "string"
+  );
+}
+
+/** Sign a {@link SigninState}, valid for {@link SIGNIN_STATE_TTL_SECONDS}. */
+export async function createSigninState(
+  fields: Omit<SigninState, "v" | "exp">,
+  signingKey: string,
+  now = Math.floor(Date.now() / 1000),
+): Promise<string> {
+  const state: SigninState = { v: 1, exp: now + SIGNIN_STATE_TTL_SECONDS, ...fields };
+  return signPayload(new TextEncoder().encode(JSON.stringify(state)), signingKey, SIGNIN_STATE_PURPOSE);
+}
+
+/** Verify a sign-in state token, returning its payload or `null` if invalid/expired/tampered. */
+export async function verifySigninState(
+  token: string,
+  signingKey: string,
+  now = Math.floor(Date.now() / 1000),
+): Promise<SigninState | null> {
+  const decoded = await verifyPayload(token, signingKey, SIGNIN_STATE_PURPOSE);
+  if (!isSigninState(decoded) || decoded.exp <= now) return null;
+  return decoded;
+}
+
+/** A signed-in reader's session. `me` is already in `reader-identity.ts`'s normalized form. */
+export interface ReaderSession {
+  readonly v: 1;
+  readonly exp: number;
+  readonly me: string;
+}
+
+function isReaderSession(value: unknown): value is ReaderSession {
+  if (typeof value !== "object" || value === null) return false;
+  const session = value as Record<string, unknown>;
+  return session.v === 1 && typeof session.exp === "number" && typeof session.me === "string";
+}
+
+/** Sign a {@link ReaderSession} token for `me` (already normalized), valid for {@link READER_SESSION_TTL_SECONDS}. */
+export async function createReaderSessionToken(
+  me: string,
+  signingKey: string,
+  now = Math.floor(Date.now() / 1000),
+): Promise<string> {
+  const session: ReaderSession = { v: 1, exp: now + READER_SESSION_TTL_SECONDS, me };
+  return signPayload(new TextEncoder().encode(JSON.stringify(session)), signingKey, READER_SESSION_PURPOSE);
+}
+
+/** Verify a reader session token, returning its payload or `null` if invalid/expired/tampered. */
+export async function verifyReaderSessionToken(
+  token: string,
+  signingKey: string,
+  now = Math.floor(Date.now() / 1000),
+): Promise<ReaderSession | null> {
+  const decoded = await verifyPayload(token, signingKey, READER_SESSION_PURPOSE);
+  if (!isReaderSession(decoded) || decoded.exp <= now) return null;
+  return decoded;
+}
+
+/** Build the `Set-Cookie` header value that starts a reader session. */
+export function readerSessionSetCookie(token: string): string {
+  return `${READER_SESSION_COOKIE}=${token}; Path=/; Max-Age=${READER_SESSION_TTL_SECONDS}; Secure; HttpOnly; SameSite=Lax`;
+}
+
+/** Build the `Set-Cookie` header value that clears a reader session (used nowhere yet, kept for symmetry with future sign-out). */
+export function readerSessionClearCookie(): string {
+  return `${READER_SESSION_COOKIE}=; Path=/; Max-Age=0; Secure; HttpOnly; SameSite=Lax`;
+}
+
+/** Extract the reader session cookie's raw token value from a request's `Cookie` header, if present. */
+export function readReaderSessionCookie(request: Request): string | null {
+  const header = request.headers.get("Cookie");
+  if (!header) return null;
+  for (const part of header.split(";")) {
+    const separator = part.indexOf("=");
+    if (separator === -1) continue;
+    const name = part.slice(0, separator).trim();
+    if (name === READER_SESSION_COOKIE) return part.slice(separator + 1).trim();
+  }
+  return null;
+}

--- a/Resources/Template/worker/render-utils.ts
+++ b/Resources/Template/worker/render-utils.ts
@@ -1,0 +1,68 @@
+/**
+ * Small, dependency-free rendering helpers shared across the Worker's hand-rolled HTML responses
+ * and mf2-JSON extraction. Extracted from `worker.ts` (rather than left there and imported back)
+ * so modules like `reader-auth.ts`/`gated-content.ts` that `worker.ts` itself composes into
+ * `ROUTES` can use them without an import cycle.
+ */
+
+export function escapeHTML(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    "\"": "&quot;",
+    "'": "&#39;",
+  })[character] ?? character);
+}
+
+/**
+ * Extracts a plain-text value from an mf2 `content` property entry. Microformats2-JSON — and
+ * `@dwk/micropub`'s own accepted input shape — allows `content` to be either a plain string or a
+ * rich-text object (`{ html, value }`); naively coercing the object form with `String(...)`
+ * produces the literal `"[object Object]"`.
+ */
+export function extractMf2ContentString(raw: unknown): string {
+  if (typeof raw === "string") return raw;
+  if (raw && typeof raw === "object") {
+    const obj = raw as { value?: unknown; html?: unknown };
+    if (typeof obj.value === "string") return obj.value;
+    // Standard Micropub JSON *create* shape for HTML content: { html } with no `value` key at
+    // all — `value` only appears in mf2 read back off a rendered page, not in what a client
+    // posts — so `html` is checked as a fallback, not just `value`.
+    if (typeof obj.html === "string") return obj.html;
+  }
+  return "";
+}
+
+/** A photo attachment extracted from an mf2 `photo` property entry. */
+export interface ExtractedPhoto {
+  readonly url: string;
+  readonly alt?: string;
+}
+
+/**
+ * Extracts `{ url, alt? }` pairs from an mf2 `photo` property array — each entry is either a
+ * plain URL string or the mf2 alt-text object shape `{ value, alt }`, mirroring
+ * {@link extractMf2ContentString}'s tolerance for `content`'s two accepted shapes.
+ */
+export function extractMf2Photos(raw: unknown): ExtractedPhoto[] {
+  if (!Array.isArray(raw)) return [];
+  const photos: ExtractedPhoto[] = [];
+  for (const entry of raw) {
+    if (typeof entry === "string" && entry.length > 0) {
+      photos.push({ url: entry });
+      continue;
+    }
+    if (entry && typeof entry === "object") {
+      const obj = entry as { value?: unknown; alt?: unknown };
+      if (typeof obj.value === "string" && obj.value.length > 0) {
+        photos.push(
+          typeof obj.alt === "string" && obj.alt.length > 0
+            ? { url: obj.value, alt: obj.alt }
+            : { url: obj.value },
+        );
+      }
+    }
+  }
+  return photos;
+}

--- a/Resources/Template/worker/token-signing.test.ts
+++ b/Resources/Template/worker/token-signing.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { base64url, decodeBase64url, deriveKey, signPayload, verifyPayload } from "./token-signing.ts";
+
+describe("base64url / decodeBase64url", () => {
+  it("round-trips arbitrary bytes without padding or unsafe characters", () => {
+    const bytes = new Uint8Array([0, 1, 2, 251, 252, 253, 254, 255]);
+    const encoded = base64url(bytes);
+    expect(encoded).not.toMatch(/[+/=]/);
+    expect(decodeBase64url(encoded)).toEqual(bytes);
+  });
+
+  it("returns null for an invalid encoding", () => {
+    expect(decodeBase64url("not base64url!!")).toBeNull();
+  });
+});
+
+describe("deriveKey", () => {
+  it("derives independent subkeys per purpose from the same secret", async () => {
+    const a = await deriveKey("secret", "purpose-a");
+    const b = await deriveKey("secret", "purpose-b");
+    const payload = new TextEncoder().encode("hello");
+    const sigA = await crypto.subtle.sign("HMAC", a, payload);
+    expect(await crypto.subtle.verify("HMAC", b, sigA, payload)).toBe(false);
+  });
+});
+
+describe("signPayload / verifyPayload", () => {
+  it("round-trips a JSON payload through sign and verify", async () => {
+    const payload = new TextEncoder().encode(JSON.stringify({ hello: "world" }));
+    const token = await signPayload(payload, "secret", "test-purpose");
+    const decoded = await verifyPayload(token, "secret", "test-purpose");
+    expect(decoded).toEqual({ hello: "world" });
+  });
+
+  it("rejects a token signed under a different purpose", async () => {
+    const payload = new TextEncoder().encode(JSON.stringify({ hello: "world" }));
+    const token = await signPayload(payload, "secret", "purpose-a");
+    expect(await verifyPayload(token, "secret", "purpose-b")).toBeNull();
+  });
+
+  it("rejects a token signed with a different secret", async () => {
+    const payload = new TextEncoder().encode(JSON.stringify({ hello: "world" }));
+    const token = await signPayload(payload, "secret-a", "test-purpose");
+    expect(await verifyPayload(token, "secret-b", "test-purpose")).toBeNull();
+  });
+
+  it("rejects a tampered payload", async () => {
+    const payload = new TextEncoder().encode(JSON.stringify({ hello: "world" }));
+    const token = await signPayload(payload, "secret", "test-purpose");
+    const [, signature] = token.split(".");
+    const tampered = `${base64url(new TextEncoder().encode(JSON.stringify({ hello: "tampered" })))}.${signature}`;
+    expect(await verifyPayload(tampered, "secret", "test-purpose")).toBeNull();
+  });
+
+  it("rejects a malformed token", async () => {
+    expect(await verifyPayload("not-a-token", "secret", "test-purpose")).toBeNull();
+    expect(await verifyPayload("a.b.c", "secret", "test-purpose")).toBeNull();
+  });
+
+  it("rejects an oversized token", async () => {
+    const huge = "a".repeat(10_000);
+    expect(await verifyPayload(huge, "secret", "test-purpose", 8_192)).toBeNull();
+  });
+});

--- a/Resources/Template/worker/token-signing.ts
+++ b/Resources/Template/worker/token-signing.ts
@@ -50,7 +50,7 @@ export async function deriveKey(secret: string, purpose: string): Promise<Crypto
 }
 
 /** Sign `payload` (already-serialized JSON bytes) with the purpose-derived key. */
-export async function signPayload(payload: Uint8Array, signingKey: string, purpose: string): Promise<string> {
+export async function signPayload(payload: Uint8Array<ArrayBuffer>, signingKey: string, purpose: string): Promise<string> {
   const signature = await crypto.subtle.sign("HMAC", await deriveKey(signingKey, purpose), payload);
   return `${base64url(payload)}.${base64url(new Uint8Array(signature))}`;
 }

--- a/Resources/Template/worker/token-signing.ts
+++ b/Resources/Template/worker/token-signing.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared HMAC token-signing primitives for this Worker's hand-rolled, self-contained
+ * `base64url(payload).base64url(signature)` tokens (consent grants, reader sign-in state,
+ * reader sessions) — extracted from `worker.ts` (which originated `ConsentGrant`/
+ * `SolidOidcConsentGrant`'s identical shape) so new token kinds don't duplicate this
+ * security-sensitive encode/sign/verify code.
+ */
+
+export function base64url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function decodeBase64url(value: string): Uint8Array<ArrayBuffer> | null {
+  try {
+    const padded = value.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(value.length / 4) * 4, "=");
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Derives a purpose-specific HMAC key from `secret` via HKDF, so that `TOKEN_SIGNING_KEY` — the
+ * one secret provisioned for consent-token signing, owner-password comparison, and (as of #1568)
+ * reader sign-in/session tokens — yields independent subkeys per purpose. A weakness or misuse in
+ * one purpose's key can't cross over into another's.
+ */
+export async function deriveKey(secret: string, purpose: string): Promise<CryptoKey> {
+  const baseKey = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    "HKDF",
+    false,
+    ["deriveKey"],
+  );
+  return crypto.subtle.deriveKey(
+    { name: "HKDF", hash: "SHA-256", salt: new Uint8Array(0), info: new TextEncoder().encode(purpose) },
+    baseKey,
+    { name: "HMAC", hash: "SHA-256", length: 256 },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+/** Sign `payload` (already-serialized JSON bytes) with the purpose-derived key. */
+export async function signPayload(payload: Uint8Array, signingKey: string, purpose: string): Promise<string> {
+  const signature = await crypto.subtle.sign("HMAC", await deriveKey(signingKey, purpose), payload);
+  return `${base64url(payload)}.${base64url(new Uint8Array(signature))}`;
+}
+
+/**
+ * Verify a `signPayload` token and return its decoded JSON payload, or `null` when the token is
+ * malformed, oversized, or its signature doesn't verify. Callers still owe their own shape/expiry
+ * checks on the returned value — this only proves the bytes are what `signPayload` produced.
+ */
+export async function verifyPayload(
+  token: string,
+  signingKey: string,
+  purpose: string,
+  maxLength = 8_192,
+): Promise<unknown> {
+  if (token.length > maxLength) return null;
+  const [payloadPart, signaturePart, extra] = token.split(".");
+  if (!payloadPart || !signaturePart || extra !== undefined) return null;
+  const payload = decodeBase64url(payloadPart);
+  const signature = decodeBase64url(signaturePart);
+  if (!payload || !signature) return null;
+  if (!(await crypto.subtle.verify("HMAC", await deriveKey(signingKey, purpose), signature, payload))) return null;
+  try {
+    return JSON.parse(new TextDecoder().decode(payload));
+  } catch {
+    return null;
+  }
+}

--- a/Resources/Template/worker/worker.test.ts
+++ b/Resources/Template/worker/worker.test.ts
@@ -23,6 +23,9 @@ import {
 } from "./worker";
 import worker from "./worker";
 import { tagFediverseUrl } from "./utm-codes.ts";
+import { createMicropubStore } from "@dwk/micropub";
+import { READER_SESSION_COOKIE, createReaderSessionToken } from "./reader-session.ts";
+import { normalizeReaderIdentity } from "./reader-identity.ts";
 
 const testEnv = env as unknown as WorkerEnv;
 
@@ -2076,4 +2079,134 @@ test("activityPubConfig: AP_MODERATORS is ignored (undefined) for a Person actor
     makeActivityPubEnv({ AP_MODERATORS: "https://mod1.example/actor" }),
   );
   expect(config?.moderators).toBeUndefined();
+});
+
+// --- Worker read gate (#1568) ------------------------------------------------------------
+
+async function sessionCookieFor(me: string): Promise<string> {
+  const token = await createReaderSessionToken(normalizeReaderIdentity(me), testEnv.TOKEN_SIGNING_KEY);
+  return `${READER_SESSION_COOKIE}=${token}`;
+}
+
+/** Minimal stub satisfying `Fetcher`, since the vitest miniflare env has no real ASSETS binding. */
+function assetsAlways404(): WorkerEnv["ASSETS"] {
+  return { fetch: async () => new Response("Not Found", { status: 404 }) } as unknown as WorkerEnv["ASSETS"];
+}
+
+test("contacts/signin: renders the sign-in form with no me", async () => {
+  const response = await fetchWorker(new Request("https://owner.example/contacts/signin"));
+  expect(response.status).toBe(200);
+  expect(await response.text()).toContain('name="me"');
+});
+
+test("contacts/signin: discovers the endpoint and redirects with a signed state", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      '<html><head><link rel="authorization_endpoint" href="https://alice.example/auth"></head></html>',
+      { headers: { "content-type": "text/html" } },
+    )) as unknown as typeof fetch;
+  try {
+    const response = await fetchWorker(
+      new Request("https://owner.example/contacts/signin?me=https://alice.example/"),
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain("https://alice.example/auth");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("contacts/callback: verifies identity, checks the allowlist, and starts a session", async () => {
+  const { createSigninState } = await import("./reader-session.ts");
+  const state = await createSigninState(
+    {
+      me: "https://alice.example/",
+      redirectTo: "/notes/hello",
+      authorizationEndpoint: "https://alice.example/auth",
+      verifier: "v",
+    },
+    testEnv.TOKEN_SIGNING_KEY,
+  );
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ me: "https://alice.example/" }), {
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+  try {
+    await testEnv.SOCIAL_KV!.put("contacts:allowlist", JSON.stringify(["alice.example"]));
+    const response = await fetchWorker(
+      new Request(`https://owner.example/contacts/callback?code=abc&state=${encodeURIComponent(state)}`),
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/notes/hello");
+    expect(response.headers.get("set-cookie")).toContain(READER_SESSION_COOKIE);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("contacts/feed: 403 without a session, 200 listing only contacts-visibility posts with one", async () => {
+  const unauthorized = await fetchWorker(new Request("https://owner.example/contacts/feed"));
+  expect(unauthorized.status).toBe(403);
+
+  const store = createMicropubStore({ MICROPUB_DB: testEnv.MICROPUB_DB! });
+  await store.insertPost({
+    url: "https://owner.example/notes/gate-feed-restricted",
+    type: "h-entry",
+    properties: { name: ["Gate Feed Restricted"], visibility: ["contacts"] },
+    now: 1_000,
+  });
+  const cookie = await sessionCookieFor("https://alice.example/");
+  const authorized = await fetchWorker(
+    new Request("https://owner.example/contacts/feed", { headers: { Cookie: cookie } }),
+  );
+  expect(authorized.status).toBe(200);
+  expect(await authorized.text()).toContain("Gate Feed Restricted");
+});
+
+test("gated permalink fallback: unrelated 404s are untouched, plausible post URLs are gated", async () => {
+  const assetsEnv = { ...testEnv, ASSETS: assetsAlways404() };
+
+  // Not shaped like a post permalink — the gate never engages, plain 404 exactly as before #1568.
+  const unrelated = await worker.fetch(
+    new Request("https://owner.example/styles.css"),
+    assetsEnv,
+    createExecutionContext(),
+  );
+  expect(unrelated.status).toBe(404);
+
+  // Plausible post URL, no session — uniform 403, not a leak-revealing 404.
+  const noSession = await worker.fetch(
+    new Request("https://owner.example/notes/some-slug"),
+    assetsEnv,
+    createExecutionContext(),
+  );
+  expect(noSession.status).toBe(403);
+
+  // Authorized session, but no such post — falls back to the plain 404 (safe: only a verified,
+  // allowlisted contact ever reaches this branch).
+  const cookie = await sessionCookieFor("https://alice.example/");
+  const authorizedNoPost = await worker.fetch(
+    new Request("https://owner.example/notes/does-not-exist-either", { headers: { Cookie: cookie } }),
+    assetsEnv,
+    createExecutionContext(),
+  );
+  expect(authorizedNoPost.status).toBe(404);
+
+  // Authorized session, real restricted post — renders it.
+  const store = createMicropubStore({ MICROPUB_DB: testEnv.MICROPUB_DB! });
+  await store.insertPost({
+    url: "https://owner.example/notes/gate-permalink-restricted",
+    type: "h-entry",
+    properties: { name: ["Gate Permalink Restricted"], visibility: ["contacts"] },
+    now: 1_000,
+  });
+  const rendered = await worker.fetch(
+    new Request("https://owner.example/notes/gate-permalink-restricted", { headers: { Cookie: cookie } }),
+    assetsEnv,
+    createExecutionContext(),
+  );
+  expect(rendered.status).toBe(200);
+  expect(await rendered.text()).toContain("Gate Permalink Restricted");
 });

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -65,6 +65,7 @@ import utmCodesArtifact from "../utm-codes.json";
 import { tagFediverseUrl } from "./utm-codes.ts";
 import { GOAL_ENDPOINT_PATH } from "../scripts/experiments-paths.ts";
 import { base64url, decodeBase64url, deriveKey } from "./token-signing.ts";
+import { escapeHTML, extractMf2ContentString, extractMf2Photos, type ExtractedPhoto } from "./render-utils.ts";
 
 /**
  * Per-site Cloudflare Worker entry point.
@@ -423,16 +424,6 @@ async function secretsMatch(provided: string, expected: string, comparisonSecret
   // Keep both passwords as message data under one server-controlled key and delegate the MAC
   // comparison to WebCrypto instead of comparing attacker-influenced bytes in JavaScript.
   return crypto.subtle.verify("HMAC", key, expectedMAC, encoder.encode(provided));
-}
-
-function escapeHTML(value: string): string {
-  return value.replace(/[&<>"']/g, (character) => ({
-    "&": "&amp;",
-    "<": "&lt;",
-    ">": "&gt;",
-    "\"": "&quot;",
-    "'": "&#39;",
-  })[character] ?? character);
 }
 
 function consentPage(request: AuthorizationRequest): Response {
@@ -931,63 +922,6 @@ function handleWebmentionQueue(
     WEBMENTION_INBOX: env.WEBMENTION_INBOX,
   };
   return consumer(batch, webmentionEnv, ctx);
-}
-
-/**
- * Extracts a plain-text value from an mf2 `content` property entry (V-4.1, #363 review fix).
- * Microformats2-JSON — and `@dwk/micropub`'s own accepted input shape — allows `content` to be
- * either a plain string or a rich-text object (`{ html, value }`); naively coercing the object
- * form with `String(...)` produces the literal `"[object Object]"`, which would silently publish
- * garbage to followers instead of skipping the fan-out. `undefined` (missing/unrecognized shape)
- * is treated the same as an empty string by the caller, which already skips the fan-out rather
- * than publish an empty Note.
- */
-function extractMf2ContentString(raw: unknown): string {
-  if (typeof raw === "string") return raw;
-  if (raw && typeof raw === "object") {
-    const obj = raw as { value?: unknown; html?: unknown };
-    if (typeof obj.value === "string") return obj.value;
-    // Standard Micropub JSON *create* shape for HTML content: { html } with no `value` key at
-    // all — `value` only appears in mf2 read back off a rendered page, not in what a client
-    // posts — so `html` is checked as a fallback, not just `value`.
-    if (typeof obj.html === "string") return obj.html;
-  }
-  return "";
-}
-
-/** A photo attachment extracted from an mf2 `photo` property entry, ready for AS2 mapping. */
-interface ExtractedPhoto {
-  readonly url: string;
-  readonly alt?: string;
-}
-
-/**
- * Extracts `{ url, alt? }` pairs from an mf2 `photo` property array (#1240) — each entry is
- * either a plain URL string or the mf2 alt-text object shape `{ value, alt }`, mirroring
- * {@link extractMf2ContentString}'s tolerance for `content`'s two accepted shapes. Feeds the AS2
- * `attachment` mapping in `fanOutMicropubCreateToActivityPub` so a photo post is renderable by
- * media-only Fediverse clients (Pixelfed shows only posts with attachments).
- */
-function extractMf2Photos(raw: unknown): ExtractedPhoto[] {
-  if (!Array.isArray(raw)) return [];
-  const photos: ExtractedPhoto[] = [];
-  for (const entry of raw) {
-    if (typeof entry === "string" && entry.length > 0) {
-      photos.push({ url: entry });
-      continue;
-    }
-    if (entry && typeof entry === "object") {
-      const obj = entry as { value?: unknown; alt?: unknown };
-      if (typeof obj.value === "string" && obj.value.length > 0) {
-        photos.push(
-          typeof obj.alt === "string" && obj.alt.length > 0
-            ? { url: obj.value, alt: obj.alt }
-            : { url: obj.value },
-        );
-      }
-    }
-  }
-  return photos;
 }
 
 /**

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -64,6 +64,7 @@ import experimentsArtifact from "./experiments.json";
 import utmCodesArtifact from "../utm-codes.json";
 import { tagFediverseUrl } from "./utm-codes.ts";
 import { GOAL_ENDPOINT_PATH } from "../scripts/experiments-paths.ts";
+import { base64url, decodeBase64url, deriveKey } from "./token-signing.ts";
 
 /**
  * Per-site Cloudflare Worker entry point.
@@ -242,49 +243,6 @@ interface ConsentGrant {
   codeChallenge: string;
   scope: string;
   resources: string[];
-}
-
-function base64url(bytes: Uint8Array): string {
-  let binary = "";
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-function decodeBase64url(value: string): Uint8Array<ArrayBuffer> | null {
-  try {
-    const padded = value.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(value.length / 4) * 4, "=");
-    const binary = atob(padded);
-    const bytes = new Uint8Array(binary.length);
-    for (let index = 0; index < binary.length; index += 1) {
-      bytes[index] = binary.charCodeAt(index);
-    }
-    return bytes;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Derives a purpose-specific HMAC key from `secret` via HKDF, so that `TOKEN_SIGNING_KEY` — the
- * one secret provisioned for both consent-token signing and owner-password comparison — yields
- * independent subkeys per purpose. A weakness or misuse in one purpose's key can't cross over
- * into the other's.
- */
-async function deriveKey(secret: string, purpose: string): Promise<CryptoKey> {
-  const baseKey = await crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(secret),
-    "HKDF",
-    false,
-    ["deriveKey"],
-  );
-  return crypto.subtle.deriveKey(
-    { name: "HKDF", hash: "SHA-256", salt: new Uint8Array(0), info: new TextEncoder().encode(purpose) },
-    baseKey,
-    { name: "HMAC", hash: "SHA-256", length: 256 },
-    false,
-    ["sign", "verify"],
-  );
 }
 
 function grantFor(request: AuthorizationRequest, expiresAt: number): ConsentGrant {

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -66,6 +66,8 @@ import { tagFediverseUrl } from "./utm-codes.ts";
 import { GOAL_ENDPOINT_PATH } from "../scripts/experiments-paths.ts";
 import { base64url, decodeBase64url, deriveKey } from "./token-signing.ts";
 import { escapeHTML, extractMf2ContentString, extractMf2Photos, type ExtractedPhoto } from "./render-utils.ts";
+import { handleReaderCallback, handleReaderSignin } from "./reader-auth.ts";
+import { handleGatedFallback, handlePrivateFeed } from "./gated-content.ts";
 
 /**
  * Per-site Cloudflare Worker entry point.
@@ -1745,6 +1747,31 @@ export const ROUTES: readonly WorkerRoute[] = [
     methods: ["GET", "HEAD"],
     handler: (request, env, ctx) => handleWebFinger(request, env, ctx),
   },
+  {
+    // IndieAuth relying-party sign-in for a visitor proving their own site's identity (#1568):
+    // no `me` renders the form, `me` present discovers that site's authorization_endpoint and
+    // redirects there. See gated-content.ts's design doc for the full flow.
+    path: "/contacts/signin",
+    match: "exact",
+    methods: ["GET"],
+    handler: (request, env) => handleReaderSignin(request, env),
+  },
+  {
+    // OAuth redirect target for the sign-in above: redeems the code, verifies identity, checks
+    // the pushed allowlist, and starts a reader session (#1568).
+    path: "/contacts/callback",
+    match: "exact",
+    methods: ["GET"],
+    handler: (request, env) => handleReaderCallback(request, env),
+  },
+  {
+    // Private h-feed of restricted (`visibility: contacts`) posts, gated the same way as a
+    // restricted permalink (#1568).
+    path: "/contacts/feed",
+    match: "exact",
+    methods: ["GET", "HEAD"],
+    handler: (request, env) => handlePrivateFeed(request, env),
+  },
 ];
 
 export function matchRoute(pathname: string, routes: readonly WorkerRoute[] = ROUTES): WorkerRoute | null {
@@ -1839,6 +1866,13 @@ export default {
         return new Response("No assets binding configured", { status: 500 });
       }
       response = await assets.fetch(request);
+      // A restricted (`visibility: contacts`) post is never in the static build (#1568), so its
+      // permalink always misses here — give the read gate a chance to serve it (or a uniform 403
+      // for an unauthenticated/unauthorized visitor) before falling back to the plain asset 404.
+      if (response.status === 404) {
+        const gated = await handleGatedFallback(request, env, pathname);
+        if (gated !== null) response = gated;
+      }
     }
 
     // Goal-signal conversion counting (#1270 slice 1): applied to whatever response the branches

--- a/docs/superpowers/specs/2026-08-18-worker-read-gate-design.md
+++ b/docs/superpowers/specs/2026-08-18-worker-read-gate-design.md
@@ -1,0 +1,316 @@
+# Worker read gate: IndieAuth-gated permalinks + private h-feed — design (#1568)
+
+**Status:** approved design, pre-implementation.
+**Issue:** [#1568](https://github.com/Anglesite/Anglesite/issues/1568), slice 4
+of epic #963. Related: decision record
+`docs/superpowers/specs/2026-08-18-audience-limited-posting-decisions.md` §2.4,
+`docs/superpowers/specs/2026-08-18-contacts-allowlist-push-design.md` (#1567,
+slice 3 — defines the allowlist store this design reads from).
+
+## 1. Context and goal
+
+Restricted posts (`visibility: contacts`) live only in the Worker's
+`MICROPUB_DB` D1 store — never in `Source/` or the static build (§2.1 of the
+decision record). This issue makes them readable by the site owner's known
+contacts: a gated permalink per post, and a private h-feed listing all of
+them, both behind an IndieAuth identity check against the allowlist #1567
+pushes to `SOCIAL_KV`.
+
+**The open question this design resolves:** how does a *visitor* prove "I am
+`https://alice.example/`" to this site? The decision record says "a visitor
+signs in with their own site (IndieAuth)". The site's already-shipped
+`/authorize` + `/token` endpoints (`worker.ts`'s `indieAuthHandler`) cannot do
+this — `approveAuthorization` unconditionally mints `me: `${baseUrl}/``
+gated on the *owner's* password (`worker.ts:904-914`); they are a
+single-tenant authorization server for the site's own owner (used today by
+Micropub/Microsub clients), not an identity provider for arbitrary visitors.
+Authenticating a visitor as themselves requires this Worker to act as an
+IndieAuth **relying party (client)** toward *the visitor's own site*:
+discover their authorization endpoint, redirect them there, handle the
+callback, verify the returned `me`. Nothing like this exists in the codebase
+today. This design specifies it, scoped as tightly as the protocol allows.
+
+## 2. Identity flow: scope-less "profile exchange", not an access token
+
+IndieAuth supports two shapes of code redemption:
+
+- **Access-token grant** (`scope` non-empty): redeemed at the `token_endpoint`,
+  DPoP-bound (mandatory in `@dwk/indieauth`'s own implementation,
+  `handler.ts:447-458`). This site never needs an access token for a
+  visitor's site — it only needs to know *who they are*, once, to start a
+  session.
+- **Profile-only exchange** (no `scope` requested): redeemed at the
+  `authorization_endpoint` itself, no DPoP, returns `{ me, profile? }`. This
+  is exactly `@dwk/indieauth`'s own `handleProfileExchange`
+  (`handler.ts:519-528`) — proof this flow is real and already supported
+  reciprocally by any site (including this one) built on `@dwk/indieauth`.
+
+This design always requests **no scope** and redeems at the
+**authorization endpoint**. This avoids building a DPoP proof *generator*
+(this codebase only ever verifies DPoP, never creates it) and avoids ever
+holding a token for another site — the only thing carried forward is a
+verified `me` string, immediately turned into our own session.
+
+Consequence: discovery only needs to find `authorization_endpoint` (not
+`token_endpoint`).
+
+## 3. Discovery: reuse `safeFetch`, hand-roll rel-link parsing
+
+`@dwk/webmention`'s `discoverEndpoint` (`discovery.ts`) is the exact template
+— fetch a user-supplied URL through the SSRF-safe wrapper, check the `Link`
+header, fall back to scanning `<link>`/`<a>` elements — but its `rel`
+matching, `parseLinkHeader`, and `scanElements` helpers live in
+`@dwk/webmention/src/html.ts`, which is not part of the package's public
+`exports` map (only `./dist/index.js` is), and the package's own
+`findWebmentionEndpoint` hardcodes the `webmention` rel. `@dwk/safe-fetch`'s
+`safeFetch` **is** public and is reused directly — no SSRF logic is
+reimplemented. The small (~60-line) rel-link/Link-header scanner is
+duplicated locally in `reader-discovery.ts`, the same call this repo already
+made for `post-type-discovery.ts`'s `slugify`/`randomSlug` (comment there:
+*"reimplemented here (not imported) because the package doesn't export its
+internal helpers"*). A follow-up to promote this scanner into `@dwk/safe-fetch`
+or a new shared package (it is genuinely generic, not Webmention-specific) is
+worth raising upstream separately — out of scope for this app-side issue.
+
+Only `rel="authorization_endpoint"` is discovered (§2). RFC 8414
+`/.well-known/oauth-authorization-server` metadata discovery (the modern
+alternative to rel-links) is not implemented in v1 — rel-link discovery has
+the widest existing IndieAuth ecosystem support and keeps this module small;
+metadata-based discovery is a reasonable follow-up if a real contact's site
+turns out to need it.
+
+## 4. Stateless flow: no new D1 table
+
+Both the in-flight "signing in" state and the finished session are carried as
+HMAC-signed, `base64url(payload).base64url(signature)` tokens — the exact
+pattern `worker.ts` already uses three times over (`ConsentGrant`,
+`SolidOidcConsentGrant`, and their `createXToken`/`verifyXToken` pairs), keyed
+off the same `TOKEN_SIGNING_KEY` via `deriveKey(secret, purpose)` (HKDF, one
+independent subkey per purpose). `base64url`/`decodeBase64url`/`deriveKey`
+are extracted from `worker.ts` into a new shared `token-signing.ts` (pure
+refactor, §6 Task 2) so the reader-auth modules can reuse them without
+duplicating security-sensitive crypto code.
+
+**Sign-in state token** (`reader-session.ts`, purpose
+`"reader-signin-state"`, 10-minute TTL) — round-trips through the visitor's
+authorization server as the OAuth `state` parameter, so no server-side
+pending-request storage is needed:
+
+```ts
+interface SigninState {
+  readonly v: 1;
+  readonly exp: number; // unix seconds
+  readonly me: string; // canonicalized claimed identity (input, unverified)
+  readonly redirectTo: string; // site-relative path to return to on success
+  readonly authorizationEndpoint: string; // discovered once; callback reuses it, no re-fetch
+  readonly verifier: string; // PKCE code_verifier
+}
+```
+
+**Reader session cookie** (`reader-session.ts`, purpose `"reader-session"`,
+30-day TTL, cookie name `__Host-anglesite_reader`):
+
+```ts
+interface ReaderSession {
+  readonly v: 1;
+  readonly exp: number;
+  readonly me: string; // normalized identity (reader-identity.ts's scheme-less form)
+}
+```
+
+`Set-Cookie: __Host-anglesite_reader=<token>; Path=/; Secure; HttpOnly; SameSite=Lax; Max-Age=2592000`.
+The `__Host-` prefix requires exactly this shape (`Secure`, `Path=/`, no
+`Domain`) and is a meaningful hardening: the browser refuses to honor the
+cookie from anywhere but this exact origin over HTTPS.
+
+**Known v1 limitation** (documented, not fixed here): a cookie is a fine
+credential for a browser but most feed readers cannot attach a custom cookie
+to a subscribed URL. A contact's browser session works immediately; getting
+their feed reader onto the private h-feed (§7) may need a follow-up (e.g. a
+per-contact bearer token/URL) if that turns out to matter in practice.
+
+## 5. Identity normalization: match `ContactStore.knownMeURLs()` exactly
+
+Per `docs/superpowers/specs/2026-08-18-contacts-allowlist-push-design.md`,
+`SOCIAL_KV` key `contacts:allowlist` holds a bare JSON array of
+`Contact.swift`'s `normalizedIdentityKey(for:)` output: lowercased host, path
+with any trailing slash trimmed, **scheme dropped entirely**:
+
+```swift
+func normalizedIdentityKey(for url: URL) -> String {
+    let host = (url.host ?? "").lowercased()
+    var path = url.path
+    if path.hasSuffix("/") { path.removeLast() }
+    return host + path
+}
+```
+
+`reader-identity.ts` ports this verbatim to TypeScript:
+
+```ts
+export function normalizeReaderIdentity(me: string): string {
+  const url = new URL(me);
+  const host = (url.hostname ?? "").toLowerCase();
+  let path = url.pathname;
+  if (path.endsWith("/")) path = path.slice(0, -1);
+  return host + path;
+}
+```
+
+(`url.hostname` — not `url.host`, which would include a non-default port;
+Swift's `URL.host` also excludes the port, so this keeps the two languages'
+outputs identical for a port-bearing `me`, an edge case neither side special-
+cases beyond matching each other.)
+
+The token/callback's verified `me` is always run through
+`canonicalizeProfileUrl` (from `@dwk/indieauth`, already imported elsewhere
+in `worker.ts`) first — guaranteeing a well-formed absolute URL with a
+non-empty path — before `normalizeReaderIdentity` reduces it to the
+allowlist-comparable key.
+
+## 6. The gate: 403 uniformly, scoped to plausible post URLs
+
+The Worker's `fetch()` already falls through to `env.ASSETS.fetch(request)`
+for anything not in `ROUTES` (`worker.ts:1944-1949` today). This is the first
+feature to serve post content dynamically (no existing precedent — confirmed
+by grep, `ROUTES` is exhaustively protocol endpoints). The gate hooks in
+exactly there: when the asset fetch 404s, `gated-content.ts`'s
+`handleGatedFallback` gets a chance to serve a restricted post instead of the
+asset 404.
+
+**No-existence-leak requirement** (from the issue): an unauthenticated or
+unauthorized visitor must not be able to tell "this restricted post exists"
+apart from "this URL is nothing at all". The gate resolves this by checking
+the session **before** ever touching the post store: any GET/HEAD request
+without a valid, allowlisted reader session gets an identical, static 403 —
+regardless of whether a post lives at that URL. Only a verified, allowlisted
+session proceeds to the D1 lookup, where a genuine miss still falls through
+to the ordinary plain-text 404 (safe, because the requester is already inside
+the trust boundary).
+
+To avoid turning *every* unrelated 404 on the site into a 403 for anonymous
+visitors (a real UX regression and its own faint signal — "this site has a
+private area" on every stray typo), the fallback only engages for paths
+**shaped like a post permalink**, matching exactly the two shapes
+`generatePostUrl` produces (`worker.ts:1063-1067`):
+
+```ts
+const SLUG = /^[a-z0-9-]{1,80}$/;
+const KNOWN_COLLECTIONS = new Set([
+  "notes", "articles", "photos", "albums",
+  "bookmarks", "likes", "replies", "events", "reviews",
+]);
+
+export function looksLikePostPermalink(pathname: string): boolean {
+  const segments = pathname.split("/").filter((s) => s.length > 0);
+  if (segments.length === 1) return SLUG.test(segments[0]!);
+  if (segments.length === 2) {
+    return KNOWN_COLLECTIONS.has(segments[0]!) && SLUG.test(segments[1]!);
+  }
+  return false;
+}
+```
+
+Any other 404'd path (asset extensions, deeper paths, uppercase, etc.) is
+untouched — `handleGatedFallback` returns `null` and the caller keeps the
+plain 404 exactly as today.
+
+```ts
+export async function handleGatedFallback(
+  request: Request,
+  env: Pick<WorkerEnv, "SOCIAL_KV" | "MICROPUB_DB" | "TOKEN_SIGNING_KEY">,
+  pathname: string,
+): Promise<Response | null> {
+  if (request.method !== "GET" && request.method !== "HEAD") return null;
+  if (!looksLikePostPermalink(pathname)) return null;
+  if (!env.MICROPUB_DB || !env.TOKEN_SIGNING_KEY) return null;
+
+  const me = await requireReaderSession(request, env);
+  if (me === null) return forbidden(request.method);
+
+  const store = createMicropubStore({ MICROPUB_DB: env.MICROPUB_DB });
+  const url = new URL(request.url);
+  const record = await store.getPost(`${url.origin}${pathname}`);
+  if (!record || record.deleted) return null;
+  if ((record.properties.visibility?.[0] ?? "public") !== "contacts") return null;
+
+  return renderGatedPermalink(record, url.origin, request.method);
+}
+```
+
+`forbidden()` is a static 403 (mirrors `notFound()`, `worker.ts:1867-1872`),
+plus one safe, non-leaking addition: a link to `/contacts/signin?redirect=<this
+request's own path>` — echoing the requester's *own* input back to them
+carries no information they don't already have, and gives a real person a way
+to actually sign in instead of a dead end.
+
+## 7. Private h-feed
+
+`GET /contacts/feed` — same gate (`requireReaderSession`, 403 uniformly on
+failure — a feed reader needs a stable non-interactive failure, so this route
+never redirects, only 200s or 403s). On success, lists all live posts with
+`visibility: contacts` via `MicropubStore.listPosts` with
+`filters.visibilities: ["contacts"]`, `order: "desc"`, and a fixed page size
+(50 — no pagination in v1; the decision record doesn't call for it and a
+contacts-only feed is not expected to need it soon), rendered as an h-feed.
+
+## 8. Rendering: minimal hand-rolled markup, not Astro parity
+
+`Hentry.astro`/`CollectionIndex.astro`/`Hcard.astro` are full Astro
+components (JSON-LD schema, cited-embed cards, licensing links, syndication
+links, webmention interactions UI) that cannot run outside the Astro build —
+there is no SSR adapter configured (confirmed: `env.ASSETS` serves a purely
+static build). Reproducing all of that from raw mf2 JSON inside the Worker is
+out of scope for this issue. `gated-content.ts` renders the **microformats2
+markup only** — the same class names, so a contact's feed reader parses it
+identically — reusing `worker.ts`'s existing `extractMf2ContentString` /
+`extractMf2Photos` (exported, not duplicated) and `escapeHTML`:
+
+- Permalink: `<article class="h-entry">` with `p-name` (from
+  `properties.name`), `e-content` (from `extractMf2ContentString`), `u-photo`
+  images (from `extractMf2Photos`), `u-url`/`dt-published`
+  (`properties.published`), `p-category` tags — mirroring `Hentry.astro`'s
+  structure (`layouts/Hentry.astro:83-118`) minus JSON-LD/embeds/licensing/
+  syndication/interactions.
+- Feed: `<div class="h-feed"><h1 class="p-name">...</h1><ul>...</ul></div>`
+  wrapping one abbreviated `h-entry` per post — mirroring
+  `CollectionIndex.astro:25-39`.
+
+Both responses set `cache-control: private, no-store` (contact-specific
+content must never be shared-cached) and the same restrictive
+`content-security-policy`/`referrer-policy`/`x-content-type-options` headers
+`consentPage()` already sets (`worker.ts:504-513`).
+
+## 9. New routes
+
+| Path | Methods | Purpose |
+|---|---|---|
+| `/contacts/signin` | GET | Render the sign-in form (no `me`), or start discovery + redirect (`me` present) |
+| `/contacts/callback` | GET | OAuth redirect target: redeem code, verify identity, check allowlist, set session cookie |
+| `/contacts/feed` | GET, HEAD | Private h-feed of all live `visibility: contacts` posts |
+
+No new `WorkerEnv` bindings — `SOCIAL_KV`, `MICROPUB_DB`, `AUTH_DB` (unused
+here), `TOKEN_SIGNING_KEY` all already exist. No `wrangler.toml`/
+`WorkerComposition.swift` changes. No `vitest.config.ts` binding changes —
+`MICROPUB_DB` and `SOCIAL_KV` are already in the Miniflare test bindings.
+
+## 10. Explicitly out of scope (this issue)
+
+- RFC 8414 metadata-based endpoint discovery (§3).
+- Non-cookie (e.g. bearer-token) access for feed-reader clients (§4).
+- Pagination on the private feed (§7).
+- JSON-LD / embeds / licensing / syndication / webmention-interactions parity
+  with the public Astro rendering (§8).
+- The allowlist push itself (#1567) and the composer visibility toggle
+  (#1566) — this issue only *reads* `contacts:allowlist` and `MICROPUB_DB`,
+  both already specified by their own issues.
+
+## 11. Files
+
+New, under `Resources/Template/worker/`: `token-signing.ts` (extracted from
+`worker.ts`), `reader-identity.ts`, `reader-discovery.ts`,
+`reader-session.ts`, `reader-auth.ts`, `gated-content.ts`, plus a `.test.ts`
+beside each. Modified: `worker.ts` (import the new modules, export
+`extractMf2ContentString`/`extractMf2Photos`, three new `ROUTES` entries, the
+asset-404 fallback hook), `worker.test.ts` (integration coverage for the new
+routes and fallback).


### PR DESCRIPTION
Closes #1568

## Summary

- Gated permalinks and a private h-feed for restricted (`visibility: contacts`) posts stored in `MICROPUB_DB`, served dynamically since they're never in the static build.
- A visitor authenticates by proving they own their own site: this Worker acts as an IndieAuth relying party (endpoint discovery via `@dwk/safe-fetch`, a scope-less "profile exchange" redemption — no DPoP, no access token — matching `@dwk/indieauth`'s own reciprocal `handleProfileExchange` flow), then checks the verified identity against the `contacts:allowlist` KV key #1567 pushes.
- Unauthenticated/unauthorized requests to a plausible post-permalink path get a uniform 403 *before* any store lookup, so no response difference can reveal which posts exist.
- Design doc: `docs/superpowers/specs/2026-08-18-worker-read-gate-design.md`.

New modules under `Resources/Template/worker/`: `token-signing.ts` (HMAC helpers extracted from `worker.ts`), `render-utils.ts` (`escapeHTML`/mf2 extraction, also extracted), `reader-identity.ts`, `reader-discovery.ts`, `reader-session.ts`, `reader-auth.ts`, `gated-content.ts` — each with its own test file. `worker.ts` gains three routes (`/contacts/signin`, `/contacts/callback`, `/contacts/feed`) and one hook into the existing asset-404 fallback branch. No new `WorkerEnv` bindings, no `wrangler.toml`/`WorkerComposition.swift`/`vitest.config.ts` changes — everything this issue needs (`SOCIAL_KV`, `MICROPUB_DB`, `TOKEN_SIGNING_KEY`) already exists.

Depends on #1567 (allowlist push) and #1566 (composer) for end-to-end function in production, but is independently testable/mergeable per the epic decision record (`docs/superpowers/specs/2026-08-18-audience-limited-posting-decisions.md` §3).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite-skills` (MCP sidecar server).

## Test plan

Template/Worker-only change — no Swift source files touched, so the app build/test checklist below doesn't apply as literally written; ran the actually-relevant commands instead:

- [x] `npm run test:worker` (`Resources/Template`) — 282/282 passing (9 files; 143 new tests added by this PR)
- [x] `npx tsc --noEmit -p tsconfig.json` (`Resources/Template`) — clean
- [x] `npx tsx --test "scripts/**/*.test.ts" "src/**/*.test.ts"` (`Resources/Template`) — 902/904 passing, 2 pre-existing skips, unaffected by this change
- [x] `swift test --package-path . --filter AnglesiteCoreTests.ActivityPubActorTests` and `--filter AnglesiteCoreTests.WorkerCompositionTests` — the two suites that read `worker.ts`'s content or its wrangler.toml generation — both pass (no coupling broken)
- [ ] Full `swift test --package-path .` / `xcodebuild ... build` — not run; no Swift files changed in this PR