### PR TITLE
feat(#1569): assert no restricted content reaches Source/ or dist/

### DIFF
--- a/Resources/Template/scripts/pre-deploy-check.test.ts
+++ b/Resources/Template/scripts/pre-deploy-check.test.ts
@@ -13,6 +13,8 @@ import {
   checkAnglesiteConfig,
   checkExperiments,
   checkRSL,
+  checkNoRestrictedContentInSource,
+  checkNoRestrictedContentInDist,
   runningExperimentControlDistPath,
   runningExperimentVariantDistPath,
 } from "./pre-deploy-check";
@@ -102,6 +104,62 @@ test("checkPII: flags an SSN with the pii-ssn category", () => {
   const issues = checkPII("<p>SSN: 123-45-6789</p>", "dist/contact.html");
   assert.equal(issues.length, 1);
   assert.equal(issues[0].category, "pii-ssn");
+});
+
+test("checkNoRestrictedContentInSource: flags YAML frontmatter visibility: contacts", () => {
+  const file = "src/content/notes/leaked.md";
+  const content = "---\npublishDate: 2026-08-18\nvisibility: contacts\n---\nBody text.\n";
+  const issues = checkNoRestrictedContentInSource(file, content);
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "error");
+  assert.equal(issues[0].category, "restricted-content-in-source");
+  assert.equal(issues[0].file, file);
+});
+
+test("checkNoRestrictedContentInSource: flags a quoted visibility value too", () => {
+  const content = '---\nvisibility: "contacts"\n---\nBody.\n';
+  const issues = checkNoRestrictedContentInSource("src/content/notes/leaked.md", content);
+  assert.equal(issues.length, 1);
+});
+
+test("checkNoRestrictedContentInSource: does not flag ordinary content with no visibility field", () => {
+  const content = "---\npublishDate: 2026-08-18\ntags: [\"hello\"]\n---\nThis is your first note.\n";
+  const issues = checkNoRestrictedContentInSource("src/content/notes/hello-note.md", content);
+  assert.deepEqual(issues, []);
+});
+
+test("checkNoRestrictedContentInSource: does not flag public visibility", () => {
+  const content = "---\nvisibility: public\n---\nBody.\n";
+  const issues = checkNoRestrictedContentInSource("src/content/notes/hello-note.md", content);
+  assert.deepEqual(issues, []);
+});
+
+test("checkNoRestrictedContentInDist: flags a leaked mf2 JSON property array in built output", () => {
+  const file = "dist/notes/leaked/index.html";
+  const content = '<script type="application/json">{"properties":{"visibility":["contacts"]}}</script>';
+  const issues = checkNoRestrictedContentInDist(file, content);
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "error");
+  assert.equal(issues[0].category, "restricted-content-in-dist");
+  assert.equal(issues[0].file, file);
+});
+
+test("checkNoRestrictedContentInDist: flags a JSON string form", () => {
+  const content = '{"visibility":"contacts"}';
+  const issues = checkNoRestrictedContentInDist("dist/api/posts.json", content);
+  assert.equal(issues.length, 1);
+});
+
+test("checkNoRestrictedContentInDist: does not flag ordinary built HTML", () => {
+  const content = "<html><body><p>Hello world.</p></body></html>";
+  const issues = checkNoRestrictedContentInDist("dist/index.html", content);
+  assert.deepEqual(issues, []);
+});
+
+test("checkNoRestrictedContentInDist: does not flag public visibility", () => {
+  const content = '{"visibility":"public"}';
+  const issues = checkNoRestrictedContentInDist("dist/api/posts.json", content);
+  assert.deepEqual(issues, []);
 });
 
 // Pagefind's UI bundle embeds its translators' contact addresses as `thanks_to` credits. Those

--- a/Resources/Template/scripts/pre-deploy-check.ts
+++ b/Resources/Template/scripts/pre-deploy-check.ts
@@ -53,6 +53,14 @@ const DIST_DIR = join(process.cwd(), "dist");
 const HEADERS_FILE = join(DIST_DIR, "_headers");
 const CONFIG_FILE = join(process.cwd(), ".site-config");
 const ANGLESITE_CONFIG_FILE = join(process.cwd(), "anglesite.json");
