### PR TITLE
feat(#1577): serve RFC 9728 oauth-protected-resource metadata

### DIFF
--- a/Resources/Template/worker/worker.test.ts
+++ b/Resources/Template/worker/worker.test.ts
@@ -384,6 +384,35 @@ test("IndieAuth metadata advertises the authorization and token endpoints", asyn
   });
 });
 
+test("RFC 9728 protected-resource metadata points agents at this site's own authorization server (#1577)", async () => {
+  const response = await fetchWorker(new Request("https://owner.example/.well-known/oauth-protected-resource"));
+  expect(response.status).toBe(200);
+  expect(response.headers.get("content-type")).toBe("application/json");
+  await expect(response.json()).resolves.toStrictEqual({
+    resource: "https://owner.example",
+    authorization_servers: ["https://owner.example"],
+    scopes_supported: ["create", "update", "delete", "media", "follow", "channels", "read"],
+    dpop_bound_access_tokens_required: true,
+    dpop_signing_alg_values_supported: ["ES256", "ES384", "RS256", "PS256"],
+  });
+});
+
+test("routing: protected-resource metadata rejects undeclared methods and mirrors HEAD", async () => {
+  const post = await fetchWorker(
+    new Request("https://owner.example/.well-known/oauth-protected-resource", { method: "POST" }),
+  );
+  expect(post.status).toBe(405);
+  expect(post.headers.get("allow")).toBe("GET, HEAD");
+
+  const get = await fetchWorker(new Request("https://owner.example/.well-known/oauth-protected-resource"));
+  const head = await fetchWorker(
+    new Request("https://owner.example/.well-known/oauth-protected-resource", { method: "HEAD" }),
+  );
+  expect(head.status).toBe(get.status);
+  expect(head.headers.get("content-type")).toBe(get.headers.get("content-type"));
+  expect(await head.text()).toBe("");
+});
+
 test("IndieAuth owner consent completes PKCE sign-in and issues a DPoP token", async () => {
   const verifier = "anglesite-indieauth-verifier-with-more-than-forty-three-characters";
   const challenge = await pkceChallenge(verifier);

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -867,6 +867,36 @@ function indieAuthHandler(request: Request, env: WorkerEnv) {
 }
 
 /**
+ * RFC 9728 OAuth 2.0 Protected Resource Metadata (#1577, slice 2 of the #1326 Agent Readiness
+ * ladder) — the resource-side counterpart to the RFC 8414 `/.well-known/oauth-authorization-server`
+ * document `indieAuthHandler` already serves. Points an agent at this site's own IndieAuth
+ * authorization server before it calls the IndieAuth-gated endpoints (Micropub, Microsub, the
+ * media endpoint).
+ *
+ * IndieAuth's endpoints are always live for every site (`AUTH_DB`/`TOKEN_SIGNING_KEY` are
+ * required, not optional, on `WorkerEnv`), so — like that document — this one is unconditional and
+ * needs no binding checks.
+ */
+function handleOAuthProtectedResourceMetadata(request: Request): Response {
+  const baseUrl = new URL(request.url).origin;
+  const metadata = {
+    resource: baseUrl,
+    authorization_servers: [baseUrl],
+    // Mirrors indieAuthHandler's scopesSupported — see its comment for why Micropub's and
+    // Microsub's scopes are both listed.
+    scopes_supported: ["create", "update", "delete", "media", "follow", "channels", "read"],
+    // `@dwk/indieauth` always issues DPoP-bound tokens (`token_type: "DPoP"`, never plain
+    // Bearer — see its metadata.ts), so bearer_methods_supported is omitted and these two fields
+    // mirror the algorithm list the authorization-server metadata document advertises.
+    dpop_bound_access_tokens_required: true,
+    dpop_signing_alg_values_supported: ["ES256", "ES384", "RS256", "PS256"],
+  };
+  return new Response(JSON.stringify(metadata), {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
  * Inbound-Webmention receive endpoint (V-3.1, #359).
  *
  * Composes `@dwk/webmention`'s receiver: a form-encoded `POST` of `source` + `target` is
@@ -1572,6 +1602,13 @@ export const ROUTES: readonly WorkerRoute[] = [
     match: "exact",
     methods: ["GET", "HEAD"],
     handler: (request, env, ctx) => indieAuthHandler(request, env)(request, env, ctx),
+  },
+  {
+    // RFC 9728 protected-resource metadata (#1577) — see handleOAuthProtectedResourceMetadata.
+    path: "/.well-known/oauth-protected-resource",
+    match: "exact",
+    methods: ["GET", "HEAD"],
+    handler: (request) => handleOAuthProtectedResourceMetadata(request),
   },
   {
     // GET renders/redirects the authorization request; POST redeems an authorization code for

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -835,16 +835,21 @@ function handleSolidPodGcScheduled(
   return gc(controller, env as unknown as SolidPodGcEnv, ctx);
 }
 
+/**
+ * Micropub's scopes ("create"/"update"/"delete"/"media") plus Microsub's ("follow"/"channels"/
+ * "read", V-4.3 #365) — @dwk/indieauth's constrainScopes drops any requested scope absent from
+ * this list, so a client authorizing for Microsub without "follow"/"channels" listed here would
+ * silently be granted an empty scope and then fail every Microsub action with
+ * `insufficient_scope`. Shared with the RFC 9728 protected-resource metadata (#1577) below so the
+ * two documents can't silently drift.
+ */
+const INDIEAUTH_SCOPES_SUPPORTED = ["create", "update", "delete", "media", "follow", "channels", "read"] as const;
+
 function indieAuthHandler(request: Request, env: WorkerEnv) {
   const baseUrl = new URL(request.url).origin;
   return createIndieAuth({
     baseUrl,
-    // Micropub's scopes ("create"/"update"/"delete"/"media") plus Microsub's ("follow"/
-    // "channels"/"read", V-4.3 #365) — @dwk/indieauth's constrainScopes drops any requested
-    // scope absent from this list, so a client authorizing for Microsub without "follow"/
-    // "channels" listed here would silently be granted an empty scope and then fail every
-    // Microsub action with `insufficient_scope`.
-    scopesSupported: ["create", "update", "delete", "media", "follow", "channels", "read"],
+    scopesSupported: INDIEAUTH_SCOPES_SUPPORTED,
     resourceIndicatorPolicy(resource) {
       try {
         return new URL(resource).origin === baseUrl;
@@ -882,9 +887,7 @@ function handleOAuthProtectedResourceMetadata(request: Request): Response {
   const metadata = {
     resource: baseUrl,
     authorization_servers: [baseUrl],
-    // Mirrors indieAuthHandler's scopesSupported — see its comment for why Micropub's and
-    // Microsub's scopes are both listed.
-    scopes_supported: ["create", "update", "delete", "media", "follow", "channels", "read"],
+    scopes_supported: INDIEAUTH_SCOPES_SUPPORTED,
     // `@dwk/indieauth` always issues DPoP-bound tokens (`token_type: "DPoP"`, never plain
     // Bearer — see its metadata.ts), so bearer_methods_supported is omitted and these two fields
     // mirror the algorithm list the authorization-server metadata document advertises.


### PR DESCRIPTION
Closes #1577

## Summary

- Adds `handleOAuthProtectedResourceMetadata` and a new `/.well-known/oauth-protected-resource` route in `Resources/Template/worker/worker.ts` — RFC 9728 OAuth 2.0 Protected Resource Metadata, the resource-side counterpart to the RFC 8414 `/.well-known/oauth-authorization-server` document `indieAuthHandler` already serves. It points an agent at the site's own IndieAuth authorization server before it calls the IndieAuth-gated endpoints (Micropub, Microsub, the media endpoint).
- Unconditional, like the RFC 8414 document — IndieAuth's `AUTH_DB`/`TOKEN_SIGNING_KEY` are required (not optional) on `WorkerEnv`, so every deployed site serves this.
- `dpop_bound_access_tokens_required`/`dpop_signing_alg_values_supported` are set (not `bearer_methods_supported`) because `@dwk/indieauth` always issues DPoP-bound tokens, never plain Bearer.
- Leaves `oauthProtectedResource.anglesiteProvides` as `false` in `Sources/AnglesiteCore/AgentReadinessReport.swift` — per #1326's established pattern (see #1489/#1491 for `linkHeaders`), that flip is a follow-up once a real deploy is checked against Cloudflare's live Agent Readiness scan.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Template changes are app-only (`Resources/Template/`) — no MCP schema change here.

## Test plan

- [x] `npm run test:worker` (Resources/Template) — 284/284 passing, including 2 new tests
- [x] `swift test --package-path .` — 601/601 passing
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [ ] Manual smoke (if UI-touching): N/A — no UI change