### PR TITLE
feat(#1570): forward /inbox submissions to the owner's email

### DIFF
--- a/Resources/Template/worker/worker.test.ts
+++ b/Resources/Template/worker/worker.test.ts
@@ -7,6 +7,7 @@ import {
   validateInboxFields,
   isRateLimited,
   handleInbox,
+  buildInboxForwardRaw,
   handleIndieAuthConsent,
   createConsentToken,
   verifyConsentToken,
@@ -145,6 +146,102 @@ test("handleInbox: 500s when INBOX_KV isn't bound", async () => {
   });
   const response = await handleInbox(request, {});
   expect(response.status).toBe(500);
+});
+
+function makeFakeSendEmail(): { send: (message: unknown) => Promise<void>; calls: unknown[] } {
+  const calls: unknown[] = [];
+  return {
+    calls,
+    async send(message: unknown) {
+      calls.push(message);
+    },
+  };
+}
+
+test("handleInbox: forwards to SEND_EMAIL when both it and INBOX_FORWARD_EMAIL are bound", async () => {
+  const kv = makeFakeKV();
+  const sendEmail = makeFakeSendEmail();
+  const request = new Request("https://my-site.example/inbox", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ subject: "Hello", from: "a@example.com", message: "Hi there" }),
+  });
+  const response = await handleInbox(request, {
+    INBOX_KV: kv,
+    SEND_EMAIL: sendEmail as never,
+    INBOX_FORWARD_EMAIL: "owner@example.com",
+  });
+  expect(response.status).toBe(202);
+  expect(sendEmail.calls.length).toBe(1);
+});
+
+test("handleInbox: still stages the submission and returns 202 when SEND_EMAIL.send rejects", async () => {
+  const kv = makeFakeKV();
+  const sendEmail = {
+    async send() {
+      throw new Error("destination address not verified");
+    },
+  };
+  const request = new Request("https://my-site.example/inbox", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ subject: "Hello", from: "a@example.com", message: "Hi there" }),
+  });
+  const response = await handleInbox(request, {
+    INBOX_KV: kv,
+    SEND_EMAIL: sendEmail as never,
+    INBOX_FORWARD_EMAIL: "owner@example.com",
+  });
+  expect(response.status).toBe(202);
+  const [, stagedRaw] = [...kv.store.entries()].find(([key]) => key.startsWith("inbox:"))!;
+  expect(JSON.parse(stagedRaw).subject).toBe("Hello");
+});
+
+test("handleInbox: does not call SEND_EMAIL.send when INBOX_FORWARD_EMAIL is unset", async () => {
+  const kv = makeFakeKV();
+  const sendEmail = makeFakeSendEmail();
+  const request = new Request("https://my-site.example/inbox", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ subject: "Hello", from: "a@example.com", message: "Hi there" }),
+  });
+  const response = await handleInbox(request, { INBOX_KV: kv, SEND_EMAIL: sendEmail as never });
+  expect(response.status).toBe(202);
+  expect(sendEmail.calls.length).toBe(0);
+});
+
+test("buildInboxForwardRaw: base64-encodes the subject header, so embedded CRLF can't inject a header", () => {
+  const raw = buildInboxForwardRaw("inbox@my-site.example", "owner@example.com", {
+    id: "abc-123",
+    receivedAt: "2026-08-18T00:00:00.000Z",
+    subject: "Hi\r\nBcc: attacker@evil.example",
+    from: "a@example.com",
+    message: "hello",
+  });
+  // The header/body boundary is the *first* blank line — split only there, not on every blank
+  // line the body itself may contain (the injected value's own CRLF creates one further down).
+  const headerEnd = raw.indexOf("\r\n\r\n");
+  const headerBlock = raw.slice(0, headerEnd);
+  const bodyBlock = raw.slice(headerEnd + 4);
+  expect(headerBlock).not.toContain("Bcc:");
+  expect(headerBlock).toMatch(/^Subject: =\?UTF-8\?B\?[A-Za-z0-9+/=]+\?=$/m);
+  // The raw, unencoded content only ever appears in the body, after the header/body separator.
+  expect(bodyBlock).toContain("Hi\r\nBcc: attacker@evil.example");
+});
+
+test("buildInboxForwardRaw: puts from/message in the body untouched and the recipient in To", () => {
+  const raw = buildInboxForwardRaw("inbox@my-site.example", "owner@example.com", {
+    id: "abc-123",
+    receivedAt: "2026-08-18T00:00:00.000Z",
+    subject: "Hello",
+    from: "a@example.com",
+    message: "Hi there",
+  });
+  expect(raw).toContain("To: <owner@example.com>");
+  expect(raw).toContain('From: "Site Inbox" <inbox@my-site.example>');
+  expect(raw).toContain("From: a@example.com");
+  expect(raw).toContain("Hi there");
+  expect(raw).toContain("Submission ID: abc-123");
 });
 
 function base64url(bytes: Uint8Array): string {

--- a/Resources/Template/worker/worker.test.ts
+++ b/Resources/Template/worker/worker.test.ts
@@ -244,6 +244,52 @@ test("buildInboxForwardRaw: puts from/message in the body untouched and the reci
   expect(raw).toContain("Submission ID: abc-123");
 });
 