+const SOURCE_CONTENT_DIR = join(process.cwd(), "src", "content");
+
+// The restricted-posting epic's audience tier (#963 §2.2): a `visibility: contacts` value on
+// Micropub's `visibility` mf2 property. Matches whether the value shows up YAML-style (Source/
+// frontmatter), JSON-string-style, or as a JSON mf2 property array (`"visibility":["contacts"]`,
+// the exact shape `MicropubPost.entry` stamps and `dist/` could echo back if a post-family JSON
+// export ever serialized raw properties).
+const RESTRICTED_VISIBILITY_PATTERN = /"?visibility"?\s*:\s*(\[\s*)?"?contacts"?/i;
 
 const PII_PATTERNS = [
   { name: "email", pattern: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g },
@@ -699,6 +707,40 @@ export function checkAnglesiteConfig(raw: string | null): Issue[] {
   return [];
 }
 
+/**
+ * Defense-in-depth backstop for the composer-only restricted-posting design (#963 §2.1, #1569): a
+ * `visibility: contacts` post publishes straight into the Worker's D1 store via Micropub and must
+ * never be written to `Source/` as content-collection frontmatter. This isn't the enforcement
+ * mechanism — the composer never offers to write it there — it's a check that fires if a future
+ * regression, sync bug, or manual edit did.
+ */
+export function checkNoRestrictedContentInSource(relPath: string, content: string): Issue[] {
+  if (!RESTRICTED_VISIBILITY_PATTERN.test(content)) return [];
+  return [{
+    severity: "error",
+    category: "restricted-content-in-source",
+    message: 'Restricted (visibility: contacts) content found in Source/ — restricted posts must publish via Micropub straight to the Worker, never as Source/ content.',
+    file: relPath,
+    remediation: "Remove the restricted content from Source/; it belongs in the Worker's D1 post store, not the git-canonical site.",
+  }];
+}
+
+/**
+ * Same backstop as `checkNoRestrictedContentInSource`, for the built `dist/` output: restricted
+ * content must never reach the static build, since it's served exclusively through the Worker's
+ * IndieAuth read gate (#1568), never the CDN-served static site.
+ */
+export function checkNoRestrictedContentInDist(relPath: string, content: string): Issue[] {
+  if (!RESTRICTED_VISIBILITY_PATTERN.test(content)) return [];
+  return [{
+    severity: "error",
+    category: "restricted-content-in-dist",
+    message: 'Restricted (visibility: contacts) content found in the built dist/ output — it must be served only through the Worker\'s read gate, never the static build.',
+    file: relPath,
+    remediation: "Rebuild after removing the restricted content from Source/, and check for a regression in the composer/Micropub-to-D1 publish path.",
+  }];
+}
+
 const EXPERIMENT_ID_PATTERN = /^[A-Za-z0-9-]+$/;
 const KNOWN_GOAL_KINDS = new Set(["pageview", "route", "scroll", "visible"]);
 const CLIENT_GOAL_KINDS = new Set(["scroll", "visible"]);
@@ -1120,6 +1162,16 @@ async function scan(): Promise<Issue[]> {
   issues.push(...checkAnglesiteConfig(anglesiteConfigContent));
 
   try {
+    for await (const file of walk(SOURCE_CONTENT_DIR)) {
+      if (!/\.(md|mdx|json)$/i.test(file)) continue;
+      const content = await readFile(file, "utf-8");
+      issues.push(...checkNoRestrictedContentInSource(relative(process.cwd(), file), content));
+    }
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+  }
+
+  try {
     await stat(DIST_DIR);
   } catch {
     issues.push({ severity: "warning", category: "missing-security-artifact", message: "No dist/ directory found — nothing to scan." });
@@ -1183,6 +1235,7 @@ async function scan(): Promise<Issue[]> {
     relPaths.push(rel);
 
     issues.push(...checkPII(content, rel));
+    issues.push(...checkNoRestrictedContentInDist(rel, content));
 
     const isHtmlOrCss = /\.(html?|css)$/i.test(file);
     if (controlDistPath !== null && rel === controlDistPath) controlHtmlContent = content;

--- a/Sources/AnglesiteApp/BlockedDeploySheetView.swift
+++ b/Sources/AnglesiteApp/BlockedDeploySheetView.swift
@@ -105,6 +105,7 @@ private struct FailureCard: View {
         case .embedMediaHotlink: return "photo.badge.exclamationmark"
         case .wellKnownCollision: return "exclamationmark.lock"
         case .anglesiteConfigInvalid: return "doc.badge.gearshape"
+        case .restrictedContentInSource, .restrictedContentInDist: return "lock.trianglebadge.exclamationmark"
         case .other: return "exclamationmark.triangle"
         }
     }
@@ -121,6 +122,8 @@ private struct FailureCard: View {
         case .embedMediaHotlink: return "Hotlinked embed media"
         case .wellKnownCollision: return "/.well-known/ collision"
         case .anglesiteConfigInvalid: return "anglesite.json invalid"
+        case .restrictedContentInSource: return "Restricted content in Source/"
+        case .restrictedContentInDist: return "Restricted content in dist/"
         case .other: return "Other"
         }
     }

--- a/Sources/AnglesiteCore/PreDeployCheck.swift
+++ b/Sources/AnglesiteCore/PreDeployCheck.swift
@@ -71,6 +71,15 @@ public actor PreDeployCheck {
             /// network-free, distinct from the deploy-time declared-vs-live check
             /// (`DeployCommand.Result.domainConfigDrift`).
             case anglesiteConfigInvalid = "anglesite-config-invalid"
+            /// A restricted (`visibility: contacts`) post's content was found in `Source/` —
+            /// restricted posts publish straight to the Worker's D1 store via Micropub and must
+            /// never be written to `Source/` as content-collection frontmatter (#963 §2.1,
+            /// #1569). Defense-in-depth backstop, not the primary mechanism.
+            case restrictedContentInSource = "restricted-content-in-source"
+            /// A restricted (`visibility: contacts`) post's content was found in the built
+            /// `dist/` output — restricted content must only ever be served through the Worker's
+            /// IndieAuth read gate (#1568), never the static build (#963 §2.1, #1569).
+            case restrictedContentInDist = "restricted-content-in-dist"
             /// Any category code this build doesn't recognize yet — decoding falls back here
             /// instead of throwing, so a future/typo'd category can't crash the whole scan (#742).
             case other = "other"

--- a/Tests/AnglesiteCoreTests/PreDeployCheckTests.swift
+++ b/Tests/AnglesiteCoreTests/PreDeployCheckTests.swift
@@ -53,7 +53,7 @@ struct PreDeployCheckTests {
         #expect(failures[0].remediation?.contains("PII_EMAIL_ALLOW") == true)
     }
 
-    @Test("Parses all nine concrete failure categories") func parsesAllNineConcreteFailureCategories() async {
+    @Test("Parses all eleven concrete failure categories") func parsesAllElevenConcreteFailureCategories() async {
         let json = """
         {
           "version": 1,
@@ -67,7 +67,9 @@ struct PreDeployCheckTests {
             {"category": "keystatic-route", "message": "m", "file": "a", "remediation": "r"},
             {"category": "csp-misconfigured", "message": "m", "file": "a", "remediation": "r"},
             {"category": "embed-media-hotlink", "message": "m", "file": "a", "remediation": "r"},
-            {"category": "anglesite-config-invalid", "message": "m", "file": "a", "remediation": "r"}
+            {"category": "anglesite-config-invalid", "message": "m", "file": "a", "remediation": "r"},
+            {"category": "restricted-content-in-source", "message": "m", "file": "a", "remediation": "r"},
+            {"category": "restricted-content-in-dist", "message": "m", "file": "a", "remediation": "r"}
           ],
           "warnings": []
         }
@@ -84,7 +86,7 @@ struct PreDeployCheckTests {
         #expect(
             Set(failures.map(\.category)) == Set([
                 .piiEmail, .piiPhone, .piiSSN, .exposedToken, .thirdPartyScript, .keystaticRoute, .cspMisconfigured,
-                .embedMediaHotlink, .anglesiteConfigInvalid,
+                .embedMediaHotlink, .anglesiteConfigInvalid, .restrictedContentInSource, .restrictedContentInDist,
             ])
         )
     }


### PR DESCRIPTION
Closes #1569

## Summary

- Add `checkNoRestrictedContentInSource`/`checkNoRestrictedContentInDist` to `pre-deploy-check.ts`, scanning `src/content/**/*.{md,mdx,json}` frontmatter and built `dist/` output for a leaked `visibility: contacts` value.
- This is the defense-in-depth backstop from the audience-limited-posting epic (#963 §2.1): a restricted post is composer-published straight into the Worker's D1 store and should never touch `Source/` or the static build, so this check exists to catch a future regression, sync bug, or manual mistake — not as the primary enforcement mechanism.
- Add matching `ScanFailure.Category` cases (`restrictedContentInSource`/`restrictedContentInDist`) on the Swift side, plus icon/label wiring in `BlockedDeploySheetView`, following the same pattern as every other wire category rather than falling back to `.other`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `npx tsx --test scripts/pre-deploy-check.test.ts` (from `Resources/Template/`) — 140/140 pass, including 8 new tests
- [x] `npx tsx --test scripts/*.test.ts scripts/embeds/*.test.ts src/lib/*.test.ts` (from `Resources/Template/`) — 888/890 pass, 2 pre-existing skips, 0 failures
- [x] `swift test --package-path . --filter "PreDeployCheckTests|PreDeployCheckFixtureTests"` — 16/16 pass, including the fixture test that round-trips the real script's JSON through `PreDeployCheck.parse`
- [x] `swift build --package-path .` — clean