+function decodeRfc2047(headerValue: string): string {
+  const words = [...headerValue.matchAll(/=\?UTF-8\?B\?([A-Za-z0-9+/=]+)\?=/g)].map((m) => m[1]!);
+  const bytes = words.flatMap((w) => [...atob(w)].map((c) => c.charCodeAt(0)));
+  return new TextDecoder().decode(new Uint8Array(bytes));
+}
+
+test("buildInboxForwardRaw: folds a near-MAX_SUBJECT_LENGTH subject into multiple RFC 2047 encoded-words, each within the 75-char cap", () => {
+  const longSubject = "x".repeat(200); // MAX_SUBJECT_LENGTH
+  const raw = buildInboxForwardRaw("inbox@my-site.example", "owner@example.com", {
+    id: "abc-123",
+    receivedAt: "2026-08-18T00:00:00.000Z",
+    subject: longSubject,
+    from: "a@example.com",
+    message: "hi",
+  });
+  const headerEnd = raw.indexOf("\r\n\r\n");
+  const headerBlock = raw.slice(0, headerEnd);
+  const subjectMatch = headerBlock.match(/Subject: ([\s\S]*?)\r\nMIME-Version:/);
+  expect(subjectMatch).not.toBeNull();
+  const subjectHeader = subjectMatch![1]!;
+  const lines = subjectHeader.split("\r\n ");
+  expect(lines.length).toBeGreaterThan(1);
+  for (const line of lines) {
+    expect(line.length).toBeLessThanOrEqual(75);
+    expect(line).toMatch(/^=\?UTF-8\?B\?[A-Za-z0-9+/=]+\?=$/);
+  }
+  expect(decodeRfc2047(subjectHeader)).toBe(`[Inbox] ${longSubject}`);
+});
+
+test("buildInboxForwardRaw: a multi-byte-character subject decodes correctly across an encoded-word fold boundary", () => {
+  // A run of 3-byte UTF-8 characters (each "🙂"-adjacent BMP emoji-free code point) long enough
+  // to straddle the 45-byte-per-word boundary, verifying the UTF-8 boundary backoff doesn't
+  // corrupt a character split across two words.
+  const longSubject = "café ".repeat(40); // each "é" is 2 bytes — forces non-ASCII byte splits
+  const raw = buildInboxForwardRaw("inbox@my-site.example", "owner@example.com", {
+    id: "abc-123",
+    receivedAt: "2026-08-18T00:00:00.000Z",
+    subject: longSubject,
+    from: "a@example.com",
+    message: "hi",
+  });
+  const headerEnd = raw.indexOf("\r\n\r\n");
+  const subjectMatch = raw.slice(0, headerEnd).match(/Subject: ([\s\S]*?)\r\nMIME-Version:/);
+  expect(decodeRfc2047(subjectMatch![1]!)).toBe(`[Inbox] ${longSubject}`);
+});
+
 function base64url(bytes: Uint8Array): string {
   let binary = "";
   for (const byte of bytes) binary += String.fromCharCode(byte);

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -68,6 +68,7 @@ import { base64url, decodeBase64url, deriveKey } from "./token-signing.ts";
 import { escapeHTML, extractMf2ContentString, extractMf2Photos, type ExtractedPhoto } from "./render-utils.ts";
 import { handleReaderCallback, handleReaderSignin } from "./reader-auth.ts";
 import { handleGatedFallback, handlePrivateFeed } from "./gated-content.ts";
+import { EmailMessage } from "cloudflare:email";
 
 /**
  * Per-site Cloudflare Worker entry point.
@@ -104,6 +105,18 @@ export interface WorkerEnv extends IndieAuthEnv {
   ASSETS?: Fetcher;
   INBOX_KV?: InboxKV;
   SOCIAL_KV?: InboxKV;
+  /**
+   * Owner-email forwarding for `/inbox` submissions (#1570, reconciling #587 with the
+   * email-as-DM decision) — additive to the `INBOX_KV` capture above, which stays the
+   * structured record. Both optional: a site whose owner hasn't run email setup
+   * (`EmailSetupPlanner`/`EmailSetupExecutor`) has neither bound, and `handleInbox` degrades to
+   * KV-only capture rather than throwing. `SEND_EMAIL`'s `destination_address` (see
+   * `WorkerComposition.generateWranglerToml`, Swift) restricts the binding to `INBOX_FORWARD_EMAIL`
+   * specifically — the Worker can't be made to send anywhere else even if this env were
+   * otherwise compromised.
+   */
+  SEND_EMAIL?: SendEmail;
+  INBOX_FORWARD_EMAIL?: string;
   INDIEAUTH_OWNER_PASSWORD: string;
   /**
    * Inbound-Webmention bindings (V-3.1, #359). All optional: a site that hasn't provisioned
@@ -1519,9 +1532,66 @@ async function parseRequestFields(request: Request): Promise<Record<string, stri
   return null;
 }
 
+/** RFC 2047 "B" (base64) encoded-word. Every byte of `value` round-trips through the base64
+ *  alphabet only, so an anonymous submitter's raw subject can never inject a CR/LF — or anything
+ *  else — into the header it's placed in, regardless of content (#1570). */
+function encodeMimeHeaderValue(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return `=?UTF-8?B?${btoa(binary)}?=`;
+}
+
+/** Builds the raw RFC 5322 message `forwardInboxSubmissionByEmail` hands to `EmailMessage`.
+ *  `submission.from`/`.message` are anonymous, unvalidated user input — they appear only in the
+ *  body (after the blank line separating headers from body), never in a header, so unlike
+ *  `.subject` they need no encoding: there's no header-injection surface for body content
+ *  regardless of what it contains. Exported for direct unit testing of that injection-safety
+ *  property. */
+export function buildInboxForwardRaw(
+  fromAddress: string,
+  toAddress: string,
+  submission: InboxFields & { id: string; receivedAt: string },
+): string {
+  const headers = [
+    `From: "Site Inbox" <${fromAddress}>`,
+    `To: <${toAddress}>`,
+    `Subject: ${encodeMimeHeaderValue(`[Inbox] ${submission.subject}`)}`,
+    "MIME-Version: 1.0",
+    'Content-Type: text/plain; charset="utf-8"',
+    "Content-Transfer-Encoding: 8bit",
+  ];
+  const body = [
+    "New /inbox submission — replies go directly to the sender, this address doesn't relay them.",
+    "",
+    `From: ${submission.from}`,
+    `Subject: ${submission.subject}`,
+    "",
+    submission.message,
+    "",
+    "—",
+    `Submission ID: ${submission.id}`,
+    `Received: ${submission.receivedAt}`,
+  ];
+  return `${headers.join("\r\n")}\r\n\r\n${body.join("\r\n")}\r\n`;
+}
+
+/** Best-effort — callers must swallow rejections; see `handleInbox`'s comment on why an email
+ *  failure must never affect the KV/git capture path. */
+async function forwardInboxSubmissionByEmail(
+  sendEmail: SendEmail,
+  toAddress: string,
+  siteHostname: string,
+  submission: InboxFields & { id: string; receivedAt: string },
+): Promise<void> {
+  const fromAddress = `inbox@${siteHostname}`;
+  const raw = buildInboxForwardRaw(fromAddress, toAddress, submission);
+  await sendEmail.send(new EmailMessage(fromAddress, toAddress, raw));
+}
+
 export async function handleInbox(
   request: Request,
-  env: Pick<WorkerEnv, "INBOX_KV">,
+  env: Pick<WorkerEnv, "INBOX_KV" | "SEND_EMAIL" | "INBOX_FORWARD_EMAIL">,
 ): Promise<Response> {
   if (request.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
   if (!env.INBOX_KV) return new Response("Inbox capture not configured", { status: 500 });
@@ -1548,6 +1618,21 @@ export async function handleInbox(
   const id = crypto.randomUUID();
   const submission = { id, ...validated, receivedAt: new Date().toISOString() };
   await env.INBOX_KV.put(`inbox:${id}`, JSON.stringify(submission));
+
+  // #1570: additionally forwards to the owner's email, reconciling #587 with the email-as-DM
+  // decision — KV above (→ git commit-back via `InboxSubmissionSync`) stays the structured
+  // record regardless of whether this succeeds. Best-effort only: a bounced/misconfigured
+  // destination address or an Email Routing binding that isn't fully verified yet must never
+  // roll back the KV write or turn a successfully captured submission into an error response.
+  if (env.SEND_EMAIL && env.INBOX_FORWARD_EMAIL) {
+    try {
+      await forwardInboxSubmissionByEmail(
+        env.SEND_EMAIL, env.INBOX_FORWARD_EMAIL, new URL(request.url).hostname, submission,
+      );
+    } catch (error) {
+      console.error("inbox: failed to forward submission by email", error);
+    }
+  }
 
   return new Response(null, { status: 202 });
 }

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -1532,14 +1532,35 @@ async function parseRequestFields(request: Request): Promise<Record<string, stri
   return null;
 }
 
-/** RFC 2047 "B" (base64) encoded-word. Every byte of `value` round-trips through the base64
- *  alphabet only, so an anonymous submitter's raw subject can never inject a CR/LF — or anything
- *  else — into the header it's placed in, regardless of content (#1570). */
+/** Max payload bytes per RFC 2047 "B" encoded-word: the spec caps a whole encoded-word
+ *  (`=?UTF-8?B?...?=`) at 75 characters. `"=?UTF-8?B?"` (10) + `"?="` (2) leaves 63 for the
+ *  base64 portion; 60 of those (a multiple of 4, so no padding) decode to exactly 45 bytes —
+ *  keeping each word at 72 characters, under the cap with room to spare. */
+const MAX_ENCODED_WORD_PAYLOAD_BYTES = 45;
+
+/** RFC 2047 "B" (base64) encoded-word(s), folded per RFC 2047 §2's 75-char-per-word cap (a
+ *  near-`MAX_SUBJECT_LENGTH` subject would otherwise produce one oversized word some strict
+ *  MTAs reject or mangle) — consecutive words separated only by folding whitespace (`\r\n `),
+ *  which RFC 2047 defines as insignificant between adjacent encoded-words, so decoders
+ *  reconstruct the original value across the fold. Every byte of `value` round-trips through
+ *  the base64 alphabet only, so an anonymous submitter's raw subject can never inject a CR/LF —
+ *  or anything else — into the header it's placed in, regardless of content (#1570). Each word's
+ *  payload ends on a UTF-8 character boundary so no chunk decodes to invalid UTF-8. */
 function encodeMimeHeaderValue(value: string): string {
   const bytes = new TextEncoder().encode(value);
-  let binary = "";
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return `=?UTF-8?B?${btoa(binary)}?=`;
+  const words: string[] = [];
+  let start = 0;
+  do {
+    let end = Math.min(start + MAX_ENCODED_WORD_PAYLOAD_BYTES, bytes.length);
+    // Back off while the next byte is a UTF-8 continuation byte (10xxxxxx) so a multi-byte
+    // character never splits across two encoded-words.
+    while (end < bytes.length && (bytes[end]! & 0xc0) === 0x80) end--;
+    let binary = "";
+    for (const byte of bytes.slice(start, end)) binary += String.fromCharCode(byte);
+    words.push(`=?UTF-8?B?${btoa(binary)}?=`);
+    start = end;
+  } while (start < bytes.length);
+  return words.join("\r\n ");
 }
 
 /** Builds the raw RFC 5322 message `forwardInboxSubmissionByEmail` hands to `EmailMessage`.

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -951,6 +951,11 @@ final class DeployModel {
         // the very next ordinary deploy — mirrors resolveIsHostedCommunity's declared-config read
         // just above.
         let runningExperiments = DeployCoordinator.resolveRunningExperiments(sourceDirectory: siteDirectory)
+        // #1570: reuses the owner's email address from EmailSetupPlanner/EmailSetupExecutor
+        // (already "in the stack") so /inbox submissions additionally forward there, alongside
+        // the existing KV→git capture — mirrors resolveRunningExperiments's identical
+        // declared-config read just above.
+        let inboxForwardEmail = DeployCoordinator.resolveInboxForwardEmail(sourceDirectory: siteDirectory)
         let provisionResult = await socialCommand.provision(
             siteID: siteID,
             siteDirectory: siteDirectory,
@@ -963,6 +968,7 @@ final class DeployModel {
             apUsername: apUsername,
             acknowledgesPaidPlan: acknowledgesPaidPlan,
             inboxCaptureEnabled: settings.inboxCaptureEnabled ?? false,
+            inboxForwardEmail: inboxForwardEmail,
             activityPubActorType: isHostedCommunity ? "Group" : nil,
             moderators: isHostedCommunity ? settings.moderators : nil,
             experiments: runningExperiments

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -367,6 +367,12 @@
     "Add Agent…" : {
 
     },
+    "Add Contact" : {
+
+    },
+    "Add Contact…" : {
+
+    },
     "Add DNS Records" : {
 
     },
@@ -428,6 +434,9 @@
 
     },
     "Add page ${name} to ${site}" : {
+
+    },
+    "Add people you know by their website address, or scan Contacts to find people you already follow." : {
 
     },
     "Add post ${title2} to ${site}" : {
@@ -1150,58 +1159,10 @@
     "Contacts" : {
 
     },
-    "Contacts…" : {
-
-    },
     "Contacts access wasn't granted." : {
 
     },
-    "Couldn't read your contacts" : {
-
-    },
-    "Couldn't scan Contacts" : {
-
-    },
-    "Find in Contacts…" : {
-
-    },
-    "Add Contact" : {
-
-    },
-    "Add Contact…" : {
-
-    },
-    "Edit Contact" : {
-
-    },
-    "No contacts yet" : {
-
-    },
-    "Open System Settings" : {
-
-    },
-    "Suggestions" : {
-
-    },
-    "Website (e.g. https://example.com)" : {
-
-    },
-    "^[%lld contact](inflect: true)" : {
-
-    },
-    "Use “%@” from Contacts for %@?" : {
-
-    },
-    "“%@” matches a follower — add as a contact?" : {
-
-    },
-    "Add people you know by their website address, or scan Contacts to find people you already follow." : {
-
-    },
-    "The contacts file may be damaged. Back it up, then remove Config/contacts.json to start fresh." : {
-
-    },
-    "Couldn't save your change" : {
+    "Contacts…" : {
 
     },
     "Contains slot-fill content — double-click to edit %@" : {
@@ -1338,6 +1299,9 @@
     "Couldn't read your Cloudflare API token: %@" : {
 
     },
+    "Couldn't read your contacts" : {
+
+    },
     "Couldn't run the check" : {
 
     },
@@ -1351,6 +1315,12 @@
 
     },
     "Couldn't save this change: %@" : {
+
+    },
+    "Couldn't save your change" : {
+
+    },
+    "Couldn't scan Contacts" : {
 
     },
     "Couldn't update this file — see the debug log for details." : {
@@ -1569,6 +1539,9 @@
     "ESI Fragments" : {
 
     },
+    "Edit Contact" : {
+
+    },
     "Edit Footer" : {
 
     },
@@ -1633,6 +1606,9 @@
 
     },
     "Enforce" : {
+
+    },
+    "Enter a valid email address." : {
 
     },
     "Enter a valid mail domain and at least one MX host to prepare the DNS records." : {
@@ -1776,6 +1752,9 @@
     "Find a community by keyword" : {
 
     },
+    "Find in Contacts…" : {
+
+    },
     "Find on local network" : {
 
     },
@@ -1828,6 +1807,9 @@
 
     },
     "Forward to Anglesite" : {
+
+    },
+    "Forward to email" : {
 
     },
     "Free during open beta: 100 instances, 20,000 queries/month, 500 crawled pages/day. Reader queries run on Cloudflare's AI models — beyond free limits, usage is billed by Cloudflare." : {
@@ -2410,6 +2392,9 @@
     "No component usage learned yet." : {
 
     },
+    "No contacts yet" : {
+
+    },
     "No content collections found." : {
 
     },
@@ -2611,6 +2596,9 @@
     "Open Source Acknowledgments…" : {
 
     },
+    "Open System Settings" : {
+
+    },
     "Open Website Anyway" : {
 
     },
@@ -2663,6 +2651,9 @@
 
     },
     "Optional" : {
+
+    },
+    "Optional — also sends each submission to this address by email. Leave blank to keep captures git-only." : {
 
     },
     "Optional: tls-reports@example.com" : {
@@ -3694,6 +3685,9 @@
     "Suggested fix: %@" : {
 
     },
+    "Suggestions" : {
+
+    },
     "Summarizing…" : {
 
     },
@@ -3749,6 +3743,9 @@
 
     },
     "The build produced no output." : {
+
+    },
+    "The contacts file may be damaged. Back it up, then remove Config/contacts.json to start fresh." : {
 
     },
     "The domain must be managed in Cloudflare. Your API token needs Zone DNS Edit, Zone Settings Edit, and WAF Edit permissions." : {
@@ -4025,6 +4022,9 @@
     "Use this domain as your Bluesky handle" : {
 
     },
+    "Use “%@” from Contacts for %@?" : {
+
+    },
     "Used to push backups and publish sites to GitHub over HTTPS (the sandboxed app can't run `git` or `gh`, so it pushes in-process with this token). Create a fine-grained token scoped to All repositories with Contents: Read and write and Administration: Read and write access (Administration is needed to create a new repo when publishing) at github.com/settings/tokens. Stored in the macOS Keychain under `io.dwk.anglesite` and never written to logs." : {
 
     },
@@ -4095,6 +4095,9 @@
 
     },
     "Website" : {
+
+    },
+    "Website (e.g. https://example.com)" : {
 
     },
     "Website Settings…" : {
@@ -4215,6 +4218,9 @@
 
     },
     "Zoom Out" : {
+
+    },
+    "^[%lld contact](inflect: true)" : {
 
     },
     "claude-code-acp" : {
@@ -4344,6 +4350,9 @@
           }
         }
       }
+    },
+    "“%@” matches a follower — add as a contact?" : {
+
     },
     "“%@” → “%@”" : {
       "localizations" : {

--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -160,6 +160,16 @@ final class PlistEditorModel {
     /// The most recently loaded `SiteSettings`, the base for toggle read-modify-write saves.
     private var workerSettings = SiteSettings()
 
+    /// The Inbox Capture section's "forward to email" text field (#1570) — pre-filled by
+    /// `loadWorkers()` from `DeployCoordinator.resolveInboxForwardEmail` (`anglesite.json`'s
+    /// `email.inboxForwardAddress`). Mutable, like `activityPubUsername`, so the Workers tab can
+    /// bind a `TextField` directly for live typing; `saveInboxForwardEmail(_:)` is the explicit
+    /// commit step. A dedicated field rather than reusing `email.dmarcReportEmail` — see that
+    /// field's doc comment (`DomainConfig.Email`) for why forwarding must be an explicit,
+    /// separate opt-in.
+    var inboxForwardEmail = ""
+    private(set) var inboxForwardEmailError: String?
+
     /// The ActivityPub handle text field's current value (#1239) — pre-filled with
     /// `DeployCoordinator.resolveEffectiveActivityPubUsername` (the `.site-config` `AP_USERNAME`
     /// override, or the hostname-derived default) by `loadWorkers()`. Mutable (like
@@ -1071,6 +1081,8 @@ final class PlistEditorModel {
         workerSettings = settings
         inboxCaptureEnabled = settings.inboxCaptureEnabled ?? false
         inboxCaptureNamespaceID = settings.provisionedWorkerResources?.inboxKVNamespaceID
+        inboxForwardEmail = DeployCoordinator.resolveInboxForwardEmail(sourceDirectory: sourceDirectory) ?? ""
+        inboxForwardEmailError = nil
         workerLastDeployedIDs = settings.lastDeployedWorkerIDs ?? []
         let catalog = await workerCatalogProvider()
         let snapshot = graphSnapshotProvider()
@@ -1213,6 +1225,28 @@ final class PlistEditorModel {
         workerSettings = settings
         inboxCaptureEnabled = true
         inboxCaptureError = nil
+    }
+
+    /// Persists the `/inbox` email-forwarding destination to `anglesite.json`'s
+    /// `email.inboxForwardAddress` (#1570) — a dedicated field the owner explicitly opts into
+    /// here, deliberately not reused from `email.dmarcReportEmail` (see `DomainConfig.Email`'s
+    /// doc comment). A blank value writes an explicit empty string (not simply omitting the
+    /// write) so it actually clears a previously-set address on disk —
+    /// `DomainConfigStore.save`'s merge only preserves keys the caller doesn't mention, so
+    /// turning forwarding back off has to write through, not just skip the write.
+    func saveInboxForwardEmail(_ newValue: String) {
+        let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty || trimmed.contains("@") else {
+            inboxForwardEmailError = String(localized: "Enter a valid email address.")
+            return
+        }
+        inboxForwardEmailError = nil
+        inboxForwardEmail = trimmed
+        DomainConfigStore.update(sourceDirectory: sourceDirectory) { config in
+            var email = config.email ?? DomainConfig.Email()
+            email.inboxForwardAddress = trimmed
+            config.email = email
+        }
     }
 
     /// Loads what the Social tab shows: persisted `SiteSettings` (for the Atmosphere toggle) and

--- a/Sources/AnglesiteApp/PlistEditorView.swift
+++ b/Sources/AnglesiteApp/PlistEditorView.swift
@@ -44,6 +44,7 @@ struct PlistEditorView: View {
     @FocusState private var titleFocused: Bool
     @FocusState private var languageFocused: Bool
     @FocusState private var activityPubUsernameFocused: Bool
+    @FocusState private var inboxForwardEmailFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -1031,6 +1032,32 @@ struct PlistEditorView: View {
                 Label(inboxCaptureError, systemImage: "exclamationmark.triangle.fill")
                     .foregroundStyle(.orange)
                     .font(.callout)
+            }
+            if model.inboxCaptureEnabled {
+                Divider()
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Forward to email")
+                        .font(.callout)
+                    TextField("owner@example.com", text: $model.inboxForwardEmail)
+                        .textFieldStyle(.roundedBorder)
+                        .focused($inboxForwardEmailFocused)
+                        .onSubmit { model.saveInboxForwardEmail(model.inboxForwardEmail) }
+                        .onChange(of: inboxForwardEmailFocused) { wasFocused, isFocused in
+                            if wasFocused, !isFocused {
+                                model.saveInboxForwardEmail(model.inboxForwardEmail)
+                            }
+                        }
+                        .frame(minWidth: 240)
+                    if let inboxForwardEmailError = model.inboxForwardEmailError {
+                        Text(inboxForwardEmailError)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                    Text("Optional — also sends each submission to this address by email. Leave blank to keep captures git-only.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
         }
     }

--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -259,6 +259,20 @@ public enum DeployCoordinator {
         return (domainConfig.experiments?.active ?? []).filter { $0.status == "running" }
     }
 
+    /// The owner's email address (#1570) for `WorkerComposition`'s `inboxForwardEmail` —
+    /// `Source/anglesite.json`'s `email.dmarcReportEmail`, the same address `EmailSetupPlanner`/
+    /// `EmailSetupExecutor` already persisted there when the owner ran email setup (reconciling
+    /// #587 with the email-as-DM decision: reusing what's "already in the stack" rather than
+    /// inventing a second owner-email field). `nil` when email setup was never run, mirroring
+    /// `resolveRunningExperiments`'s "read the declared config, default to the inert case on any
+    /// failure" shape — `WorkerComposition.generateWranglerToml` then omits the `[[send_email]]`
+    /// binding entirely and `/inbox` capture stays KV/git-only.
+    public static func resolveInboxForwardEmail(sourceDirectory: URL) -> String? {
+        let domainConfig = (try? DomainConfigStore(sourceDirectory: sourceDirectory).load()) ?? DomainConfig()
+        let email = domainConfig.email?.dmarcReportEmail?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (email?.isEmpty ?? true) ? nil : email
+    }
+
     /// The site's best-known public URL for `WorkerComposition`'s `SITE_URL` var (#359) — the
     /// address the composed Worker uses for its own outbound requests, e.g. `CommunityMembershipClient`'s
     /// ActivityPub actor ID and outbox (#1085). The workers.dev host `DeployCommand.persistSiteURL`

--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -260,16 +260,16 @@ public enum DeployCoordinator {
     }
 
     /// The owner's email address (#1570) for `WorkerComposition`'s `inboxForwardEmail` —
-    /// `Source/anglesite.json`'s `email.dmarcReportEmail`, the same address `EmailSetupPlanner`/
-    /// `EmailSetupExecutor` already persisted there when the owner ran email setup (reconciling
-    /// #587 with the email-as-DM decision: reusing what's "already in the stack" rather than
-    /// inventing a second owner-email field). `nil` when email setup was never run, mirroring
-    /// `resolveRunningExperiments`'s "read the declared config, default to the inert case on any
-    /// failure" shape — `WorkerComposition.generateWranglerToml` then omits the `[[send_email]]`
-    /// binding entirely and `/inbox` capture stays KV/git-only.
+    /// `Source/anglesite.json`'s `email.inboxForwardAddress`, a dedicated field
+    /// `PlistEditorModel.saveInboxForwardEmail` writes from the Workers tab's Inbox Capture
+    /// section, deliberately distinct from `email.dmarcReportEmail` (see that field's doc
+    /// comment for why reusing it would be a silent behavior change). `nil` until the owner
+    /// explicitly opts in, mirroring `resolveRunningExperiments`'s "read the declared config,
+    /// default to the inert case on any failure" shape — `WorkerComposition.generateWranglerToml`
+    /// then omits the `[[send_email]]` binding entirely and `/inbox` capture stays KV/git-only.
     public static func resolveInboxForwardEmail(sourceDirectory: URL) -> String? {
         let domainConfig = (try? DomainConfigStore(sourceDirectory: sourceDirectory).load()) ?? DomainConfig()
-        let email = domainConfig.email?.dmarcReportEmail?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let email = domainConfig.email?.inboxForwardAddress?.trimmingCharacters(in: .whitespacesAndNewlines)
         return (email?.isEmpty ?? true) ? nil : email
     }
 

--- a/Sources/AnglesiteCore/DomainConfig.swift
+++ b/Sources/AnglesiteCore/DomainConfig.swift
@@ -169,10 +169,21 @@ public struct DomainConfig: Equatable, Sendable {
     public struct Email: Codable, Equatable, Sendable {
         public var provider: String?
         public var dmarcReportEmail: String?
+        /// The owner's email address for `/inbox` forwarding (#1570, `WorkerComposition`'s
+        /// `inboxForwardEmail`) — deliberately a separate field from `dmarcReportEmail` rather
+        /// than reusing it: a DMARC aggregate-report mailbox is often monitored differently
+        /// (automated tooling, a different person) than where the owner wants forwarded visitor
+        /// contact messages to land, and defaulting one from the other would be a silent
+        /// behavior change for any site that already had `dmarcReportEmail` set for its original
+        /// purpose. `nil` (the default) means "no forwarding configured" even when
+        /// `dmarcReportEmail` is set — `PlistEditorModel.saveInboxForwardEmail` is the only
+        /// writer, so forwarding only ever turns on when the owner explicitly opts in.
+        public var inboxForwardAddress: String?
 
-        public init(provider: String? = nil, dmarcReportEmail: String? = nil) {
+        public init(provider: String? = nil, dmarcReportEmail: String? = nil, inboxForwardAddress: String? = nil) {
             self.provider = provider
             self.dmarcReportEmail = dmarcReportEmail
+            self.inboxForwardAddress = inboxForwardAddress
         }
     }
 

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -198,6 +198,12 @@ public actor SocialWorkerProvisionCommand {
         /// existing caller's behavior unchanged — the KV namespace is created (or, if
         /// `knownResources`/a prior `wrangler.toml` already has one, reused) only when `true`.
         inboxCaptureEnabled: Bool = false,
+        /// The owner's email address (`DeployCoordinator.resolveInboxForwardEmail`, #1570) that
+        /// `/inbox` submissions additionally forward to, alongside the existing KV→git capture.
+        /// Forwarded verbatim to `WorkerComposition.generateWranglerToml`, which already ignores
+        /// it unless `inboxCaptureEnabled` is `true` and omits the `[[send_email]]` binding for
+        /// an implausible value. `nil` (the default) matches every existing caller unchanged.
+        inboxForwardEmail: String? = nil,
         /// This site's ActivityPub actor type (V-5.1b, #907; `SiteSettings`'s sibling concept
         /// to `communityActorURL`) — `"Group"` for a hosted community, `nil` for an ordinary
         /// Person actor. Forwarded verbatim to `WorkerComposition.generateWranglerToml`, which
@@ -281,7 +287,7 @@ public actor SocialWorkerProvisionCommand {
                     return .failed(reason: "wrangler created D1 database \(name) but no database id was found", exitCode: 0, resources: resources)
                 }
                 resources.d1DatabaseID = id
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, activityPubActorType: activityPubActorType, moderators: moderators, experiments: experiments) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, inboxForwardEmail: inboxForwardEmail, activityPubActorType: activityPubActorType, moderators: moderators, experiments: experiments) {
                     return failure
                 }
             }
@@ -308,7 +314,7 @@ public actor SocialWorkerProvisionCommand {
                     return .failed(reason: "wrangler created KV namespace \(name) but no namespace id was found", exitCode: 0, resources: resources)
                 }
                 resources.kvNamespaceID = id
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, activityPubActorType: activityPubActorType, moderators: moderators, experiments: experiments) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, inboxForwardEmail: inboxForwardEmail, activityPubActorType: activityPubActorType, moderators: moderators, experiments: experiments) {
                     return failure
                 }
             }
@@ -328,7 +334,7 @@ public actor SocialWorkerProvisionCommand {
                     return failure
                 }
                 resources.r2BucketName = name
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, activityPubActorType: activityPubActorType, moderators: moderators, experiments: experiments) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, inboxForwardEmail: inboxForwardEmail, activityPubActorType: activityPubActorType, moderators: moderators, experiments: experiments) {
                     return failure
                 }
             }
@@ -351,7 +357,7 @@ public actor SocialWorkerProvisionCommand {
                     return failure
                 }
                 resources.podBlobsR2BucketName = name
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, activityPubActorType: activityPubActorType, moderators: moderators, experiments: experiments) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, inboxForwardEmail: inboxForwardEmail, activityPubActorType: activityPubActorType, moderators: moderators, experiments: experiments) {
                     return failure
                 }
             }
@@ -390,7 +396,7 @@ public actor SocialWorkerProvisionCommand {
             if resources.inboxAccountID == nil {
                 resources.inboxAccountID = await accountIDSource(token)
             }
-            if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, inboxCaptureEnabled: inboxCaptureEnabled, activityPubActorType: activityPubActorType, moderators: moderators, experiments: experiments) {
+            if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, inboxCaptureEnabled: inboxCaptureEnabled, inboxForwardEmail: inboxForwardEmail, activityPubActorType: activityPubActorType, moderators: moderators, experiments: experiments) {
                 return failure
             }
         }
@@ -403,7 +409,7 @@ public actor SocialWorkerProvisionCommand {
             // `wrangler secret put` (below) resolves the Worker's project name from
             // wrangler.toml in the working directory — persist it here first so that lookup
             // succeeds even on an ActivityPub-only first deploy.
-            if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, activityPubActorType: activityPubActorType, moderators: moderators, experiments: experiments) {
+            if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, inboxForwardEmail: inboxForwardEmail, activityPubActorType: activityPubActorType, moderators: moderators, experiments: experiments) {
                 return failure
             }
             let keys: ActivityPubKeyProvisioning.Secrets
@@ -498,6 +504,7 @@ public actor SocialWorkerProvisionCommand {
                 routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName,
                 apUsername: apUsername,
                 inboxCaptureEnabled: inboxCaptureEnabled,
+                inboxForwardEmail: inboxForwardEmail,
                 activityPubActorType: activityPubActorType, moderators: moderators,
                 experiments: experiments
             ) {
@@ -525,6 +532,7 @@ public actor SocialWorkerProvisionCommand {
                 routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName,
                 apUsername: apUsername,
                 inboxCaptureEnabled: inboxCaptureEnabled,
+                inboxForwardEmail: inboxForwardEmail,
                 activityPubActorType: activityPubActorType, moderators: moderators,
                 experiments: experiments
             ) {
@@ -552,6 +560,7 @@ public actor SocialWorkerProvisionCommand {
                 routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName,
                 apUsername: apUsername,
                 inboxCaptureEnabled: inboxCaptureEnabled,
+                inboxForwardEmail: inboxForwardEmail,
                 activityPubActorType: activityPubActorType, moderators: moderators,
                 experiments: experiments
             ) {
@@ -559,7 +568,7 @@ public actor SocialWorkerProvisionCommand {
             }
         }
 
-        if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, activityPubActorType: activityPubActorType, moderators: moderators, experiments: experiments) {
+        if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, inboxForwardEmail: inboxForwardEmail, activityPubActorType: activityPubActorType, moderators: moderators, experiments: experiments) {
             return failure
         }
 
@@ -648,6 +657,7 @@ public actor SocialWorkerProvisionCommand {
         displayName: String? = nil,
         apUsername: String? = nil,
         inboxCaptureEnabled: Bool = false,
+        inboxForwardEmail: String? = nil,
         activityPubActorType: String? = nil,
         moderators: [String]? = nil,
         experiments: [DomainConfig.Experiments.Experiment] = []
@@ -660,6 +670,7 @@ public actor SocialWorkerProvisionCommand {
                 resources: resources,
                 inboxCaptureEnabled: inboxCaptureEnabled,
                 inboxKVNamespaceID: resources.inboxKVNamespaceID,
+                inboxForwardEmail: inboxForwardEmail,
                 siteURL: siteURL,
                 displayName: displayName,
                 activityPubActorType: activityPubActorType,

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -182,6 +182,15 @@ public enum WorkerComposition {
     ///     `inboxCaptureEnabled` is `true` — if `nil` or empty, the emitted
     ///     `[[kv_namespaces]]` block gets a placeholder empty `id` for provisioning to fill in
     ///     later, rather than throwing.
+    ///   - inboxForwardEmail: The owner's email address (`DomainConfig.Email.dmarcReportEmail`,
+    ///     already captured by `EmailSetupPlanner`/`EmailSetupExecutor`) that `/inbox`
+    ///     submissions should additionally forward to (#1570, reconciling #587 with the
+    ///     email-as-DM decision) — the KV→git commit-back pipeline stays the structured record;
+    ///     this is purely additive. Ignored unless `inboxCaptureEnabled` is `true`. `nil`, empty,
+    ///     or a value that fails `isSafeTomlStringValue`/contains no `"@"` omits both the
+    ///     `[[send_email]]` binding and the `INBOX_FORWARD_EMAIL` var entirely — the composed
+    ///     Worker's `handleInbox` degrades to KV-only capture without either bound
+    ///     (`worker.ts`'s concern, not this function's).
     ///   - siteURL: The site's public URL, threaded into the composed Worker's config.
     ///   - displayName: The site's display name (`SiteSettings.displayName`, already falling back
     ///     to the site name by the time a caller passes it in — this function stays pure and does
@@ -223,6 +232,7 @@ public enum WorkerComposition {
         resources: ProvisionedResources = .init(),
         inboxCaptureEnabled: Bool = false,
         inboxKVNamespaceID: String? = nil,
+        inboxForwardEmail: String? = nil,
         siteURL: String? = nil,
         displayName: String? = nil,
         activityPubActorType: String? = nil,
@@ -571,6 +581,21 @@ public enum WorkerComposition {
             }
         }
 
+        // #1570: /inbox submissions additionally forward to the owner's email — restricted to a
+        // single `destination_address` (rather than left open) so the binding can never be used
+        // to send anywhere but the owner's own configured address, verified separately via
+        // Cloudflare Email Routing. `INBOX_FORWARD_EMAIL` below carries the same address into the
+        // Worker as a var, since `EmailMessage`'s `to` must match it exactly at request time
+        // (worker.ts's concern, not this function's).
+        let hasInboxForwarding = inboxCaptureEnabled
+            && (inboxForwardEmail.map(isPlausibleEmailAddress) ?? false)
+        if hasInboxForwarding, let inboxForwardEmail {
+            lines.append("")
+            lines.append("[[send_email]]")
+            lines.append("name = \"SEND_EMAIL\"")
+            lines.append("destination_address = \"\(inboxForwardEmail)\"")
+        }
+
         var varsLines: [String] = []
         // SITE_URL: the canonical origin the queue consumers key on — Webmention's verifier
         // scopes accepted targets with it, WebSub's consumer derives its topic URLs from it, and
@@ -604,6 +629,13 @@ public enum WorkerComposition {
             if !safeModerators.isEmpty {
                 varsLines.append("AP_MODERATORS = \"\(safeModerators.joined(separator: ","))\"")
             }
+        }
+        // INBOX_FORWARD_EMAIL (#1570): the same address as the `[[send_email]]` block's
+        // `destination_address` above, threaded as a var too because `EmailMessage`'s `to`
+        // argument is a runtime value the Worker must supply itself — Wrangler only *authorizes*
+        // the binding to send to this one address, it doesn't supply the recipient implicitly.
+        if hasInboxForwarding, let inboxForwardEmail {
+            varsLines.append("INBOX_FORWARD_EMAIL = \"\(inboxForwardEmail)\"")
         }
         if !varsLines.isEmpty {
             lines.append("")
@@ -656,5 +688,18 @@ public enum WorkerComposition {
     static func isSafeTomlStringValue(_ value: String) -> Bool {
         !value.contains("\"") && !value.contains("\\")
             && !value.unicodeScalars.contains(where: { $0.value < 0x20 || $0.value == 0x7F })
+    }
+
+    /// A light plausibility check for `inboxForwardEmail` — not RFC 5322 validation (nothing
+    /// else in this file validates `.site-config`-sourced strings that deeply either, see
+    /// `resolveActivityPubUsername`'s doc comment for the precedent), just enough to keep an
+    /// obviously-wrong value out of the generated `destination_address`: non-empty, contains
+    /// exactly one `@` with content on both sides, no whitespace, and safe to interpolate per
+    /// `isSafeTomlStringValue`. An implausible value degrades to omitting both the
+    /// `[[send_email]]` binding and `INBOX_FORWARD_EMAIL` var, same as `nil`.
+    static func isPlausibleEmailAddress(_ value: String) -> Bool {
+        guard isSafeTomlStringValue(value), !value.contains(where: \.isWhitespace) else { return false }
+        let parts = value.split(separator: "@", omittingEmptySubsequences: false)
+        return parts.count == 2 && !parts[0].isEmpty && !parts[1].isEmpty
     }
 }

--- a/Tests/AnglesiteAppTests/PlistEditorModelInboxCaptureTests.swift
+++ b/Tests/AnglesiteAppTests/PlistEditorModelInboxCaptureTests.swift
@@ -151,4 +151,62 @@ struct PlistEditorModelInboxCaptureTests {
         #expect(fixture.model.inboxCaptureEnabled == false)
         #expect(fixture.model.inboxCaptureError != nil)
     }
+
+    // MARK: - inboxForwardEmail (#1570)
+
+    @Test("loadWorkers pre-fills inboxForwardEmail from anglesite.json's email.inboxForwardAddress")
+    func loadWorkersPreFillsForwardEmail() async throws {
+        let fixture = try await makeFixture()
+        try DomainConfigStore(sourceDirectory: fixture.model.sourceDirectory).save(
+            DomainConfig(email: .init(inboxForwardAddress: "owner@example.com")))
+
+        await fixture.model.loadWorkers()
+
+        #expect(fixture.model.inboxForwardEmail == "owner@example.com")
+    }
+
+    @Test("saveInboxForwardEmail trims and persists a valid address without disturbing dmarcReportEmail")
+    func saveInboxForwardEmailPersists() async throws {
+        let fixture = try await makeFixture()
+        try DomainConfigStore(sourceDirectory: fixture.model.sourceDirectory).save(
+            DomainConfig(email: .init(provider: "fastmail", dmarcReportEmail: "dmarc@example.com")))
+        await fixture.model.loadWorkers()
+
+        fixture.model.saveInboxForwardEmail("  owner@example.com  ")
+
+        #expect(fixture.model.inboxForwardEmail == "owner@example.com")
+        #expect(fixture.model.inboxForwardEmailError == nil)
+        let saved = try DomainConfigStore(sourceDirectory: fixture.model.sourceDirectory).load()
+        #expect(saved.email?.inboxForwardAddress == "owner@example.com")
+        #expect(saved.email?.dmarcReportEmail == "dmarc@example.com")
+        #expect(saved.email?.provider == "fastmail")
+    }
+
+    @Test("saveInboxForwardEmail rejects a value with no @ and leaves the prior address on disk")
+    func saveInboxForwardEmailRejectsInvalid() async throws {
+        let fixture = try await makeFixture()
+        try DomainConfigStore(sourceDirectory: fixture.model.sourceDirectory).save(
+            DomainConfig(email: .init(inboxForwardAddress: "owner@example.com")))
+        await fixture.model.loadWorkers()
+
+        fixture.model.saveInboxForwardEmail("not-an-email")
+
+        #expect(fixture.model.inboxForwardEmailError != nil)
+        let saved = try DomainConfigStore(sourceDirectory: fixture.model.sourceDirectory).load()
+        #expect(saved.email?.inboxForwardAddress == "owner@example.com")
+    }
+
+    @Test("saveInboxForwardEmail with a blank value clears a previously-set address")
+    func saveInboxForwardEmailClears() async throws {
+        let fixture = try await makeFixture()
+        try DomainConfigStore(sourceDirectory: fixture.model.sourceDirectory).save(
+            DomainConfig(email: .init(inboxForwardAddress: "owner@example.com")))
+        await fixture.model.loadWorkers()
+
+        fixture.model.saveInboxForwardEmail("   ")
+
+        #expect(fixture.model.inboxForwardEmail == "")
+        #expect(fixture.model.inboxForwardEmailError == nil)
+        #expect(DeployCoordinator.resolveInboxForwardEmail(sourceDirectory: fixture.model.sourceDirectory) == nil)
+    }
 }

--- a/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
@@ -186,6 +186,42 @@ struct DeployCoordinatorTests {
         #expect(DeployCoordinator.resolveRunningExperiments(sourceDirectory: dir).isEmpty)
     }
 
+    // MARK: - resolveInboxForwardEmail (#1570)
+
+    @Test("resolveInboxForwardEmail reads email.dmarcReportEmail from anglesite.json")
+    func resolveInboxForwardEmailReadsDmarcReportEmail() throws {
+        let dir = try temporaryDirectory()
+        let store = DomainConfigStore(sourceDirectory: dir)
+        try store.save(DomainConfig(email: .init(provider: "fastmail", dmarcReportEmail: "owner@example.com")))
+        #expect(DeployCoordinator.resolveInboxForwardEmail(sourceDirectory: dir) == "owner@example.com")
+    }
+
+    @Test("resolveInboxForwardEmail is nil with no anglesite.json at all")
+    func resolveInboxForwardEmailNilByDefault() throws {
+        let dir = try temporaryDirectory()
+        #expect(DeployCoordinator.resolveInboxForwardEmail(sourceDirectory: dir) == nil)
+    }
+
+    @Test("resolveInboxForwardEmail is nil when email setup was run but no report address was set")
+    func resolveInboxForwardEmailNilWithoutReportAddress() throws {
+        let dir = try temporaryDirectory()
+        let store = DomainConfigStore(sourceDirectory: dir)
+        try store.save(DomainConfig(email: .init(provider: "fastmail", dmarcReportEmail: nil)))
+        #expect(DeployCoordinator.resolveInboxForwardEmail(sourceDirectory: dir) == nil)
+    }
+
+    @Test("resolveInboxForwardEmail trims whitespace and treats an all-whitespace value as nil")
+    func resolveInboxForwardEmailTrimsWhitespace() throws {
+        let dir = try temporaryDirectory()
+        let store = DomainConfigStore(sourceDirectory: dir)
+        try store.save(DomainConfig(email: .init(dmarcReportEmail: "  owner@example.com  ")))
+        #expect(DeployCoordinator.resolveInboxForwardEmail(sourceDirectory: dir) == "owner@example.com")
+
+        let dir2 = try temporaryDirectory()
+        try DomainConfigStore(sourceDirectory: dir2).save(DomainConfig(email: .init(dmarcReportEmail: "   ")))
+        #expect(DeployCoordinator.resolveInboxForwardEmail(sourceDirectory: dir2) == nil)
+    }
+
     // MARK: - deployLogSources
 
     @Test("deployLogSources includes worker-provision:<siteID> so SocialWorkerProvisionCommand's wrangler output reaches the drawer")

--- a/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
@@ -188,11 +188,11 @@ struct DeployCoordinatorTests {
 
     // MARK: - resolveInboxForwardEmail (#1570)
 
-    @Test("resolveInboxForwardEmail reads email.dmarcReportEmail from anglesite.json")
-    func resolveInboxForwardEmailReadsDmarcReportEmail() throws {
+    @Test("resolveInboxForwardEmail reads email.inboxForwardAddress from anglesite.json")
+    func resolveInboxForwardEmailReadsInboxForwardAddress() throws {
         let dir = try temporaryDirectory()
         let store = DomainConfigStore(sourceDirectory: dir)
-        try store.save(DomainConfig(email: .init(provider: "fastmail", dmarcReportEmail: "owner@example.com")))
+        try store.save(DomainConfig(email: .init(provider: "fastmail", inboxForwardAddress: "owner@example.com")))
         #expect(DeployCoordinator.resolveInboxForwardEmail(sourceDirectory: dir) == "owner@example.com")
     }
 
@@ -202,11 +202,19 @@ struct DeployCoordinatorTests {
         #expect(DeployCoordinator.resolveInboxForwardEmail(sourceDirectory: dir) == nil)
     }
 
-    @Test("resolveInboxForwardEmail is nil when email setup was run but no report address was set")
-    func resolveInboxForwardEmailNilWithoutReportAddress() throws {
+    @Test("resolveInboxForwardEmail is nil when a dmarcReportEmail is set but no inboxForwardAddress was — reusing one for the other would be a silent behavior change")
+    func resolveInboxForwardEmailIgnoresDmarcReportEmail() throws {
         let dir = try temporaryDirectory()
         let store = DomainConfigStore(sourceDirectory: dir)
-        try store.save(DomainConfig(email: .init(provider: "fastmail", dmarcReportEmail: nil)))
+        try store.save(DomainConfig(email: .init(provider: "fastmail", dmarcReportEmail: "dmarc@example.com")))
+        #expect(DeployCoordinator.resolveInboxForwardEmail(sourceDirectory: dir) == nil)
+    }
+
+    @Test("resolveInboxForwardEmail is nil when email setup was run but no forward address was set")
+    func resolveInboxForwardEmailNilWithoutForwardAddress() throws {
+        let dir = try temporaryDirectory()
+        let store = DomainConfigStore(sourceDirectory: dir)
+        try store.save(DomainConfig(email: .init(provider: "fastmail", inboxForwardAddress: nil)))
         #expect(DeployCoordinator.resolveInboxForwardEmail(sourceDirectory: dir) == nil)
     }
 
@@ -214,11 +222,11 @@ struct DeployCoordinatorTests {
     func resolveInboxForwardEmailTrimsWhitespace() throws {
         let dir = try temporaryDirectory()
         let store = DomainConfigStore(sourceDirectory: dir)
-        try store.save(DomainConfig(email: .init(dmarcReportEmail: "  owner@example.com  ")))
+        try store.save(DomainConfig(email: .init(inboxForwardAddress: "  owner@example.com  ")))
         #expect(DeployCoordinator.resolveInboxForwardEmail(sourceDirectory: dir) == "owner@example.com")
 
         let dir2 = try temporaryDirectory()
-        try DomainConfigStore(sourceDirectory: dir2).save(DomainConfig(email: .init(dmarcReportEmail: "   ")))
+        try DomainConfigStore(sourceDirectory: dir2).save(DomainConfig(email: .init(inboxForwardAddress: "   ")))
         #expect(DeployCoordinator.resolveInboxForwardEmail(sourceDirectory: dir2) == nil)
     }
 

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -309,6 +309,34 @@ struct SocialWorkerProvisionCommandTests {
         #expect(toml.contains("id = \"inbox-kv-id\""))
     }
 
+    @Test("inboxCaptureEnabled + inboxForwardEmail writes a send_email binding into wrangler.toml")
+    func provisionsInboxCaptureWithForwardEmail() async throws {
+        let site = try temporaryDirectory()
+        let recorder = WranglerRecorder([
+            ["kv", "namespace", "create", "my-site-inbox", "--json"]: .init(stdout: #"{"result":{"id":"inbox-kv-id"}}"#, stderr: "", exitCode: 0),
+        ])
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "token" },
+            runner: recorder.runner,
+            deployer: DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1)).deployer,
+            accountIDSource: { _ in "acct-1" }
+        )
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: [],
+            inboxCaptureEnabled: true, inboxForwardEmail: "owner@example.com"
+        )
+
+        guard case .succeeded = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        let toml = try String(contentsOf: site.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(toml.contains("[[send_email]]"))
+        #expect(toml.contains("destination_address = \"owner@example.com\""))
+        #expect(toml.contains("INBOX_FORWARD_EMAIL = \"owner@example.com\""))
+    }
+
     @Test("inboxCaptureEnabled false never invokes wrangler kv namespace create")
     func inboxCaptureDisabledNeverCreatesNamespace() async throws {
         let site = try temporaryDirectory()

--- a/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
@@ -146,6 +146,51 @@ struct WorkerCompositionTests {
         #expect(!toml.contains("main ="))
     }
 
+    // MARK: - inbox forwarding (#1570)
+
+    @Test("inboxCaptureEnabled + a plausible inboxForwardEmail emits a send_email binding and var")
+    func inboxForwardingEmitsSendEmailBinding() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [], inboxCaptureEnabled: true, inboxForwardEmail: "owner@example.com")
+        #expect(toml.contains("[[send_email]]"))
+        #expect(toml.contains("name = \"SEND_EMAIL\""))
+        #expect(toml.contains("destination_address = \"owner@example.com\""))
+        #expect(toml.contains("INBOX_FORWARD_EMAIL = \"owner@example.com\""))
+    }
+
+    @Test("inboxForwardEmail nil omits the send_email binding and var")
+    func inboxForwardingOmittedWithoutEmail() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [], inboxCaptureEnabled: true)
+        #expect(!toml.contains("send_email"))
+        #expect(!toml.contains("INBOX_FORWARD_EMAIL"))
+    }
+
+    @Test("inboxForwardEmail is ignored when inboxCaptureEnabled is false")
+    func inboxForwardingIgnoredWhenCaptureDisabled() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [], inboxForwardEmail: "owner@example.com")
+        #expect(!toml.contains("send_email"))
+        #expect(!toml.contains("INBOX_FORWARD_EMAIL"))
+    }
+
+    @Test("an implausible inboxForwardEmail (no @) omits the send_email binding and var")
+    func inboxForwardingOmittedForImplausibleEmail() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [], inboxCaptureEnabled: true, inboxForwardEmail: "not-an-email")
+        #expect(!toml.contains("send_email"))
+        #expect(!toml.contains("INBOX_FORWARD_EMAIL"))
+    }
+
+    @Test("a TOML-unsafe inboxForwardEmail (embedded quote) omits the send_email binding and var")
+    func inboxForwardingOmittedForUnsafeEmail() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [], inboxCaptureEnabled: true,
+            inboxForwardEmail: "owner\"@example.com")
+        #expect(!toml.contains("send_email"))
+        #expect(!toml.contains("INBOX_FORWARD_EMAIL"))
+    }
+
     @Test("route claims emit deterministic, sorted, deduplicated run_worker_first entries")
     func selectiveRunWorkerFirst() throws {
         let claims = [


### PR DESCRIPTION
Closes #1570

## Summary

- The composed Worker's `/inbox` route now additionally forwards each submission to the owner's email via a Cloudflare `send_email` binding, alongside the existing `INBOX_KV` → git commit-back capture (`InboxSubmissionSync`), which stays the structured record.
- `WorkerComposition.generateWranglerToml` learns `inboxForwardEmail`, emitting `[[send_email]]` (restricted to a single `destination_address`) and an `INBOX_FORWARD_EMAIL` var only when `inboxCaptureEnabled` and the address is plausible.
- The forwarding address is a dedicated opt-in field — `Source/anglesite.json`'s `email.inboxForwardAddress`, new on `DomainConfig.Email` — set via a "Forward to email" text field in the Workers tab's Inbox Capture section (`PlistEditorModel.saveInboxForwardEmail`). Deliberately **not** reused from `email.dmarcReportEmail`: that's a different address for a different purpose (automated DMARC reports vs. a personal inbox), and defaulting one from the other would have been a silent behavior change for any site that already ran email setup.
- `handleInbox` sends best-effort: an email failure (unverified destination, etc.) never blocks the KV write or turns a captured submission into an error response. The submitter's raw `subject`/`from`/`message` are anonymous, unvalidated input; `subject` is RFC 2047/base64-encoded (folded at 75 chars per encoded-word, on UTF-8 boundaries) before it ever reaches a header, and `from`/`message` only ever appear in the body — no header-injection surface regardless of content.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .`
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`)
- [x] `npm run test:worker` (Resources/Template) — `handleInbox` forwarding tests + `buildInboxForwardRaw`/`encodeMimeHeaderValue` injection-safety and RFC 2047 folding tests
- [x] `npx astro check` (Resources/Template) — 0 errors
