### PR TITLE
feat(#1518): A/B slice 5 — configure/start lifecycle UI

### DIFF
--- a/JS/edit-overlay/src/messages.ts
+++ b/JS/edit-overlay/src/messages.ts
@@ -84,6 +84,25 @@ export function postPlacementPick(
   return true;
 }
 
+export interface GoalElementPickMessage {
+  id: string;
+  type: "anglesite:pick-goal-element";
+  path: string;
+  selector: ElementInfo;
+}
+
+/** Posts a goal-element-pick report to native — same "no reply" contract as
+ *  `postPlacementPick`; the app resolves the pick into a CSS selector and updates its own UI. */
+export function postGoalElementPick(
+  message: GoalElementPickMessage,
+  win: WebKitWindow = window as unknown as WebKitWindow,
+): boolean {
+  const handler = win.webkit?.messageHandlers?.anglesite;
+  if (!handler) return false;
+  handler.postMessage(message);
+  return true;
+}
+
 /** Install `window.anglesite._handleReply` so native can deliver replies, and return an
  *  `awaitReply` registrar bound to a closure-private map — each install gets its own. */
 export function installReplyHandler(

--- a/JS/edit-overlay/src/overlay.ts
+++ b/JS/edit-overlay/src/overlay.ts
@@ -9,6 +9,7 @@ import {
   installReplyHandler,
   nextEditID,
   postEdit,
+  postGoalElementPick,
   postPlacementPick,
   type EditMessage,
   type EditReply,
@@ -17,6 +18,7 @@ import { showToast } from "./toast.js";
 import { installVisibleElementsReporter } from "./visible-elements.js";
 
 export const HOVER_CLASS = "anglesite-hover";
+export const GOAL_PICK_HOVER_CLASS = "anglesite-goal-pick-hover";
 export const EDITABLE_CLASS = "anglesite-editing";
 export const IMAGE_DROP_TARGET_CLASS = "anglesite-image-drop-target";
 export const IMAGE_DROP_ACTIVE_CLASS = "anglesite-image-drop-active";
@@ -40,6 +42,10 @@ function installStyles(): void {
   style.textContent = [
     `.${HOVER_CLASS} { outline: 2px solid rgba(0, 122, 255, 0.8); outline-offset: 2px; cursor: text; }`,
     `.${EDITABLE_CLASS} { outline: 2px solid rgba(0, 122, 255, 1); outline-offset: 2px; background: rgba(0, 122, 255, 0.05); }`,
+    // Distinct color from HOVER_CLASS (blue) on purpose: goal-element pick mode can hover any
+    // element, including ones that also qualify for ordinary click-to-edit hover, and the two
+    // modes' feedback must stay visually distinguishable.
+    `.${GOAL_PICK_HOVER_CLASS} { outline: 2px dashed rgba(255, 149, 0, 0.9); outline-offset: 2px; cursor: pointer; }`,
     // !important here (unlike HOVER_CLASS/EDITABLE_CLASS above): site stylesheets commonly reset
     // `img { outline: none }`, and the drop-target ring needs to survive that.
     `.${IMAGE_DROP_TARGET_CLASS} { outline: 3px dashed rgba(0, 122, 255, 0.9) !important; outline-offset: 4px !important; filter: brightness(0.9) !important; }`,
@@ -161,6 +167,70 @@ export function installPlacementPickMode(win: Window & typeof globalThis = windo
   };
   anglesiteWin.anglesite._enterPlacementMode = controls.enter;
   anglesiteWin.anglesite._exitPlacementMode = controls.exit;
+  return controls;
+}
+
+export interface GoalPickControls {
+  enter(): void;
+  exit(): void;
+}
+
+/** Goal-element-pick mode (#1270 slice 5): while active, hovering any element outlines it and a
+ *  click reports its `ElementInfo` via `anglesite:pick-goal-element` instead of the normal
+ *  click-to-edit path — same exclusivity contract as `installPlacementPickMode`, entered only via
+ *  an explicit native call. Adds hover feedback placement-pick mode doesn't have, since "point at
+ *  the reviews section" is materially harder to do accurately with no visual confirmation of the
+ *  candidate element before clicking. */
+export function installGoalPickMode(win: Window & typeof globalThis = window): GoalPickControls {
+  let active = false;
+  let hovered: Element | null = null;
+
+  const clearHover = () => {
+    hovered?.classList.remove(GOAL_PICK_HOVER_CLASS);
+    hovered = null;
+  };
+
+  document.addEventListener("mouseover", (ev) => {
+    if (!active) return;
+    const target = ev.target as Element | null;
+    if (!target || target.nodeType !== 1) return;
+    if (hovered && hovered !== target) hovered.classList.remove(GOAL_PICK_HOVER_CLASS);
+    target.classList.add(GOAL_PICK_HOVER_CLASS);
+    hovered = target;
+  });
+  document.addEventListener("mouseout", (ev) => {
+    if (!active) return;
+    const target = ev.target as Element | null;
+    if (target === hovered) clearHover();
+  });
+
+  const clickHandler = (ev: MouseEvent) => {
+    if (!active) return;
+    const target = ev.target as Element | null;
+    if (!target || target.nodeType !== 1) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    clearHover();
+    postGoalElementPick(
+      {
+        id: nextEditID(),
+        type: "anglesite:pick-goal-element",
+        path: location.pathname,
+        selector: elementInfoFor(target),
+      },
+      win as unknown as Parameters<typeof postGoalElementPick>[1],
+    );
+  };
+  document.addEventListener("click", clickHandler, { capture: true });
+
+  const anglesiteGoalWin = win as unknown as { anglesite?: { _enterGoalPickMode?: () => void; _exitGoalPickMode?: () => void } };
+  anglesiteGoalWin.anglesite = anglesiteGoalWin.anglesite ?? {};
+  const controls: GoalPickControls = {
+    enter: () => { active = true; },
+    exit: () => { active = false; clearHover(); },
+  };
+  anglesiteGoalWin.anglesite._enterGoalPickMode = controls.enter;
+  anglesiteGoalWin.anglesite._exitGoalPickMode = controls.exit;
   return controls;
 }
 
@@ -446,4 +516,5 @@ export function install(): void {
   attachImageDrop(awaitReply);
   installVisibleElementsReporter();
   installPlacementPickMode(window);
+  installGoalPickMode(window);
 }

--- a/JS/edit-overlay/test/overlay-goal-pick.test.ts
+++ b/JS/edit-overlay/test/overlay-goal-pick.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { installGoalPickMode, GOAL_PICK_HOVER_CLASS } from "../src/overlay.js";
+
+describe("installGoalPickMode", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `<section id="reviews"><p>Great product</p></section>`;
+  });
+
+  it("does nothing on click before enter() is called", () => {
+    const posted: unknown[] = [];
+    const win = { webkit: { messageHandlers: { anglesite: { postMessage: (m: unknown) => posted.push(m) } } } } as any;
+    installGoalPickMode(win);
+    document.querySelector("p")!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(posted).toHaveLength(0);
+  });
+
+  it("posts anglesite:pick-goal-element for the clicked element while active", () => {
+    const posted: unknown[] = [];
+    const win = { webkit: { messageHandlers: { anglesite: { postMessage: (m: unknown) => posted.push(m) } } } } as any;
+    const controls = installGoalPickMode(win);
+    controls.enter();
+    document.querySelector("p")!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(posted).toHaveLength(1);
+    expect((posted[0] as any).type).toBe("anglesite:pick-goal-element");
+    expect((posted[0] as any).selector.tag).toBe("P");
+  });
+
+  it("stops posting after exit()", () => {
+    const posted: unknown[] = [];
+    const win = { webkit: { messageHandlers: { anglesite: { postMessage: (m: unknown) => posted.push(m) } } } } as any;
+    const controls = installGoalPickMode(win);
+    controls.enter();
+    controls.exit();
+    document.querySelector("p")!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(posted).toHaveLength(0);
+  });
+
+  it("adds a hover outline class to the candidate element while active, and clears it on mouseout", () => {
+    const win = { webkit: { messageHandlers: { anglesite: { postMessage: vi.fn() } } } } as any;
+    const controls = installGoalPickMode(win);
+    controls.enter();
+    const p = document.querySelector("p")!;
+    p.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    expect(p.classList.contains(GOAL_PICK_HOVER_CLASS)).toBe(true);
+    p.dispatchEvent(new MouseEvent("mouseout", { bubbles: true }));
+    expect(p.classList.contains(GOAL_PICK_HOVER_CLASS)).toBe(false);
+  });
+
+  it("exposes window.anglesite._enterGoalPickMode/_exitGoalPickMode", () => {
+    const win = { webkit: { messageHandlers: { anglesite: { postMessage: vi.fn() } } } } as any;
+    installGoalPickMode(win);
+    expect(typeof win.anglesite._enterGoalPickMode).toBe("function");
+    expect(typeof win.anglesite._exitGoalPickMode).toBe("function");
+  });
+});

--- a/Resources/Template/scripts/pre-deploy-check.test.ts
+++ b/Resources/Template/scripts/pre-deploy-check.test.ts
@@ -975,6 +975,34 @@ test("checkExperiments: skips the beacon-tag check when control HTML wasn't capt
   assert.ok(!issues.some((i) => i.message.includes("control page")));
 });
 
+const VISIBLE_GOAL_ACTIVE = [{ ...VALID_ACTIVE[0], goal: { kind: "visible", selector: "#reviews" } }];
+
+test("checkExperiments: flags a visible-goal selector that matches neither built page", () => {
+  const controlHtml = `<html><head>${BEACON_SCRIPT_TAG}</head><body><h1>Home</h1></body></html>`;
+  const variantHtml = `<html><head><link rel="canonical" href="https://example.com/"><meta name="robots" content="noindex">${BEACON_SCRIPT_TAG}</head><body><h1>Home (variant)</h1></body></html>`;
+  const issues = checkExperiments(
+    JSON.stringify({ version: 1, experiments: { active: VISIBLE_GOAL_ACTIVE } }),
+    distFilesFor(["dist/index.html", "dist/x/homepage-hero/b/index.html", "dist/x/goal-beacon.js"]),
+    variantHtml,
+    "<urlset></urlset>",
+    controlHtml,
+  );
+  assert.ok(issues.some((i) => i.category === "experiments-goal-beacon" && i.message.includes("#reviews")));
+});
+
+test("checkExperiments: passes a visible-goal selector present in both built pages", () => {
+  const controlHtml = `<html><head>${BEACON_SCRIPT_TAG}</head><body><section id="reviews">Great</section></body></html>`;
+  const variantHtml = `<html><head><link rel="canonical" href="https://example.com/"><meta name="robots" content="noindex">${BEACON_SCRIPT_TAG}</head><body><section id="reviews">Great</section></body></html>`;
+  const issues = checkExperiments(
+    JSON.stringify({ version: 1, experiments: { active: VISIBLE_GOAL_ACTIVE } }),
+    distFilesFor(["dist/index.html", "dist/x/homepage-hero/b/index.html", "dist/x/goal-beacon.js"]),
+    variantHtml,
+    "<urlset></urlset>",
+    controlHtml,
+  );
+  assert.deepEqual(issues, []);
+});
+
 test("runningExperimentControlDistPath: a well-formed running experiment resolves its own dist path", () => {
   assert.equal(
     runningExperimentControlDistPath(JSON.stringify({ version: 1, experiments: { active: VALID_ACTIVE } })),

--- a/Resources/Template/scripts/pre-deploy-check.ts
+++ b/Resources/Template/scripts/pre-deploy-check.ts
@@ -817,6 +817,59 @@ function hasNoindexRobotsMeta(html: string): boolean {
   return false;
 }
 
+// Leaf (last, target) simple-selector shapes GoalSelectorBuilder's Swift-side picker can produce.
+// A trailing `:nth-child(n)` structural pseudo-class carries no attribute/content signal a regex
+// can verify, so it's stripped before matching and falls through to the bare-tag check below.
+const LEAF_PSEUDO_SUFFIX_PATTERN = /:nth-child\(\d+\)$/;
+const LEAF_ATTR_PATTERN = /^\[([\w-]+)="([^"]*)"\]$/;
+const LEAF_ID_PATTERN = /^#([\w-]+)$/;
+const LEAF_ROLE_ARIA_PATTERN = /^\[role="([^"]*)"\]\[aria-label="([^"]*)"\]$/;
+const LEAF_TAG_CLASSES_PATTERN = /^([a-z0-9]+)((?:\.[\w-]+)*)$/;
+
+/**
+ * Best-effort check that `selector`'s LAST (leaf) simple-selector component resolves against
+ * `html` — same regex-tag-isolation idiom as `findCanonicalHref`/`hasNoindexRobotsMeta` above,
+ * deliberately not a full CSS selector engine (no new dependency; see CONTRIBUTING.md's
+ * no-new-dependencies rule). This only verifies the target element's own attributes/id/classes/tag
+ * name appear somewhere in the built HTML — it does not verify the combinator chain's ancestor
+ * relationships (e.g. a "ul > li.item" selector only confirms an `li.item` exists *somewhere*, not
+ * that it's a child of a `ul`). That's an intentional, documented simplification: the beacon's
+ * `document.querySelector` needs the leaf element to exist at all for the goal to ever have a
+ * chance of firing, which is the failure class this check guards against.
+ */
+function selectorLikelyMatchesHtml(html: string, selector: string): boolean {
+  const leaf = (selector.split(" > ").pop() ?? selector).replace(LEAF_PSEUDO_SUFFIX_PATTERN, "");
+  const tagPattern = /<[a-zA-Z][^>]*>/g;
+  let m: RegExpExecArray | null;
+
+  const attrMatch = leaf.match(LEAF_ATTR_PATTERN);
+  const idMatch = leaf.match(LEAF_ID_PATTERN);
+  const roleAriaMatch = leaf.match(LEAF_ROLE_ARIA_PATTERN);
+  const tagClassesMatch = leaf.match(LEAF_TAG_CLASSES_PATTERN);
+
+  while ((m = tagPattern.exec(html)) !== null) {
+    const tag = m[0];
+    if (attrMatch && new RegExp(`\\b${attrMatch[1]}\\s*=\\s*["']${escapeRegExp(attrMatch[2])}["']`).test(tag)) return true;
+    if (idMatch && new RegExp(`\\bid\\s*=\\s*["']${escapeRegExp(idMatch[1])}["']`).test(tag)) return true;
+    if (
+      roleAriaMatch &&
+      new RegExp(`\\brole\\s*=\\s*["']${escapeRegExp(roleAriaMatch[1])}["']`).test(tag) &&
+      new RegExp(`\\baria-label\\s*=\\s*["']${escapeRegExp(roleAriaMatch[2])}["']`).test(tag)
+    )
+      return true;
+    if (tagClassesMatch) {
+      const [, tagName, dotClasses] = tagClassesMatch;
+      const classes = dotClasses.split(".").filter(Boolean);
+      const tagMatches = new RegExp(`^<${tagName}\\b`, "i").test(tag);
+      const classMatch = tag.match(/\bclass\s*=\s*["']([^"']*)["']/i);
+      const tagClasses = classMatch ? classMatch[1].split(/\s+/) : [];
+      if (tagMatches && classes.every((c) => tagClasses.includes(c))) return true;
+      if (tagMatches && classes.length === 0) return true; // bare tag / tag:nth-child(n) fallback
+    }
+  }
+  return false;
+}
+
 /**
  * Parses just enough of `anglesiteConfigRaw` to find the one well-formed running experiment's
  * `page`/`variant.page` pair, or `null` on ANY problem (missing, malformed JSON, no experiments,
@@ -1143,6 +1196,29 @@ export function checkExperiments(
           message: `Running experiment's ${roleLabel} ("${roleLabel === "control page" ? page : variantPage}") must include the goal beacon <script src="${GOAL_BEACON_SCRIPT_PATH}"> tag — its "${goal.kind}" goal can never fire without it.`,
           file: distPath,
           remediation: "Confirm the page renders through BaseLayout, so the beacon is injected for a running client-side-goal experiment.",
+        });
+      }
+    }
+  }
+
+  // A "visible" goal's selector must actually resolve against BOTH built pages — the owner picks
+  // it against the dev-server preview (Anglesite app, #1270 slice 5), which is not guaranteed to
+  // match the production build's DOM 1:1 (Astro's dev-time scoped-class hashes, in particular). A
+  // selector that only ever matched the preview is a goal that silently never fires — the same
+  // failure class the beacon-tag check above guards against.
+  if (goal.kind === "visible" && typeof goal.selector === "string") {
+    const selector = goal.selector;
+    for (const [html, roleLabel, distPath] of [
+      [controlHtmlContent, "control page", distPathFor(page)],
+      [variantHtmlContent, "variant page", distPathFor(variantPage)],
+    ] as const) {
+      if (html !== null && !selectorLikelyMatchesHtml(html, selector)) {
+        issues.push({
+          severity: "error",
+          category: "experiments-goal-beacon",
+          message: `Running experiment's "visible" goal selector (${JSON.stringify(selector)}) doesn't match anything in the built ${roleLabel} ("${roleLabel === "control page" ? page : variantPage}") — this goal can never fire.`,
+          file: distPath,
+          remediation: "Re-pick the element in the app, or hand-edit the selector to match markup that exists in the built page.",
         });
       }
     }

--- a/Resources/Template/src/layouts/BaseLayout.astro
+++ b/Resources/Template/src/layouts/BaseLayout.astro
@@ -39,6 +39,13 @@ interface Props {
   image?: string;
   /** The `og:type` this page advertises. Defaults to "website"; BlogPost overrides "article". */
   ogType?: string;
+  /**
+   * Overrides the canonical URL this page advertises, as a root-relative path (e.g. `/pricing`).
+   * Omit for ordinary pages, which canonicalize to their own URL. Set by a scaffolded A/B-test
+   * variant page (#1270 slice 5) to point back at the control page it was duplicated from — a
+   * variant must never rank in search as a distinct page from its control.
+   */
+  canonicalPath?: string;
 }
 
 const { title, description, lang, documentPath, image, ogType = "website" } = Astro.props;
@@ -97,7 +104,10 @@ const beaconExperiment =
 // Same computation BlogPost.astro/Hentry.astro use for their own JSON-LD `url` — duplicated
 // rather than threaded as a prop because every page (including ones with no per-collection
 // layout) needs a canonical link, and Astro.url/Astro.site are already in scope here.
-const canonical = new URL(Astro.url.pathname, Astro.site ?? Astro.url).href;
+const { canonicalPath } = Astro.props;
+const canonical = canonicalPath
+  ? new URL(canonicalPath, Astro.site ?? Astro.url).href
+  : new URL(Astro.url.pathname, Astro.site ?? Astro.url).href;
 const ogImage = image ? new URL(image, Astro.site ?? Astro.url).href : undefined;
 // PWA_THEME_COLOR is only written to .site-config by the PWA integration (derived from the
 // site's own --color-primary) — a site without it simply renders no theme-color meta.

--- a/Resources/Template/src/lib/sitemap-data.ts
+++ b/Resources/Template/src/lib/sitemap-data.ts
@@ -1,7 +1,9 @@
 import { getCollection } from "astro:content";
 import { ENTRY_COLLECTIONS } from "./collections.ts";
+import { readRobotsConfig } from "./robots-config.ts";
 import {
   buildSitemapUrls,
+  excludeNoindexed,
   routePathForPage,
   type SitemapEntry,
   type SitemapUrl,
@@ -14,11 +16,14 @@ import {
  */
 const PAGE_FILES = import.meta.glob("../pages/**/*.{astro,md,mdx}");
 
-/** Routes for the pages that exist in this site, dynamic routes and 404 excluded. */
+/** Routes for the pages that exist in this site, dynamic routes and 404 excluded, and any route
+ *  the site has marked noindex (#1518 slice 5: this is what keeps a scaffolded A/B-test variant
+ *  page out of the sitemap, without any experiment-specific logic here). */
 function staticPaths(): string[] {
-  return Object.keys(PAGE_FILES)
+  const paths = Object.keys(PAGE_FILES)
     .map(routePathForPage)
     .filter((path): path is string => path !== undefined);
+  return excludeNoindexed(paths, readRobotsConfig(process.cwd()).noindex);
 }
 
 /**

--- a/Resources/Template/src/lib/sitemap.test.ts
+++ b/Resources/Template/src/lib/sitemap.test.ts
@@ -1,6 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildSitemapUrls, lastmodFor, renderSitemap, routePathForPage } from "./sitemap.ts";
+import {
+  buildSitemapUrls,
+  excludeNoindexed,
+  lastmodFor,
+  renderSitemap,
+  routePathForPage,
+} from "./sitemap.ts";
 
 const SITE = "https://example.com";
 
@@ -102,4 +108,20 @@ test("lastmodFor coerces a string date", () => {
 test("lastmodFor returns undefined when there is no usable date", () => {
   assert.equal(lastmodFor({}), undefined);
   assert.equal(lastmodFor({ publishDate: "not a date" }), undefined);
+});
+
+test("excludeNoindexed drops a path with a matching noindex robots-config entry", () => {
+  const paths = ["/", "/about/", "/x/homepage-hero/b/"];
+  const result = excludeNoindexed(paths, [{ path: "/x/homepage-hero/b/" }]);
+  assert.deepEqual(result, ["/", "/about/"]);
+});
+
+test("excludeNoindexed matches a path and a noindex entry even when their trailing slash disagrees", () => {
+  assert.deepEqual(excludeNoindexed(["/about/"], [{ path: "/about" }]), []);
+  assert.deepEqual(excludeNoindexed(["/about"], [{ path: "/about/" }]), []);
+});
+
+test("excludeNoindexed keeps every path when there are no noindex entries", () => {
+  const paths = ["/", "/about/"];
+  assert.deepEqual(excludeNoindexed(paths, []), paths);
 });

--- a/Resources/Template/src/lib/sitemap.ts
+++ b/Resources/Template/src/lib/sitemap.ts
@@ -6,6 +6,7 @@
  * `<lastmod>` is what tells it which of those pages changed since its last visit.
  */
 import { escapeXml } from "./feeds.ts";
+import type { RobotsConfigEntry } from "./robots-config.ts";
 
 export interface SitemapUrl {
   /** Absolute URL of the page. */
@@ -36,6 +37,24 @@ export function routePathForPage(file: string): string | undefined {
   if (withoutExtension === "404") return undefined;
   const path = withoutExtension.replace(/(^|\/)index$/, "").replace(/\/$/, "");
   return path === "" ? "/" : `/${path}/`;
+}
+
+/** Adds a trailing slash when `path` lacks one, so a route and a robots-config entry compare
+ *  equal regardless of which convention each happened to be written in. */
+function withTrailingSlash(path: string): string {
+  return path.endsWith("/") ? path : `${path}/`;
+}
+
+/**
+ * `paths` with every route excluded that has a matching `noindex` entry in
+ * `src/data/robots-config.json` — the general mechanism behind #1518 slice 5's gate requirement
+ * that a scaffolded A/B-test variant page never appear in the sitemap. Nothing here is
+ * experiment-specific: a noindexed page belongs in neither search results nor the sitemap that
+ * feeds them, whatever put it there.
+ */
+export function excludeNoindexed(paths: string[], noindex: RobotsConfigEntry[]): string[] {
+  const noindexed = new Set(noindex.map((entry) => withTrailingSlash(entry.path)));
+  return paths.filter((path) => !noindexed.has(withTrailingSlash(path)));
 }
 
 /**

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -254,6 +254,29 @@ final class DeployModel {
             || domainConfigDriftPresented || activityPubHandleRenameConfirmationPresented
     }
 
+    /// Why calling `deploy(...)` right now would *not* run a deploy through to a terminal phase —
+    /// `nil` when it would. Each case below is one of `deploy(...)`'s own silent early returns (or,
+    /// for `awaitingUserAction`, a prompt already on screen that a second run would clobber): the
+    /// call no-ops or parks in `pendingDeploy` behind a sheet, leaving `phase` where it was.
+    ///
+    /// Most callers don't need this — Deploy is a button in the window, so parking behind the
+    /// token/license sheet *is* the flow. It exists for callers that show their own "starting…"
+    /// state keyed off `phase` and would otherwise wait forever for a transition that never comes,
+    /// and whose own sheet is what blocks the parked prompt from presenting (`ExperimentStatsModel`,
+    /// #1518). The returned text is owner-facing.
+    func deployUnavailableReason(siteDirectory: URL) -> String? {
+        if isRunning || awaitingUserAction {
+            return "Your site is already publishing. Wait for that to finish, then try again."
+        }
+        if !hasUsableToken() {
+            return "Anglesite needs your Cloudflare sign-in before it can publish. Close this and choose Publish to sign in, then start your test."
+        }
+        if !hasChosenLicense(siteDirectory: siteDirectory) {
+            return "Choose how visitors may reuse your content first. Close this and choose Publish to pick a license, then start your test."
+        }
+        return nil
+    }
+
     /// Renders the captured log lines as plain text for the "Copy log" affordance on failure.
     var logText: String {
         logLines.map(\.text).joined(separator: "\n")

--- a/Sources/AnglesiteApp/ExperimentConfigureView.swift
+++ b/Sources/AnglesiteApp/ExperimentConfigureView.swift
@@ -69,10 +69,18 @@ struct ExperimentConfigureView: View {
         }
     }
 
+    // Not a `Button`-per-row like `LicenseGateSheetView`'s comparison table: each row's actual
+    // controls (a `TextField`+button, a `Slider`+button, or a picker-launching button) must stay
+    // independently focusable and tappable, and SwiftUI doesn't support nested interactive
+    // controls inside an outer `Button`. Instead, the identifying title+icon is grouped into a
+    // single combined accessibility element carrying the `.isSelected` state — so VoiceOver
+    // reaches one clearly identified "selected"/"not selected" landmark per option, distinct from
+    // (and before) the real controls underneath it that remain separately reachable.
     @ViewBuilder
     private func goalOptionRow<Content: View>(title: String, isSelected: Bool, @ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading) {
             Label(title, systemImage: isSelected ? "checkmark.circle.fill" : "circle")
+                .accessibilityElement(children: .combine)
                 .accessibilityAddTraits(isSelected ? .isSelected : [])
             content()
         }

--- a/Sources/AnglesiteApp/ExperimentConfigureView.swift
+++ b/Sources/AnglesiteApp/ExperimentConfigureView.swift
@@ -6,6 +6,7 @@ import AnglesiteCore
 /// `model.step`'s associated `Draft` is the single source of truth for what's already set.
 struct ExperimentConfigureView: View {
     @Bindable var model: ExperimentStatsModel
+    var deployModel: DeployModel
     var enterGoalPickMode: () -> Void
     var exitGoalPickMode: () -> Void
 
@@ -61,7 +62,11 @@ struct ExperimentConfigureView: View {
                 }
                 Section {
                     Button("Start your test") {
-                        model.start(deploy: { _, _, _, _ in }) // Task 15 supplies the real deploy call
+                        model.start(deploy: { siteID, siteDirectory, configDirectory, routes in
+                            deployModel.deploy(
+                                siteID: siteID, siteDirectory: siteDirectory,
+                                configDirectory: configDirectory, currentRoutes: routes)
+                        })
                     }
                     .disabled(!model.canStart)
                 }

--- a/Sources/AnglesiteApp/ExperimentConfigureView.swift
+++ b/Sources/AnglesiteApp/ExperimentConfigureView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+import AnglesiteCore
+
+/// The configure step of the experiment lifecycle (#1518): scaffold the variant page, choose
+/// what counts as a win, then start the test. Reached from `.propose` once a `Draft` exists;
+/// `model.step`'s associated `Draft` is the single source of truth for what's already set.
+struct ExperimentConfigureView: View {
+    @Bindable var model: ExperimentStatsModel
+    var enterGoalPickMode: () -> Void
+    var exitGoalPickMode: () -> Void
+
+    @State private var scrollDepth: Double = 75
+    @State private var pageviewPath: String = ""
+
+    private var draft: ExperimentStatsModel.Draft? {
+        guard case .configure(let draft) = model.step else { return nil }
+        return draft
+    }
+
+    var body: some View {
+        Form {
+            if let draft {
+                Section(draft.name) {
+                    if draft.variantPage == nil {
+                        Button("Create the variant page") {
+                            Task { await model.scaffoldVariant() }
+                        }
+                    } else {
+                        LabeledContent("Variant page", value: draft.variantPage ?? "")
+                        Text("Edit its content from the page editor, then choose what counts as a win below.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                Section("What counts as a win?") {
+                    goalOptionRow(
+                        title: "Counts when a visitor reaches a page",
+                        isSelected: draft.goalKind == "pageview") {
+                        TextField("Page (e.g. /contact/thanks/)", text: $pageviewPath)
+                        Button("Use this page") { model.setPageviewGoal(path: pageviewPath) }
+                            .disabled(pageviewPath.isEmpty)
+                    }
+                    goalOptionRow(
+                        title: "Counts when a visitor scrolls partway down",
+                        isSelected: draft.goalKind == "scroll") {
+                        Slider(value: $scrollDepth, in: 1...100, step: 1) {
+                            Text("Scroll depth")
+                        }
+                        Button("Use \(Int(scrollDepth))% scrolled") { model.setScrollGoal(depth: Int(scrollDepth)) }
+                    }
+                    goalOptionRow(
+                        title: "Counts when a visitor sees something on the page",
+                        isSelected: draft.goalKind == "visible") {
+                        Button(model.goalPickController.state == .picking ? "Click the element in the preview…" : "Choose in the preview") {
+                            model.goalPickController.startPicking(enterOverlayMode: enterGoalPickMode, exitOverlayMode: exitGoalPickMode)
+                        }
+                        .disabled(model.goalPickController.state == .picking)
+                        if case .failed(let reason) = model.goalPickController.state {
+                            Text(reason).font(.caption).foregroundStyle(.orange)
+                        }
+                    }
+                }
+                Section {
+                    Button("Start your test") {
+                        model.start(deploy: { _, _, _, _ in }) // Task 15 supplies the real deploy call
+                    }
+                    .disabled(!model.canStart)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func goalOptionRow<Content: View>(title: String, isSelected: Bool, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading) {
+            Label(title, systemImage: isSelected ? "checkmark.circle.fill" : "circle")
+                .accessibilityAddTraits(isSelected ? .isSelected : [])
+            content()
+        }
+    }
+}

--- a/Sources/AnglesiteApp/ExperimentConfigureView.swift
+++ b/Sources/AnglesiteApp/ExperimentConfigureView.swift
@@ -6,7 +6,15 @@ import AnglesiteCore
 /// `model.step`'s associated `Draft` is the single source of truth for what's already set.
 struct ExperimentConfigureView: View {
     @Bindable var model: ExperimentStatsModel
-    var deployModel: DeployModel
+    /// Runs the site's one real deploy path — `SiteWindowModel.deploySite()`, threaded down from
+    /// `SiteWindow`. Deliberately not a `DeployModel.deploy(...)` call assembled here: only
+    /// `SiteWindowModel` can enumerate the site's full route set and its `Config/` directory, and
+    /// getting either wrong corrupts the deployed-routes snapshot or the worker plan (#1518 C2).
+    var deploySite: () -> Void
+    /// Owner-facing reason `deploySite` would not actually publish right now, or `nil`. Evaluated
+    /// at `SiteWindow`, where both `SiteWindowModel.canRunDeploy` and `DeployModel`'s own
+    /// preconditions are visible — see `ExperimentStatsModel.start(unavailableReason:deploy:)`.
+    var deployUnavailableReason: () -> String?
     var enterGoalPickMode: () -> Void
     var exitGoalPickMode: () -> Void
 
@@ -25,6 +33,9 @@ struct ExperimentConfigureView: View {
                     if draft.variantPage == nil {
                         Button("Create the variant page") {
                             Task { await model.scaffoldVariant() }
+                        }
+                        if let reason = model.scaffoldFailureReason {
+                            Text(reason).font(.caption).foregroundStyle(.orange)
                         }
                     } else {
                         LabeledContent("Variant page", value: draft.variantPage ?? "")
@@ -51,10 +62,19 @@ struct ExperimentConfigureView: View {
                     goalOptionRow(
                         title: "Counts when a visitor sees something on the page",
                         isSelected: draft.goalKind == "visible") {
-                        Button(model.goalPickController.state == .picking ? "Click the element in the preview…" : "Choose in the preview") {
-                            model.goalPickController.startPicking(enterOverlayMode: enterGoalPickMode, exitOverlayMode: exitGoalPickMode)
+                        HStack {
+                            Button(model.goalPickController.state == .picking ? "Click the element in the preview…" : "Choose in the preview") {
+                                model.goalPickController.startPicking(enterOverlayMode: enterGoalPickMode, exitOverlayMode: exitGoalPickMode)
+                            }
+                            .disabled(model.goalPickController.state == .picking)
+                            // Without this (and the sheet's `.onExitCommand`), picking mode has no
+                            // exit: the preview overlay stays armed and the button stays disabled
+                            // for the rest of the sheet's life (#1518 review, I1). Mirrors
+                            // `EffectsGalleryView`'s placement-HUD Cancel.
+                            if model.goalPickController.state == .picking {
+                                Button("Cancel") { model.goalPickController.cancel() }
+                            }
                         }
-                        .disabled(model.goalPickController.state == .picking)
                         if case .failed(let reason) = model.goalPickController.state {
                             Text(reason).font(.caption).foregroundStyle(.orange)
                         }
@@ -62,13 +82,12 @@ struct ExperimentConfigureView: View {
                 }
                 Section {
                     Button("Start your test") {
-                        model.start(deploy: { siteID, siteDirectory, configDirectory, routes in
-                            deployModel.deploy(
-                                siteID: siteID, siteDirectory: siteDirectory,
-                                configDirectory: configDirectory, currentRoutes: routes)
-                        })
+                        model.start(unavailableReason: deployUnavailableReason(), deploy: deploySite)
                     }
                     .disabled(!model.canStart)
+                    if let reason = model.startFailureReason {
+                        Text(reason).font(.caption).foregroundStyle(.orange)
+                    }
                 }
             }
         }

--- a/Sources/AnglesiteApp/ExperimentProposeView.swift
+++ b/Sources/AnglesiteApp/ExperimentProposeView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import AnglesiteCore
+
+/// The suggestion-browsing step of the experiment lifecycle (#1518): pick one of the playbook's
+/// test ideas, or type a custom one, to seed a `ExperimentStatsModel.Draft` and move to
+/// `.configure`. Reached from `.manual` by tapping a "Test ideas" row.
+struct ExperimentProposeView: View {
+    @Bindable var model: ExperimentStatsModel
+    @State private var customName = ""
+
+    var body: some View {
+        Form {
+            Section("What should we test?") {
+                ForEach(model.suggestions, id: \.title) { suggestion in
+                    Button {
+                        model.propose(from: suggestion)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(suggestion.title).font(.callout.weight(.medium))
+                            Text(suggestion.rationale).font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(suggestion.title)
+                    .accessibilityHint(suggestion.rationale)
+                }
+            }
+            Section("Or describe your own idea") {
+                TextField("What are you testing?", text: $customName)
+                Button("Start with this idea") { model.proposeCustom(name: customName) }
+                    .disabled(customName.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+        }
+    }
+}

--- a/Sources/AnglesiteApp/ExperimentRunningStatusView.swift
+++ b/Sources/AnglesiteApp/ExperimentRunningStatusView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import AnglesiteCore
+
+/// The running step of the experiment lifecycle (#1518): a live test with nothing left for the
+/// owner to configure — just a status readout until it concludes. Reached from `.configure` once
+/// `ExperimentStatsModel.observeDeployPhase(_:)` sees the starting deploy succeed.
+struct ExperimentRunningStatusView: View {
+    let experiment: DomainConfig.Experiments.Experiment
+
+    var body: some View {
+        Form {
+            Section(experiment.name) {
+                LabeledContent("Status") {
+                    Text("Live")
+                }
+                .accessibilityLabel("Status")
+                .accessibilityValue("Live")
+                if let startedAt = experiment.startedAt {
+                    LabeledContent("Started", value: startedAt)
+                }
+                Text("Your test is live. Visitors will see one version or the other; I'll tell you when there's a clear answer.")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+        }
+    }
+}

--- a/Sources/AnglesiteApp/ExperimentStatsModel.swift
+++ b/Sources/AnglesiteApp/ExperimentStatsModel.swift
@@ -115,9 +115,30 @@ final class ExperimentStatsModel: Identifiable {
             goalDepth: active.goal.depth, goalSelector: active.goal.selector))
     }
 
-    /// Advances from `.manual` to the suggestion-browsing step. A no-op from any other step.
+    /// Whether `anglesite.json` currently declares a `"running"` experiment, read fresh from disk
+    /// rather than derived from `step`. `step` alone can't answer this: `returnToManual()` (I6)
+    /// reaches `.manual` without touching the persisted config, so a running experiment can still
+    /// be live on disk while `step == .manual`. Gates `openPropose()` below — starting a new draft
+    /// from there would eventually reach `persistDraft`, which always replaces the *entire*
+    /// `experiments.active` array, silently ending the live test (losing its `"running"` status
+    /// and `startedAt`) with no warning. That violates both this schema's "only one active
+    /// experiment at a time" invariant (`DomainConfig.Experiments.active`'s doc comment) and this
+    /// codebase's "the app advises, it never surprises the owner" principle (#1518 review,
+    /// escape-hatch fix).
+    var runningExperiment: DomainConfig.Experiments.Experiment? {
+        guard let config = try? DomainConfigStore(sourceDirectory: sourceDirectory).load(),
+              let active = config.experiments?.active?.first, active.status == "running" else {
+            return nil
+        }
+        return active
+    }
+
+    /// Advances from `.manual` to the suggestion-browsing step. A no-op from any other step, and
+    /// also a no-op while a running experiment is declared on disk — reachable via
+    /// `returnToManual()` while one is live (see `runningExperiment`). The manual-entry form
+    /// itself stays reachable either way; only starting a *new* draft is refused.
     func openPropose() {
-        guard case .manual = step else { return }
+        guard case .manual = step, runningExperiment == nil else { return }
         step = .propose
     }
 

--- a/Sources/AnglesiteApp/ExperimentStatsModel.swift
+++ b/Sources/AnglesiteApp/ExperimentStatsModel.swift
@@ -205,16 +205,6 @@ final class ExperimentStatsModel: Identifiable {
         return draft.asExperiment != nil
     }
 
-    /// Test-only: replaces the in-progress `.configure` draft directly, bypassing
-    /// `scaffoldVariant`'s real file-system requirement so start-related tests can assemble a
-    /// fully-formed draft (variant page + goal) without an Astro page fixture on disk. A no-op
-    /// outside `.configure` — mirrors the guard pattern the rest of this file uses for its own
-    /// draft mutators (`updateDraftGoal`, `scaffoldVariant`).
-    func applyDraftForTesting(_ draft: Draft) {
-        guard case .configure = step else { return }
-        step = .configure(draft)
-    }
-
     /// Flips the draft's status to `running`, persists it, and invokes `deploy` — a closure rather
     /// than a direct `DeployModel` dependency so this model stays testable without constructing one
     /// (`DeployModel` pulls in token/license/container machinery none of this model's own logic

--- a/Sources/AnglesiteApp/ExperimentStatsModel.swift
+++ b/Sources/AnglesiteApp/ExperimentStatsModel.swift
@@ -59,6 +59,9 @@ final class ExperimentStatsModel: Identifiable {
 
     private(set) var step: Step
     let goalPickController = GoalElementPickController()
+    /// Resolves `siteID` back to `sourceDirectory` — the only site this model ever operates on —
+    /// rather than widening `NativeContentOperations`' general-purpose multi-site resolver.
+    private let contentOps: NativeContentOperations
 
     // #769 manual-entry fields — unchanged from before this task.
     var experimentName: String = ""
@@ -80,6 +83,8 @@ final class ExperimentStatsModel: Identifiable {
         self.sourceDirectory = sourceDirectory
         self.currentRoute = currentRoute
         self.step = Self.resolveInitialStep(sourceDirectory: sourceDirectory)
+        self.contentOps = NativeContentOperations(
+            siteDirectory: { queriedSiteID in queriedSiteID == siteID ? sourceDirectory : nil })
     }
 
     /// Reads `anglesite.json`'s declared experiment (if any) to decide where the sheet opens:
@@ -145,5 +150,58 @@ final class ExperimentStatsModel: Identifiable {
     /// entered counts themselves.
     func editAgain() {
         result = nil
+    }
+
+    /// Duplicates the control page under `/x/<experimentID>/<variantID>` via
+    /// `NativeContentOperations.duplicatePageAsVariant`, then records the built route on the
+    /// draft and persists it. A no-op outside `.configure` or once a variant is already scaffolded
+    /// (re-running would collide with the existing variant file).
+    func scaffoldVariant() async {
+        guard case .configure(var draft) = step, draft.variantPage == nil else { return }
+        let controlRelPath = "src/pages\(draft.page == "/" ? "/index" : draft.page).astro"
+        let result = await contentOps.duplicatePageAsVariant(
+            siteID: siteID, relativePath: controlRelPath, experimentID: draft.id, variantID: draft.variantID)
+        guard case .created(_, let route) = result else { return }
+        draft.variantPage = route
+        step = .configure(draft)
+        persistDraft(draft)
+    }
+
+    /// Sets a pageview goal (reaching `path` counts as a conversion) and persists the draft.
+    func setPageviewGoal(path: String) {
+        updateDraftGoal { $0.goalKind = "pageview"; $0.goalPath = path; $0.goalDepth = nil; $0.goalSelector = nil }
+    }
+
+    /// Sets a scroll-depth goal (`depth` percent of the page scrolled) and persists the draft.
+    func setScrollGoal(depth: Int) {
+        updateDraftGoal { $0.goalKind = "scroll"; $0.goalDepth = depth; $0.goalPath = nil; $0.goalSelector = nil }
+    }
+
+    /// Call after `goalPickController.state` reaches `.succeeded(selector:)` — the sheet view's
+    /// `.onChange(of: goalPickController.state)` is the caller (Task 14).
+    func applyPickedVisibleGoal() {
+        guard case .succeeded(let selector) = goalPickController.state else { return }
+        updateDraftGoal { $0.goalKind = "visible"; $0.goalSelector = selector; $0.goalPath = nil; $0.goalDepth = nil }
+        goalPickController.acknowledge()
+    }
+
+    private func updateDraftGoal(_ mutate: (inout Draft) -> Void) {
+        guard case .configure(var draft) = step else { return }
+        mutate(&draft)
+        step = .configure(draft)
+        persistDraft(draft)
+    }
+
+    /// Best-effort write-through of the in-progress draft to `anglesite.json` — a no-op until
+    /// both the variant and a goal are set (`Draft.asExperiment` is `nil` until then).
+    private func persistDraft(_ draft: Draft) {
+        guard let experiment = draft.asExperiment else { return }
+        DomainConfigStore.update(sourceDirectory: sourceDirectory) { $0.experiments = .init(active: [experiment]) }
+    }
+
+    /// Gates Task 13's start action: both the variant page and a goal must be set.
+    var canStart: Bool {
+        guard case .configure(let draft) = step else { return false }
+        return draft.asExperiment != nil
     }
 }

--- a/Sources/AnglesiteApp/ExperimentStatsModel.swift
+++ b/Sources/AnglesiteApp/ExperimentStatsModel.swift
@@ -46,13 +46,25 @@ final class ExperimentStatsModel: Identifiable {
         /// A `draft`-status `DomainConfig.Experiments.Experiment` once the variant is scaffolded
         /// and a goal is picked — `nil` while either is still missing, matching `canStart`'s gate
         /// in Task 13.
+        ///
+        /// The single choke point through which anything reaches `anglesite.json`, so it is also
+        /// where the served-route shape `scripts/pre-deploy-check.ts` demands is enforced: `page`,
+        /// `variant.page`, and a `pageview` goal's `path` all get the trailing slash, whatever
+        /// shape the `Draft` was assembled from (a fresh propose, a legacy config entry read back
+        /// by `resolveInitialStep`, or a failed start's revert). A slash-less value here fails the
+        /// gate for *every* subsequent deploy of the site — draft entries are validated too —
+        /// which is a publishing-breaking regression the app itself would have created (#1518).
         var asExperiment: DomainConfig.Experiments.Experiment? {
             guard let variantPage, let goalKind else { return nil }
             let goal = DomainConfig.Experiments.Experiment.Goal(
-                kind: goalKind, path: goalPath, depth: goalDepth, selector: goalSelector)
+                kind: goalKind,
+                path: goalPath.map { goalKind == "pageview" ? ContentScaffold.servedRoute($0) : $0 },
+                depth: goalDepth, selector: goalSelector)
             return DomainConfig.Experiments.Experiment(
-                id: id, name: name, page: page,
-                variant: .init(id: variantID, name: variantName, page: variantPage),
+                id: id, name: name, page: ContentScaffold.servedRoute(page),
+                variant: .init(
+                    id: variantID, name: variantName,
+                    page: ContentScaffold.servedRoute(variantPage)),
                 split: 0.5, goal: goal, status: "draft")
         }
     }
@@ -115,10 +127,15 @@ final class ExperimentStatsModel: Identifiable {
     }
 
     /// Seeds a `Draft` from an owner-typed name (slugified into the experiment id) and moves to
-    /// `.configure`. `page` defaults to the route the sheet was opened from.
+    /// `.configure`. `page` defaults to the route the sheet was opened from — normalized to the
+    /// served, trailing-slash form (`ContentScaffold.servedRoute`), since `currentRoute` comes from
+    /// `PreviewModel.activeRoute`/`ContentScanner.routeFromPagePath`, which produce the slash-less
+    /// file-path shape that `pre-deploy-check.ts` rejects for `experiments.active[].page` (#1518).
     func proposeCustom(name: String) {
         let slug = ContentScaffold.slugify(name)
-        step = .configure(Draft(id: slug, name: name, page: currentRoute, variantName: "\(name) — variant"))
+        step = .configure(Draft(
+            id: slug, name: name, page: ContentScaffold.servedRoute(currentRoute),
+            variantName: "\(name) — variant"))
     }
 
     /// Both variants need at least one visitor before there's anything to analyze —
@@ -152,24 +169,48 @@ final class ExperimentStatsModel: Identifiable {
         result = nil
     }
 
-    /// Duplicates the control page under `/x/<experimentID>/<variantID>` via
+    /// Duplicates the control page under `/x/<experimentID>/<variantID>/` via
     /// `NativeContentOperations.duplicatePageAsVariant`, then records the built route on the
     /// draft and persists it. A no-op outside `.configure` or once a variant is already scaffolded
     /// (re-running would collide with the existing variant file).
+    ///
+    /// A failure is surfaced through `scaffoldFailureReason` rather than swallowed: the underlying
+    /// operation's `.failed` reasons ("No page exists at …", "A variant page already exists at …",
+    /// "Couldn't find a <BaseLayout> invocation …") are each something the owner can act on, and a
+    /// button that visibly does nothing is not (#1518 review, I3).
     func scaffoldVariant() async {
         guard case .configure(var draft) = step, draft.variantPage == nil else { return }
-        let controlRelPath = "src/pages\(draft.page == "/" ? "/index" : draft.page).astro"
+        // `draft.page` is a served route (trailing slash); the control's `.astro` is at the
+        // file-path form of it — `/` → `src/pages/index.astro`, `/pricing/` → `src/pages/pricing.astro`.
+        let controlRelPath = ContentScaffold.pageRelativePath(servedRoute: draft.page)
         let result = await contentOps.duplicatePageAsVariant(
             siteID: siteID, relativePath: controlRelPath, experimentID: draft.id, variantID: draft.variantID)
-        guard case .created(_, let route) = result else { return }
-        draft.variantPage = route
-        step = .configure(draft)
-        persistDraft(draft)
+        switch result {
+        case .created(_, let route):
+            scaffoldFailureReason = nil
+            draft.variantPage = route
+            step = .configure(draft)
+            persistDraft(draft)
+        case .failed(let reason):
+            scaffoldFailureReason = reason
+        case .siteNotFound:
+            scaffoldFailureReason = "Couldn't find this site's files on disk."
+        }
     }
 
+    /// Why the last "Create the variant page" attempt didn't produce a variant — `nil` when none
+    /// has failed since the last success. Surfaced by `ExperimentConfigureView` beside the button.
+    private(set) var scaffoldFailureReason: String?
+
     /// Sets a pageview goal (reaching `path` counts as a conversion) and persists the draft.
+    ///
+    /// `path` is normalized to the served, trailing-slash form for the same reason `page` and
+    /// `variant.page` are: `pre-deploy-check.ts` validates a `pageview` goal path with
+    /// `requireTrailingSlash`, and the edge worker's `matchesGoal` compares it against the
+    /// canonicalized request path with `===`.
     func setPageviewGoal(path: String) {
-        updateDraftGoal { $0.goalKind = "pageview"; $0.goalPath = path; $0.goalDepth = nil; $0.goalSelector = nil }
+        let normalized = ContentScaffold.servedRoute(path)
+        updateDraftGoal { $0.goalKind = "pageview"; $0.goalPath = normalized; $0.goalDepth = nil; $0.goalSelector = nil }
     }
 
     /// Sets a scroll-depth goal (`depth` percent of the page scrolled) and persists the draft.
@@ -208,15 +249,54 @@ final class ExperimentStatsModel: Identifiable {
     /// Flips the draft's status to `running`, persists it, and invokes `deploy` — a closure rather
     /// than a direct `DeployModel` dependency so this model stays testable without constructing one
     /// (`DeployModel` pulls in token/license/container machinery none of this model's own logic
-    /// needs). `SiteWindow` (Task 15) supplies the real `DeployModel.deploy(...)` call; the view's
-    /// own `.onChange(of: deployModel.phase)` then calls `observeDeployPhase(_:)` below.
-    func start(deploy: (String, URL, URL, [String]) -> Void) {
+    /// needs). The view's own `.onChange(of: deployModel.phase)` then calls `observeDeployPhase(_:)`
+    /// below.
+    ///
+    /// `deploy` takes **no arguments** on purpose (#1518 review, C2). An earlier shape handed it
+    /// the site id, directories, and routes, which invited the call site to reconstruct arguments
+    /// only `SiteWindowModel.deploySite()` knows how to build correctly — and it got them wrong:
+    /// `Source/` passed as the config directory (app-owned state must never live in the git repo),
+    /// and a two-element `currentRoutes` that would have overwritten the site's whole
+    /// `DeployedRoutesSnapshot` with just the experiment's two pages. The closure now simply calls
+    /// `SiteWindowModel.deploySite()`, the one production deploy path.
+    ///
+    /// - Parameter unavailableReason: Non-`nil` when `deploy` would *not* actually run a deploy to
+    ///   completion right now (no Cloudflare sign-in yet, no license choice yet, another publish in
+    ///   flight) — see `DeployModel.deployUnavailableReason(siteDirectory:)`. In that case nothing
+    ///   is written to `anglesite.json` and the step stays on `.configure`, because `deploy(...)`
+    ///   silently parks in those cases and `.starting` would never be left (#1518 review, I5).
+    func start(unavailableReason: String? = nil, deploy: () -> Void) {
         guard case .configure(let draft) = step, var experiment = draft.asExperiment else { return }
+        if let unavailableReason {
+            startFailureReason = unavailableReason
+            return
+        }
+        startFailureReason = nil
         experiment.status = "running"
         experiment.startedAt = ISO8601DateFormatter().string(from: Date()).prefix(10).description
         DomainConfigStore.update(sourceDirectory: sourceDirectory) { $0.experiments = .init(active: [experiment]) }
         step = .starting
-        deploy(siteID, sourceDirectory, sourceDirectory, [experiment.page, experiment.variant.page])
+        deploy()
+    }
+
+    /// Whether the "Analyze manually" escape hatch applies (#1518 review, I6). Live per-variant
+    /// counts aren't wired up yet (#1270), so the manual-entry form is the only working analysis
+    /// surface — an owner mid-configure or with a running test needs a way back to it. Excluded
+    /// from `.starting`: a deploy is in flight there and `observeDeployPhase(_:)` still needs the
+    /// step to come back to it.
+    var canReturnToManual: Bool {
+        switch step {
+        case .manual, .starting: return false
+        case .propose, .configure, .running: return true
+        }
+    }
+
+    /// Returns to the `.manual` analysis form. Purely a UI move — it neither reverts nor deletes
+    /// whatever `anglesite.json` already records, so re-opening the sheet lands back on the
+    /// lifecycle step the config implies.
+    func returnToManual() {
+        guard canReturnToManual else { return }
+        step = .manual
     }
 
     /// Called from the sheet view's `.onChange(of: deployModel.phase)` while `step == .starting`.
@@ -234,7 +314,16 @@ final class ExperimentStatsModel: Identifiable {
             revertToConfigureAfterFailedStart(reason: reason)
         case .blocked:
             revertToConfigureAfterFailedStart(reason: "The pre-deploy check found issues that need fixing first.")
-        case .idle, .running, .workerNameConflict, .webmentionPaidPlanConfirmationNeeded, .domainConfigDrift:
+        case .workerNameConflict, .webmentionPaidPlanConfirmationNeeded, .domainConfigDrift:
+            // These three park the deploy on a confirmation sheet of `DeployModel`'s own — which
+            // cannot present while this sheet occupies the window's modal slot. Treated as a failed
+            // start (config rolled back to `"draft"`, so the parked deploy can't publish a test the
+            // owner never confirmed) rather than ignored: ignoring them would strand `.starting`
+            // forever, and Done is disabled during `.starting` to keep this observation alive
+            // (#1518 review, I4).
+            revertToConfigureAfterFailedStart(
+                reason: "Publishing paused and needs an answer from you. Close this and choose Publish to finish, then start your test.")
+        case .idle, .running:
             return
         }
     }

--- a/Sources/AnglesiteApp/ExperimentStatsModel.swift
+++ b/Sources/AnglesiteApp/ExperimentStatsModel.swift
@@ -2,18 +2,65 @@ import Foundation
 import Observation
 import AnglesiteCore
 
-/// Drives the Experiment Results sheet (#769): a manual-entry front door onto `ExperimentStats`.
-/// The retired Claude Code plugin's edge A/B machinery (cookie-based variant assignment, an
-/// analytics pipeline reporting impressions/conversions back to the app) was never rebuilt after
-/// #466 — see `ExperimentStats`' doc comment and the follow-up (#1270) — so this sheet takes the
-/// two variants' counts as owner-typed input (read off whatever analytics the owner already has)
-/// rather than reading them from a stored experiment config. Fresh-per-open, same lifecycle as
-/// `CopyEditReportModel`.
+/// Drives the Experiment Results sheet (#769) and, as of #1518, the experiment lifecycle that
+/// leads up to it: propose a suggestion, configure its variant/goal, start it running, and only
+/// then fall back to manual-entry analysis. The retired Claude Code plugin's edge A/B machinery
+/// (cookie-based variant assignment, an analytics pipeline reporting impressions/conversions back
+/// to the app) was never rebuilt after #466 — see `ExperimentStats`' doc comment and the
+/// follow-up (#1270) — so `.manual` still takes the two variants' counts as owner-typed input
+/// (read off whatever analytics the owner already has) rather than reading them from a stored
+/// experiment config. Fresh-per-open, same lifecycle as `CopyEditReportModel`.
 @Observable @MainActor
 final class ExperimentStatsModel: Identifiable {
     let id = UUID()
     let siteID: String
+    let sourceDirectory: URL
+    let currentRoute: String
 
+    /// The sheet's current lifecycle position, resolved from `anglesite.json`'s declared
+    /// experiment (if any) at construction time and advanced by `propose(from:)`/`proposeCustom`
+    /// (this task) and the configure/start actions (Task 12).
+    enum Step: Equatable {
+        case manual
+        case propose
+        case configure(Draft)
+        case starting
+        case running(DomainConfig.Experiments.Experiment)
+    }
+
+    /// A not-yet-declared experiment being assembled through the configure step: an id/name/page
+    /// seeded by `propose(from:)`, then filled in by Task 12's variant-scaffolding and
+    /// goal-picking actions.
+    struct Draft: Equatable {
+        var id: String
+        var name: String
+        var page: String
+        var variantID: String = "b"
+        var variantName: String
+        var variantPage: String?
+        var goalKind: String?
+        var goalPath: String?
+        var goalDepth: Int?
+        var goalSelector: String?
+
+        /// A `draft`-status `DomainConfig.Experiments.Experiment` once the variant is scaffolded
+        /// and a goal is picked — `nil` while either is still missing, matching `canStart`'s gate
+        /// in Task 13.
+        var asExperiment: DomainConfig.Experiments.Experiment? {
+            guard let variantPage, let goalKind else { return nil }
+            let goal = DomainConfig.Experiments.Experiment.Goal(
+                kind: goalKind, path: goalPath, depth: goalDepth, selector: goalSelector)
+            return DomainConfig.Experiments.Experiment(
+                id: id, name: name, page: page,
+                variant: .init(id: variantID, name: variantName, page: variantPage),
+                split: 0.5, goal: goal, status: "draft")
+        }
+    }
+
+    private(set) var step: Step
+    let goalPickController = GoalElementPickController()
+
+    // #769 manual-entry fields — unchanged from before this task.
     var experimentName: String = ""
     var controlName: String = "Original"
     var controlImpressions: Int = 0
@@ -28,8 +75,45 @@ final class ExperimentStatsModel: Identifiable {
 
     let suggestions = ExperimentStats.suggestionPlaybook
 
-    init(siteID: String) {
+    init(siteID: String, sourceDirectory: URL, currentRoute: String) {
         self.siteID = siteID
+        self.sourceDirectory = sourceDirectory
+        self.currentRoute = currentRoute
+        self.step = Self.resolveInitialStep(sourceDirectory: sourceDirectory)
+    }
+
+    /// Reads `anglesite.json`'s declared experiment (if any) to decide where the sheet opens:
+    /// `.manual` when there's nothing declared, `.running` when it's live, `.configure`
+    /// (pre-populated from the declaration) when it's still a draft.
+    private static func resolveInitialStep(sourceDirectory: URL) -> Step {
+        guard let config = try? DomainConfigStore(sourceDirectory: sourceDirectory).load(),
+              let active = config.experiments?.active?.first else {
+            return .manual
+        }
+        if active.status == "running" { return .running(active) }
+        return .configure(Draft(
+            id: active.id, name: active.name, page: active.page,
+            variantID: active.variant.id, variantName: active.variant.name, variantPage: active.variant.page,
+            goalKind: active.goal.kind, goalPath: active.goal.path,
+            goalDepth: active.goal.depth, goalSelector: active.goal.selector))
+    }
+
+    /// Advances from `.manual` to the suggestion-browsing step. A no-op from any other step.
+    func openPropose() {
+        guard case .manual = step else { return }
+        step = .propose
+    }
+
+    /// Seeds a `Draft` from a playbook suggestion's title and moves to `.configure`.
+    func propose(from suggestion: ExperimentStats.Suggestion) {
+        proposeCustom(name: suggestion.title)
+    }
+
+    /// Seeds a `Draft` from an owner-typed name (slugified into the experiment id) and moves to
+    /// `.configure`. `page` defaults to the route the sheet was opened from.
+    func proposeCustom(name: String) {
+        let slug = ContentScaffold.slugify(name)
+        step = .configure(Draft(id: slug, name: name, page: currentRoute, variantName: "\(name) — variant"))
     }
 
     /// Both variants need at least one visitor before there's anything to analyze —

--- a/Sources/AnglesiteApp/ExperimentStatsModel.swift
+++ b/Sources/AnglesiteApp/ExperimentStatsModel.swift
@@ -204,4 +204,68 @@ final class ExperimentStatsModel: Identifiable {
         guard case .configure(let draft) = step else { return false }
         return draft.asExperiment != nil
     }
+
+    /// Test-only: replaces the in-progress `.configure` draft directly, bypassing
+    /// `scaffoldVariant`'s real file-system requirement so start-related tests can assemble a
+    /// fully-formed draft (variant page + goal) without an Astro page fixture on disk. A no-op
+    /// outside `.configure` — mirrors the guard pattern the rest of this file uses for its own
+    /// draft mutators (`updateDraftGoal`, `scaffoldVariant`).
+    func applyDraftForTesting(_ draft: Draft) {
+        guard case .configure = step else { return }
+        step = .configure(draft)
+    }
+
+    /// Flips the draft's status to `running`, persists it, and invokes `deploy` — a closure rather
+    /// than a direct `DeployModel` dependency so this model stays testable without constructing one
+    /// (`DeployModel` pulls in token/license/container machinery none of this model's own logic
+    /// needs). `SiteWindow` (Task 15) supplies the real `DeployModel.deploy(...)` call; the view's
+    /// own `.onChange(of: deployModel.phase)` then calls `observeDeployPhase(_:)` below.
+    func start(deploy: (String, URL, URL, [String]) -> Void) {
+        guard case .configure(let draft) = step, var experiment = draft.asExperiment else { return }
+        experiment.status = "running"
+        experiment.startedAt = ISO8601DateFormatter().string(from: Date()).prefix(10).description
+        DomainConfigStore.update(sourceDirectory: sourceDirectory) { $0.experiments = .init(active: [experiment]) }
+        step = .starting
+        deploy(siteID, sourceDirectory, sourceDirectory, [experiment.page, experiment.variant.page])
+    }
+
+    /// Called from the sheet view's `.onChange(of: deployModel.phase)` while `step == .starting`.
+    /// Any phase other than a clean success reverts to `.configure` with the draft intact and its
+    /// config entry rolled back to `"draft"` — a failed start must never leave `anglesite.json`
+    /// claiming a test is live when the deploy that would make it so never landed.
+    func observeDeployPhase(_ phase: DeployModel.Phase) {
+        guard case .starting = step else { return }
+        switch phase {
+        case .succeeded:
+            guard let config = try? DomainConfigStore(sourceDirectory: sourceDirectory).load(),
+                  let running = config.experiments?.active?.first else { return }
+            step = .running(running)
+        case .failed(let reason, _):
+            revertToConfigureAfterFailedStart(reason: reason)
+        case .blocked:
+            revertToConfigureAfterFailedStart(reason: "The pre-deploy check found issues that need fixing first.")
+        case .idle, .running, .workerNameConflict, .webmentionPaidPlanConfirmationNeeded, .domainConfigDrift:
+            return
+        }
+    }
+
+    private func revertToConfigureAfterFailedStart(reason: String) {
+        guard case .starting = step,
+              let config = try? DomainConfigStore(sourceDirectory: sourceDirectory).load(),
+              let entry = config.experiments?.active?.first else { return }
+        DomainConfigStore.update(sourceDirectory: sourceDirectory) { config in
+            var reverted = entry
+            reverted.status = "draft"
+            reverted.startedAt = nil
+            config.experiments = .init(active: [reverted])
+        }
+        step = .configure(Draft(
+            id: entry.id, name: entry.name, page: entry.page,
+            variantID: entry.variant.id, variantName: entry.variant.name, variantPage: entry.variant.page,
+            goalKind: entry.goal.kind, goalPath: entry.goal.path,
+            goalDepth: entry.goal.depth, goalSelector: entry.goal.selector))
+        startFailureReason = reason
+    }
+
+    private(set) var startFailureReason: String?
 }

--- a/Sources/AnglesiteApp/ExperimentStatsSheetView.swift
+++ b/Sources/AnglesiteApp/ExperimentStatsSheetView.swift
@@ -9,6 +9,10 @@ import AnglesiteCore
 struct ExperimentStatsSheetView: View {
     @Bindable var model: ExperimentStatsModel
     var deployModel: DeployModel
+    /// `SiteWindowModel.deploySite()` — see `ExperimentConfigureView.deploySite`.
+    var deploySite: () -> Void
+    /// See `ExperimentConfigureView.deployUnavailableReason`.
+    var deployUnavailableReason: () -> String?
     var onDone: () -> Void
     var enterGoalPickMode: () -> Void
     var exitGoalPickMode: () -> Void
@@ -23,7 +27,8 @@ struct ExperimentStatsSheetView: View {
                     ExperimentProposeView(model: model)
                 case .configure:
                     ExperimentConfigureView(
-                        model: model, deployModel: deployModel,
+                        model: model, deploySite: deploySite,
+                        deployUnavailableReason: deployUnavailableReason,
                         enterGoalPickMode: enterGoalPickMode, exitGoalPickMode: exitGoalPickMode)
                 case .starting:
                     ProgressView("Starting your test…")
@@ -34,12 +39,32 @@ struct ExperimentStatsSheetView: View {
             .formStyle(.grouped)
             .navigationTitle("Experiment Results")
             .toolbar {
+                // One shared affordance rather than a button per non-manual view: the manual-entry
+                // form (#769) is still the only working analysis surface until live counts land
+                // (#1270), so every lifecycle step needs a way back to it (#1518 review, I6).
+                if model.canReturnToManual {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Analyze Manually") { model.returnToManual() }
+                    }
+                }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { onDone() }
+                        // A failed start is rolled back to `"draft"` by this view's own
+                        // `.onChange(of: deployModel.phase)` observer — which dies with the view.
+                        // Dismissing mid-deploy would leave `anglesite.json` permanently claiming a
+                        // test is live that never published (#1518 review, I4). `.starting` always
+                        // ends: `start(unavailableReason:deploy:)` refuses to enter it unless the
+                        // deploy will really run, and `observeDeployPhase(_:)` now handles every
+                        // non-`.running` phase.
+                        .disabled(model.step == .starting)
                 }
             }
         }
         .frame(minWidth: 520, idealWidth: 560, minHeight: 480, idealHeight: 620)
+        .onExitCommand { model.goalPickController.cancel() }
+        // Dismissing the sheet mid-pick would otherwise leave the preview overlay armed with no
+        // controller left to answer it. A no-op unless actually picking.
+        .onDisappear { model.goalPickController.cancel() }
         .onChange(of: model.step) { oldStep, newStep in
             guard AppSettings.shared.announcesLiveUpdates else { return }
             // `newStep`'s activity needs `model.startFailureReason` too: a failed deploy reverts

--- a/Sources/AnglesiteApp/ExperimentStatsSheetView.swift
+++ b/Sources/AnglesiteApp/ExperimentStatsSheetView.swift
@@ -22,7 +22,9 @@ struct ExperimentStatsSheetView: View {
                 case .propose:
                     ExperimentProposeView(model: model)
                 case .configure:
-                    ExperimentConfigureView(model: model, enterGoalPickMode: enterGoalPickMode, exitGoalPickMode: exitGoalPickMode)
+                    ExperimentConfigureView(
+                        model: model, deployModel: deployModel,
+                        enterGoalPickMode: enterGoalPickMode, exitGoalPickMode: exitGoalPickMode)
                 case .starting:
                     ProgressView("Starting your test…")
                 case .running(let experiment):

--- a/Sources/AnglesiteApp/ExperimentStatsSheetView.swift
+++ b/Sources/AnglesiteApp/ExperimentStatsSheetView.swift
@@ -126,16 +126,25 @@ struct ExperimentStatsSheetView: View {
             }
 
             Section("Test ideas") {
-                ForEach(model.suggestions, id: \.title) { suggestion in
-                    Button {
-                        model.openPropose()
-                    } label: {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(suggestion.title).font(.callout.weight(.medium))
-                            Text(suggestion.rationale).font(.caption).foregroundStyle(.secondary)
+                if let running = model.runningExperiment {
+                    // `openPropose()` refuses while a running experiment is declared (it would
+                    // otherwise be reachable here via `returnToManual()`), so this row explains
+                    // why in terms of the owner's live test rather than leaving the buttons a
+                    // silent no-op.
+                    Text("“\(running.name)” is your live test right now. Wait for it to finish before starting a new one.")
+                        .font(.caption).foregroundStyle(.secondary)
+                } else {
+                    ForEach(model.suggestions, id: \.title) { suggestion in
+                        Button {
+                            model.openPropose()
+                        } label: {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(suggestion.title).font(.callout.weight(.medium))
+                                Text(suggestion.rationale).font(.caption).foregroundStyle(.secondary)
+                            }
                         }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
                 }
             }
         }

--- a/Sources/AnglesiteApp/ExperimentStatsSheetView.swift
+++ b/Sources/AnglesiteApp/ExperimentStatsSheetView.swift
@@ -100,11 +100,15 @@ struct ExperimentStatsSheetView: View {
 
             Section("Test ideas") {
                 ForEach(model.suggestions, id: \.title) { suggestion in
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(suggestion.title).font(.callout.weight(.medium))
-                        Text(suggestion.rationale).font(.caption).foregroundStyle(.secondary)
+                    Button {
+                        model.openPropose()
+                    } label: {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(suggestion.title).font(.callout.weight(.medium))
+                            Text(suggestion.rationale).font(.caption).foregroundStyle(.secondary)
+                        }
                     }
-                    .onTapGesture { model.openPropose() }
+                    .buttonStyle(.plain)
                 }
             }
         }

--- a/Sources/AnglesiteApp/ExperimentStatsSheetView.swift
+++ b/Sources/AnglesiteApp/ExperimentStatsSheetView.swift
@@ -3,42 +3,30 @@ import AnglesiteCore
 
 /// UI for `ExperimentStatsModel` (#769): owner types in each variant's impression/conversion
 /// counts, gets `ExperimentStats`' exact Bayesian analysis back in plain language, plus the
-/// default test-idea playbook for owners who haven't started a test yet.
+/// default test-idea playbook for owners who haven't started a test yet. As of #1518, also hosts
+/// the lifecycle that leads up to manual entry — propose a suggestion, configure its
+/// variant/goal, start it running — by switching on `model.step`.
 struct ExperimentStatsSheetView: View {
     @Bindable var model: ExperimentStatsModel
+    var deployModel: DeployModel
     var onDone: () -> Void
+    var enterGoalPickMode: () -> Void
+    var exitGoalPickMode: () -> Void
 
     var body: some View {
         NavigationStack {
-            Form {
-                Section("Experiment") {
-                    TextField("What are you testing? (optional)", text: $model.experimentName)
-                }
-                variantSection(
-                    title: "Original (control)", name: $model.controlName,
-                    impressions: $model.controlImpressions, conversions: $model.controlConversions)
-                variantSection(
-                    title: "Variant (treatment)", name: $model.treatmentName,
-                    impressions: $model.treatmentImpressions, conversions: $model.treatmentConversions)
-
-                Section {
-                    Button("Analyze") {
-                        model.analyze()
-                    }
-                    .disabled(!model.canAnalyze)
-                }
-
-                if let result = model.result {
-                    resultSection(result)
-                }
-
-                Section("Test ideas") {
-                    ForEach(model.suggestions, id: \.title) { suggestion in
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(suggestion.title).font(.callout.weight(.medium))
-                            Text(suggestion.rationale).font(.caption).foregroundStyle(.secondary)
-                        }
-                    }
+            Group {
+                switch model.step {
+                case .manual:
+                    manualForm
+                case .propose:
+                    ExperimentProposeView(model: model)
+                case .configure:
+                    ExperimentConfigureView(model: model, enterGoalPickMode: enterGoalPickMode, exitGoalPickMode: exitGoalPickMode)
+                case .starting:
+                    ProgressView("Starting your test…")
+                case .running(let experiment):
+                    ExperimentRunningStatusView(experiment: experiment)
                 }
             }
             .formStyle(.grouped)
@@ -50,6 +38,76 @@ struct ExperimentStatsSheetView: View {
             }
         }
         .frame(minWidth: 520, idealWidth: 560, minHeight: 480, idealHeight: 620)
+        .onChange(of: model.step) { oldStep, newStep in
+            guard AppSettings.shared.announcesLiveUpdates else { return }
+            // `newStep`'s activity needs `model.startFailureReason` too: a failed deploy reverts
+            // `step` from `.starting` back to `.configure`, which on its own is indistinguishable
+            // from a fresh, never-started `.configure` — losing the failure announcement entirely
+            // if `activity(for:)` looked at `step` alone. Consumed here (read, not cleared) since
+            // `experimentAnnouncement` already dedupes on `old != new`.
+            if let announcement = LiveRegionAnnouncer.experimentAnnouncement(
+                from: activity(for: oldStep, failureReason: nil),
+                to: activity(for: newStep, failureReason: model.startFailureReason)) {
+                AccessibilityNotification.Announcement(announcement).post()
+            }
+        }
+        .onChange(of: deployModel.phase) { _, newPhase in
+            model.observeDeployPhase(newPhase)
+        }
+        .onChange(of: model.goalPickController.state) { _, newState in
+            if case .succeeded = newState { model.applyPickedVisibleGoal() }
+        }
+    }
+
+    private func activity(for step: ExperimentStatsModel.Step, failureReason: String?) -> LiveRegionAnnouncer.ExperimentActivity {
+        switch step {
+        case .manual, .propose: return .inactive
+        case .configure:
+            // A `.configure` step reached via `observeDeployPhase`'s revert carries a
+            // `startFailureReason`; a `.configure` step reached via propose/scaffold/goal-setting
+            // never sets one (Task 12's methods don't touch it) — so this alone distinguishes the
+            // two without `step` needing its own dedicated `.justFailed` case.
+            if let failureReason { return .failed(reason: failureReason) }
+            return .inactive
+        case .starting: return .starting
+        case .running(let e): return .running(name: e.name)
+        }
+    }
+
+    @ViewBuilder
+    private var manualForm: some View {
+        Form {
+            Section("Experiment") {
+                TextField("What are you testing? (optional)", text: $model.experimentName)
+            }
+            variantSection(
+                title: "Original (control)", name: $model.controlName,
+                impressions: $model.controlImpressions, conversions: $model.controlConversions)
+            variantSection(
+                title: "Variant (treatment)", name: $model.treatmentName,
+                impressions: $model.treatmentImpressions, conversions: $model.treatmentConversions)
+
+            Section {
+                Button("Analyze") {
+                    model.analyze()
+                }
+                .disabled(!model.canAnalyze)
+            }
+
+            if let result = model.result {
+                resultSection(result)
+            }
+
+            Section("Test ideas") {
+                ForEach(model.suggestions, id: \.title) { suggestion in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(suggestion.title).font(.callout.weight(.medium))
+                        Text(suggestion.rationale).font(.caption).foregroundStyle(.secondary)
+                    }
+                    .onTapGesture { model.openPropose() }
+                }
+            }
+        }
     }
 
     private func variantSection(

--- a/Sources/AnglesiteApp/GoalElementPickController.swift
+++ b/Sources/AnglesiteApp/GoalElementPickController.swift
@@ -1,0 +1,58 @@
+// Sources/AnglesiteApp/GoalElementPickController.swift
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives the click-to-select flow for an A/B experiment's "visible" goal (#1270 slice 5):
+/// enters the overlay's goal-pick mode, waits for a click, and builds a CSS selector from it via
+/// `GoalSelectorBuilder`. Simpler than `EffectPlacementController` — no page-model fetch or
+/// applied edit, just a synchronous pure computation on the reported `ElementInfo`. One instance
+/// per `ExperimentStatsModel` (Task 12).
+@MainActor
+@Observable
+public final class GoalElementPickController {
+    public enum State: Equatable {
+        case idle
+        case picking
+        case succeeded(selector: String)
+        case failed(String)
+    }
+
+    public private(set) var state: State = .idle
+    private var exitOverlayMode: (() -> Void)?
+
+    public init() {}
+
+    public func startPicking(enterOverlayMode: @escaping () -> Void, exitOverlayMode: @escaping () -> Void) {
+        guard case .idle = state else { return }
+        self.exitOverlayMode = exitOverlayMode
+        state = .picking
+        enterOverlayMode()
+    }
+
+    public func cancel() {
+        guard case .picking = state else { return }
+        exitOverlayMode?()
+        exitOverlayMode = nil
+        state = .idle
+    }
+
+    /// Dismisses a terminal state (`.succeeded`/`.failed`) back to `.idle` — mirrors
+    /// `EffectPlacementController.acknowledge()`'s reasoning: without this, `startPicking`'s
+    /// `.idle` guard would refuse every pick after the first for the rest of this instance's life.
+    public func acknowledge() {
+        switch state {
+        case .succeeded, .failed: state = .idle
+        case .idle, .picking: return
+        }
+    }
+
+    public func handlePick(_ message: GoalElementPickMessage) {
+        guard case .picking = state else { return }
+        exitOverlayMode?()
+        exitOverlayMode = nil
+        switch GoalSelectorBuilder.build(for: message.element) {
+        case .success(let selector): state = .succeeded(selector: selector)
+        }
+    }
+}

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -523,6 +523,9 @@
     "Analyze ${experimentName}" : {
 
     },
+    "Analyze Manually" : {
+
+    },
     "Anglesite Debug" : {
 
     },
@@ -973,6 +976,9 @@
     "Choose an image to insert into this page." : {
 
     },
+    "Choose in the preview" : {
+
+    },
     "Choose where to save the local .anglesite file." : {
 
     },
@@ -1007,6 +1013,9 @@
 
     },
     "Click Recheck to run the pre-deploy scan against this site." : {
+
+    },
+    "Click the element in the preview…" : {
 
     },
     "Click to select the nearest node" : {
@@ -1341,6 +1350,9 @@
     "Create one with **Add Site → Create new site…**, or use **Add Site → Import existing site…** to add an existing `.anglesite` package." : {
 
     },
+    "Create the variant page" : {
+
+    },
     "Creating…" : {
 
     },
@@ -1552,6 +1564,9 @@
 
     },
     "Edit and re-analyze" : {
+
+    },
+    "Edit its content from the page editor, then choose what counts as a win below." : {
 
     },
     "Editing" : {
@@ -2158,6 +2173,12 @@
     "Link Post" : {
 
     },
+    "Linked to a Fediverse follower" : {
+
+    },
+    "Linked to a followed feed" : {
+
+    },
     "List" : {
 
     },
@@ -2659,6 +2680,9 @@
     "Optional: tls-reports@example.com" : {
 
     },
+    "Or describe your own idea" : {
+
+    },
     "Ordered" : {
 
     },
@@ -2681,6 +2705,9 @@
 
     },
     "Page" : {
+
+    },
+    "Page (e.g. /contact/thanks/)" : {
 
     },
     "Pages" : {
@@ -3288,6 +3315,9 @@
     "Script" : {
 
     },
+    "Scroll depth" : {
+
+    },
     "Search" : {
 
     },
@@ -3622,6 +3652,18 @@
 
     },
     "Start a design interview for ${site}" : {
+
+    },
+    "Start with this idea" : {
+
+    },
+    "Start your test" : {
+
+    },
+    "Started" : {
+
+    },
+    "Starting your test…" : {
 
     },
     "Starting…" : {
@@ -3998,6 +4040,9 @@
     "Upload Logo…" : {
 
     },
+    "Use %lld%% scrolled" : {
+
+    },
     "Use MX Records from DNS" : {
 
     },
@@ -4022,6 +4067,9 @@
     "Use this domain as your Bluesky handle" : {
 
     },
+    "Use this page" : {
+
+    },
     "Use “%@” from Contacts for %@?" : {
 
     },
@@ -4038,6 +4086,9 @@
 
     },
     "Valid" : {
+
+    },
+    "Variant page" : {
 
     },
     "Variant rate" : {
@@ -4118,10 +4169,19 @@
     "What are you selling?" : {
 
     },
+    "What are you testing?" : {
+
+    },
     "What are you testing? (optional)" : {
 
     },
+    "What counts as a win?" : {
+
+    },
     "What kind of website are you creating?" : {
+
+    },
+    "What should we test?" : {
 
     },
     "What this website is about, in a sentence" : {
@@ -4203,6 +4263,9 @@
 
     },
     "Your site's existing search (Pagefind) keeps working for free either way — AI Search's conversational answers are an opt-in upgrade above it, not a replacement." : {
+
+    },
+    "Your test is live. Visitors will see one version or the other; I'll tell you when there's a clear answer." : {
 
     },
     "Your website was created with warnings. You can open it anyway and fix it from the website window." : {

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -4414,6 +4414,9 @@
         }
       }
     },
+    "“%@” is your live test right now. Wait for it to finish before starting a new one." : {
+
+    },
     "“%@” matches a follower — add as a contact?" : {
 
     },

--- a/Sources/AnglesiteApp/PreviewView.swift
+++ b/Sources/AnglesiteApp/PreviewView.swift
@@ -37,6 +37,12 @@ struct PreviewView: NSViewRepresentable {
     /// doc comment. Defaults to a no-op for callers (e.g. tests) that don't need it.
     var onPlacementPick: AnglesiteScriptHandler.PlacementPickHandler = { _ in }
 
+    /// Called with a decoded `anglesite:pick-goal-element` message when the owner clicks an
+    /// element in the live preview while the experiment configure step's goal picker is armed
+    /// (#1518). Forwarded straight into `AnglesiteScriptHandler`'s own `onGoalElementPick` — see
+    /// that type's doc comment. Defaults to a no-op for callers (e.g. tests) that don't need it.
+    var onGoalElementPick: AnglesiteScriptHandler.GoalElementPickHandler = { _ in }
+
     /// Called every time a navigation finishes in the preview — an HMR reload, a route change, ⌘R.
     /// The overlay's placement-pick mode is closure-local JS state that a real navigation wipes
     /// (the `WKUserScript` re-runs and comes back inactive), so anything holding "we're waiting for
@@ -73,7 +79,9 @@ struct PreviewView: NSViewRepresentable {
             // WKWebView is torn down, releasing the strong reference.
             { @Sendable elements in await provider.update(elements) }
         }
-        let handler = AnglesiteScriptHandler(router: router, onVisibleElements: onVisibleElements, onPlacementPick: onPlacementPick)
+        let handler = AnglesiteScriptHandler(
+            router: router, onVisibleElements: onVisibleElements,
+            onPlacementPick: onPlacementPick, onGoalElementPick: onGoalElementPick)
         // `wysiwygTransport` is always a `WYSIWYGCanvasController` in production
         // (`PreviewModel.wysiwygCanvas`'s concrete type); casting once here — rather than inside
         // the handler closure on every message — is what lets `updateNSView` below compare "is

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -934,7 +934,17 @@ struct SiteWindow: View {
             EmailSetupSheetView(model: setupModel, onDone: { model.emailSetupModel = nil })
         }
         .sheet(item: $bindableModel.experimentStatsModel) { statsModel in
-            ExperimentStatsSheetView(model: statsModel, onDone: { model.experimentStatsModel = nil })
+            ExperimentStatsSheetView(
+                model: statsModel,
+                deployModel: model.deploy,
+                onDone: { model.experimentStatsModel = nil },
+                enterGoalPickMode: {
+                    model.preview.webView?.evaluateJavaScript("window.anglesite?._enterGoalPickMode?.()")
+                },
+                exitGoalPickMode: {
+                    model.preview.webView?.evaluateJavaScript("window.anglesite?._exitGoalPickMode?.()")
+                }
+            )
         }
         .sheet(item: $bindableModel.designInterviewModel) { interviewModel in
             NavigationStack {
@@ -1199,6 +1209,9 @@ struct SiteWindow: View {
                 wysiwygTransport: model.preview.wysiwygCanvas,
                 onPlacementPick: { message in
                     await model.effectPlacementController.handlePick(message)
+                },
+                onGoalElementPick: { message in
+                    model.experimentStatsModel?.goalPickController.handlePick(message)
                 },
                 // A finished navigation means the page's injected JS — including the overlay's
                 // placement-pick listener — was just thrown away and came back inactive. Cancel

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -937,6 +937,17 @@ struct SiteWindow: View {
             ExperimentStatsSheetView(
                 model: statsModel,
                 deployModel: model.deploy,
+                deploySite: { model.deploySite() },
+                deployUnavailableReason: {
+                    // `deploySite()`'s own `canRunDeploy` guard first — it returns silently, which
+                    // would strand the sheet on "Starting your test…" — then `DeployModel`'s
+                    // token/license/in-flight preconditions, whose sheets can't present over this
+                    // one anyway (#1518 review, I5).
+                    guard model.canRunDeploy else {
+                        return "Your site isn't ready to publish yet. Wait for the preview to finish starting (or for the current task to end), then start your test."
+                    }
+                    return model.deploy.deployUnavailableReason(siteDirectory: statsModel.sourceDirectory)
+                },
                 onDone: { model.experimentStatsModel = nil },
                 enterGoalPickMode: {
                     model.preview.webView?.evaluateJavaScript("window.anglesite?._enterGoalPickMode?.()")

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -1222,7 +1222,7 @@ struct SiteWindow: View {
                     await model.effectPlacementController.handlePick(message)
                 },
                 onGoalElementPick: { message in
-                    model.experimentStatsModel?.goalPickController.handlePick(message)
+                    await model.experimentStatsModel?.goalPickController.handlePick(message)
                 },
                 // A finished navigation means the page's injected JS — including the overlay's
                 // placement-pick listener — was just thrown away and came back inactive. Cancel

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -723,7 +723,8 @@ final class SiteWindowModel {
     /// `presentCopyEdit`.
     func presentExperimentStats() {
         guard experimentStatsModel == nil, let site else { return }
-        experimentStatsModel = ExperimentStatsModel(siteID: site.id)
+        experimentStatsModel = ExperimentStatsModel(
+            siteID: site.id, sourceDirectory: site.sourceDirectory, currentRoute: preview.activeRoute ?? "/")
     }
 
     /// Presents the Repurpose Post sheet (#465), same pattern as `presentCopyEdit`/`presentSocialPlan`.

--- a/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
+++ b/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
@@ -10,8 +10,8 @@ import AnglesiteBridgeCore
 /// `.webView`, and evaluate the reply script back into the page.
 ///
 /// **API change vs prior versions:** the primary entry point is now
-/// `dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:onPlacementPick:)` (forwarding to
-/// `AnglesiteMessageDispatcher.dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:onPlacementPick:)`).
+/// `dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:onPlacementPick:onGoalElementPick:)` (forwarding to
+/// `AnglesiteMessageDispatcher.dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:onPlacementPick:onGoalElementPick:)`).
 /// All current callers are internal to this repo (the `WKScriptMessageHandler` impl below, the
 /// unit tests — now in `AnglesiteBridgeCoreTests`, testing `AnglesiteMessageDispatcher` directly
 /// — and `PreviewView`'s production init) and use `dispatch` directly. The old `handle(body:via:)`
@@ -33,6 +33,8 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
     public typealias ComputedStylesHandler = AnglesiteMessageDispatcher.ComputedStylesHandler
     /// Callback for `anglesite:pick-placement` messages (see `AnglesiteMessageDispatcher`).
     public typealias PlacementPickHandler = AnglesiteMessageDispatcher.PlacementPickHandler
+    /// Callback for `anglesite:pick-goal-element` messages (see `AnglesiteMessageDispatcher`).
+    public typealias GoalElementPickHandler = AnglesiteMessageDispatcher.GoalElementPickHandler
     /// Outcome of dispatching one message body (see `AnglesiteMessageDispatcher.DispatchResult`).
     public typealias DispatchResult = AnglesiteMessageDispatcher.DispatchResult
 
@@ -41,6 +43,7 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
     private let onCanvasSelection: CanvasSelectionHandler?
     private let onComputedStyles: ComputedStylesHandler?
     private let onPlacementPick: PlacementPickHandler?
+    private let onGoalElementPick: GoalElementPickHandler?
     private let logCenter: LogCenter
 
     /// - Parameters:
@@ -51,6 +54,7 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
     ///   - onCanvasSelection: Optional callback for `anglesite:canvas-selection` messages.
     ///   - onComputedStyles: Optional callback for `anglesite:computed-styles` reports.
     ///   - onPlacementPick: Optional callback for `anglesite:pick-placement` messages.
+    ///   - onGoalElementPick: Optional callback for `anglesite:pick-goal-element` messages.
     ///   - logCenter: Destination for rejection/drop diagnostics — injectable for tests.
     public init(
         router: EditRouter,
@@ -58,6 +62,7 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
         onCanvasSelection: CanvasSelectionHandler? = nil,
         onComputedStyles: ComputedStylesHandler? = nil,
         onPlacementPick: PlacementPickHandler? = nil,
+        onGoalElementPick: GoalElementPickHandler? = nil,
         logCenter: LogCenter = .shared
     ) {
         self.router = router
@@ -65,11 +70,12 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
         self.onCanvasSelection = onCanvasSelection
         self.onComputedStyles = onComputedStyles
         self.onPlacementPick = onPlacementPick
+        self.onGoalElementPick = onGoalElementPick
         self.logCenter = logCenter
         super.init()
     }
 
-    /// Forwards to `AnglesiteMessageDispatcher.dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:onPlacementPick:)`
+    /// Forwards to `AnglesiteMessageDispatcher.dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:onPlacementPick:onGoalElementPick:)`
     /// — kept here so existing call sites (this class's own `userContentController`, and any
     /// code written against the pre-split API) don't need to change.
     public static func dispatch(
@@ -78,7 +84,8 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
         onVisibleElements: VisibleElementsHandler? = nil,
         onCanvasSelection: CanvasSelectionHandler? = nil,
         onComputedStyles: ComputedStylesHandler? = nil,
-        onPlacementPick: PlacementPickHandler? = nil
+        onPlacementPick: PlacementPickHandler? = nil,
+        onGoalElementPick: GoalElementPickHandler? = nil
     ) async -> DispatchResult {
         await AnglesiteMessageDispatcher.dispatch(
             body: body,
@@ -86,7 +93,8 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
             onVisibleElements: onVisibleElements,
             onCanvasSelection: onCanvasSelection,
             onComputedStyles: onComputedStyles,
-            onPlacementPick: onPlacementPick
+            onPlacementPick: onPlacementPick,
+            onGoalElementPick: onGoalElementPick
         )
     }
 
@@ -95,8 +103,8 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
     /// `onVisibleElements`, matching the prior behavior (apply-edit only). Returns the same
     /// `Result<EditReply, EditMessage.DecodeError>` shape callers were already matching on —
     /// rejection reasons map back into the legacy decode-error type.
-    @available(*, deprecated, renamed: "dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:onPlacementPick:)",
-               message: "handle() is apply-edit only and returns a less expressive shape. Use dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:onPlacementPick:) — it covers visible-elements/canvas-selection/computed-styles/pick-placement routing too and exposes the richer DispatchResult.")
+    @available(*, deprecated, renamed: "dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:onPlacementPick:onGoalElementPick:)",
+               message: "handle() is apply-edit only and returns a less expressive shape. Use dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:onPlacementPick:onGoalElementPick:) — it covers visible-elements/canvas-selection/computed-styles/pick-placement/pick-goal-element routing too and exposes the richer DispatchResult.")
     public static func handle(body: Any, via router: EditRouter) async -> Result<EditReply, EditMessage.DecodeError> {
         switch await dispatch(body: body, via: router, onVisibleElements: nil) {
         case .editReply(let reply):
@@ -158,6 +166,7 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
         let onCanvasSelection = self.onCanvasSelection
         let onComputedStyles = self.onComputedStyles
         let onPlacementPick = self.onPlacementPick
+        let onGoalElementPick = self.onGoalElementPick
         let logCenter = self.logCenter
         Task {
             switch await Self.dispatch(
@@ -166,7 +175,8 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
                 onVisibleElements: onVisibleElements,
                 onCanvasSelection: onCanvasSelection,
                 onComputedStyles: onComputedStyles,
-                onPlacementPick: onPlacementPick
+                onPlacementPick: onPlacementPick,
+                onGoalElementPick: onGoalElementPick
             ) {
             case .editReply(let reply):
                 guard let webView else { return }

--- a/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
+++ b/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
@@ -124,6 +124,9 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
         case .rejected(.placementPickDecode):
             // Unreachable under `handle`'s contract (apply-edit only). Same fallthrough.
             return .failure(.unknownType(PlacementPickMessage.messageType))
+        case .rejected(.goalElementPickDecode):
+            // Unreachable under `handle`'s contract (apply-edit only). Same fallthrough.
+            return .failure(.unknownType(GoalElementPickMessage.messageType))
         case .visibleElementsHandled, .visibleElementsDropped:
             // Unreachable: handler is nil. Same fallthrough as above.
             return .failure(.unknownType(VisibleElementReport.messageType))
@@ -136,6 +139,9 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
         case .placementPickHandled, .placementPickDropped:
             // Unreachable: handler is nil. Same fallthrough as above.
             return .failure(.unknownType(PlacementPickMessage.messageType))
+        case .goalElementPickHandled, .goalElementPickDropped:
+            // Unreachable: handler is nil. Same fallthrough as above.
+            return .failure(.unknownType(GoalElementPickMessage.messageType))
         }
     }
 
@@ -209,6 +215,14 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
                     source: "bridge",
                     stream: .stderr,
                     text: "pick-placement message dropped: no handler installed"
+                )
+            case .goalElementPickHandled:
+                return
+            case .goalElementPickDropped:
+                await logCenter.append(
+                    source: "bridge",
+                    stream: .stderr,
+                    text: "pick-goal-element message dropped: no handler installed"
                 )
             case .rejected(let reason):
                 await logCenter.append(

--- a/Sources/AnglesiteBridgeCore/AnglesiteMessageDispatcher.swift
+++ b/Sources/AnglesiteBridgeCore/AnglesiteMessageDispatcher.swift
@@ -22,6 +22,8 @@ import AnglesiteCore
 ///    `onComputedStyles` callback, posted alongside a canvas selection. No reply.
 /// 5. anglesite:pick-placement (a PlacementPickMessage) — dispatched to the optional
 ///    onPlacementPick callback. No reply.
+/// 6. anglesite:pick-goal-element (a GoalElementPickMessage) — dispatched to the optional
+///    onGoalElementPick callback. No reply.
 public enum AnglesiteMessageDispatcher {
     /// Receives the decoded elements of an `anglesite:visible-elements` report (message type 2
     /// above). Async so implementations can hop to their model's actor; no reply flows back.
@@ -32,6 +34,8 @@ public enum AnglesiteMessageDispatcher {
     public typealias ComputedStylesHandler = @Sendable (ComputedStylesReport) async -> Void
     /// Receives a decoded `anglesite:pick-placement` message (message type 5 above).
     public typealias PlacementPickHandler = @Sendable (PlacementPickMessage) async -> Void
+    /// Receives a decoded `anglesite:pick-goal-element` message (message type 6 above).
+    public typealias GoalElementPickHandler = @Sendable (GoalElementPickMessage) async -> Void
 
     /// The `WKUserContentController`/`WebKitUserContentManager`/WebView2 script-message name
     /// every platform adapter registers its handler under — the JS overlay posts messages here
@@ -60,6 +64,10 @@ public enum AnglesiteMessageDispatcher {
         case placementPickHandled
         /// `anglesite:pick-placement` arrived but no `onPlacementPick` handler is installed.
         case placementPickDropped
+        /// `anglesite:pick-goal-element` was forwarded to the optional handler.
+        case goalElementPickHandled
+        /// `anglesite:pick-goal-element` arrived but no `onGoalElementPick` handler is installed.
+        case goalElementPickDropped
         /// Body was undecodable. Log and move on.
         case rejected(RejectionReason)
 
@@ -85,6 +93,8 @@ public enum AnglesiteMessageDispatcher {
             case computedStylesDecode(ComponentCanvasDecodeError)
             /// `anglesite:pick-placement` matched but the payload failed to decode.
             case placementPickDecode(ComponentCanvasDecodeError)
+            /// `anglesite:pick-goal-element` matched but the payload failed to decode.
+            case goalElementPickDecode(ComponentCanvasDecodeError)
         }
     }
 
@@ -96,7 +106,8 @@ public enum AnglesiteMessageDispatcher {
         onVisibleElements: VisibleElementsHandler? = nil,
         onCanvasSelection: CanvasSelectionHandler? = nil,
         onComputedStyles: ComputedStylesHandler? = nil,
-        onPlacementPick: PlacementPickHandler? = nil
+        onPlacementPick: PlacementPickHandler? = nil,
+        onGoalElementPick: GoalElementPickHandler? = nil
     ) async -> DispatchResult {
         guard let dict = body as? [String: Any] else { return .rejected(.notAnObject) }
         guard let rawType = dict["type"] else { return .rejected(.missingType) }
@@ -150,6 +161,16 @@ public enum AnglesiteMessageDispatcher {
                 return .placementPickHandled
             case .failure(let error):
                 return .rejected(.placementPickDecode(error))
+            }
+
+        case GoalElementPickMessage.messageType:
+            switch GoalElementPickMessage.decode(from: body) {
+            case .success(let message):
+                guard let handler = onGoalElementPick else { return .goalElementPickDropped }
+                await handler(message)
+                return .goalElementPickHandled
+            case .failure(let error):
+                return .rejected(.goalElementPickDecode(error))
             }
 
         default:

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -74,7 +74,7 @@ public enum ContentScaffold {
     /// alike — so a slash-less route written into `anglesite.json` fails the gate and blocks every
     /// subsequent deploy of the site, not just the experiment (#1518).
     ///
-    /// ``ContentScanner/routeFromPagePath(_:)`` and ``normalizeRoute(_:)`` both produce the
+    /// `ContentScanner.routeFromPagePath(_:)` and ``normalizeRoute(_:)`` both produce the
     /// slash-less file-path form, so anything crossing into a served-route position goes through
     /// here. Idempotent.
     public static func servedRoute(_ route: String) -> String {

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -56,8 +56,39 @@ public enum ContentScaffold {
 
     /// Where a scaffolded page lands, relative to the site root: `/about` →
     /// `src/pages/about.astro`. Expects a route already through ``normalizeRoute(_:)``.
+    ///
+    /// The argument is a *file-path* route (no trailing slash), not the served route
+    /// ``servedRoute(_:)`` produces — a trailing slash here would yield `src/pages/about/.astro`.
     public static func pageRelativePath(normalizedRoute: String) -> String {
         "src/pages" + normalizedRoute + ".astro"
+    }
+
+    /// The trailing-slash *served* form of a page route: `/about` → `/about/`, `/` → `/`.
+    ///
+    /// The template builds pages in Astro's directory format, so a page route's runtime request
+    /// path always carries a trailing slash: it is what `Astro.url.pathname` reports at render
+    /// time, what `src/lib/sitemap.ts` emits, and what `worker.ts`/`BaseLayout.astro` match a
+    /// stored path against *exactly*. `scripts/pre-deploy-check.ts` enforces the same shape on
+    /// every `experiments.active` entry's `page`, `variant.page`, and pageview-goal `path`
+    /// (`experimentPathProblem(_, { requireTrailingSlash: true })`), for draft and running entries
+    /// alike — so a slash-less route written into `anglesite.json` fails the gate and blocks every
+    /// subsequent deploy of the site, not just the experiment (#1518).
+    ///
+    /// ``ContentScanner/routeFromPagePath(_:)`` and ``normalizeRoute(_:)`` both produce the
+    /// slash-less file-path form, so anything crossing into a served-route position goes through
+    /// here. Idempotent.
+    public static func servedRoute(_ route: String) -> String {
+        route.hasSuffix("/") ? route : route + "/"
+    }
+
+    /// The inverse of ``servedRoute(_:)`` composed with ``pageRelativePath(normalizedRoute:)``:
+    /// where the `.astro` file behind a served page route lives. `/` → `src/pages/index.astro`,
+    /// `/pricing/` → `src/pages/pricing.astro`. Accepts either slash form.
+    public static func pageRelativePath(servedRoute: String) -> String {
+        let trimmed = servedRoute.hasSuffix("/") ? String(servedRoute.dropLast()) : servedRoute
+        return trimmed.isEmpty || trimmed == "/"
+            ? "src/pages/index.astro"
+            : pageRelativePath(normalizedRoute: trimmed)
     }
 
     /// Where a scaffolded collection entry lands, relative to the site root:

--- a/Sources/AnglesiteCore/GoalElementPickMessage.swift
+++ b/Sources/AnglesiteCore/GoalElementPickMessage.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// The overlay's goal-element-pick mode (Task 4) reporting a click on an arbitrary element while
+/// the owner is choosing the target for an A/B experiment's "visible" goal (#1270 slice 5).
+/// Structurally identical to `PlacementPickMessage` (same `ElementInfo` payload, same "no reply
+/// sent to the page" contract) but a distinct message type/handler — this pick feeds
+/// `GoalSelectorBuilder`, not `PlacementMatcher`/an applied edit.
+public struct GoalElementPickMessage: Sendable, Equatable {
+    public static let messageType = "anglesite:pick-goal-element"
+
+    public let path: String
+    public let element: ElementInfo
+
+    public init(path: String, element: ElementInfo) {
+        self.path = path
+        self.element = element
+    }
+
+    /// Decodes a `WKScriptMessage` body. Returns `.failure(.wrongType)` for another message's
+    /// body so the dispatcher can try the next decoder; `.malformed` when `type` matches but
+    /// `path`/`selector` (or `selector`'s required `tag`/`nthChild`) are missing.
+    public static func decode(from body: Any) -> Result<GoalElementPickMessage, ComponentCanvasDecodeError> {
+        guard let dict = body as? [String: Any], dict["type"] as? String == messageType else {
+            return .failure(.wrongType)
+        }
+        guard let path = dict["path"] as? String,
+              let selectorDict = dict["selector"] as? [String: Any],
+              let element = ElementInfo.decode(from: selectorDict) else {
+            return .failure(.malformed)
+        }
+        return .success(GoalElementPickMessage(path: path, element: element))
+    }
+}

--- a/Sources/AnglesiteCore/GoalSelectorBuilder.swift
+++ b/Sources/AnglesiteCore/GoalSelectorBuilder.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Builds a literal CSS-selector string for the A/B testing "visible" goal (#1270 slice 5) from
+/// the same `ElementInfo`/`AncestorInfo` payload `PlacementPickMessage` already decodes. Reuses
+/// the proven priority order documented in `JS/edit-overlay/src/selector.ts`
+/// (`data-anglesite-id` > `data-testid` > `#id` > `role`/`aria-label` > stable classes >
+/// `tag:nth-child`) — nothing before this emitted a literal selector string; the two adjacent
+/// mechanisms (the sidecar's `selector.mjs`, `PlacementMatcher`) resolve to a source-file patch
+/// location or a `PageModel` node id instead. Astro's dev-time `astro-*` scoped-class hashes are
+/// filtered before the class fallback is tried, since they don't survive `astro build`.
+public enum GoalSelectorBuilder {
+    public enum BuildError: Error, Equatable {}
+
+    /// Anchors on the nearest ancestor (searching nearest-first) with a stable single-element
+    /// identifier, then walks down to the leaf with `>` combinators, using each hop's own
+    /// simple-selector. If no ancestor anchors, walks the *entire* chain (root-first) the same
+    /// way — always succeeds; the result may just be a longer nth-child chain.
+    public static func build(for element: ElementInfo) -> Result<String, BuildError> {
+        if let leaf = anchoredSelector(tag: element.tag, id: element.id, classes: element.classes,
+                                        dataAnglesiteId: element.dataAnglesiteId, dataTestId: element.dataTestId,
+                                        role: element.role, ariaLabel: element.ariaLabel, nthChild: element.nthChild) {
+            return .success(leaf)
+        }
+        // No anchor at the leaf: find the nearest ancestor (search reversed — ancestors is
+        // root-first) that anchors, then join from there down through to the leaf.
+        for (index, ancestor) in element.ancestors.enumerated().reversed() {
+            if let anchor = anchoredSelector(tag: ancestor.tag, id: ancestor.id, classes: ancestor.classes,
+                                              dataAnglesiteId: nil, dataTestId: nil,
+                                              role: ancestor.role, ariaLabel: ancestor.ariaLabel, nthChild: ancestor.nthChild ?? 1) {
+                let remaining = element.ancestors[(index + 1)...].map { simpleSelector(for: $0) } + [simpleSelector(for: element)]
+                return .success(([anchor] + remaining).joined(separator: " > "))
+            }
+        }
+        // No anchor anywhere: full chain from the root-most ancestor down to the leaf.
+        let chain = element.ancestors.map { simpleSelector(for: $0) } + [simpleSelector(for: element)]
+        return .success(chain.joined(separator: " > "))
+    }
+
+    /// A simple selector that alone identifies the element (a data attribute, `#id`, or
+    /// `role`+`aria-label` pair) — or `nil` if it has none, meaning the caller must fall back to
+    /// stable classes or `tag:nth-child` (never "anchoring" material on their own).
+    private static func anchoredSelector(
+        tag: String, id: String?, classes: [String], dataAnglesiteId: String?, dataTestId: String?,
+        role: String?, ariaLabel: String?, nthChild: Int
+    ) -> String? {
+        if let dataAnglesiteId, !dataAnglesiteId.isEmpty { return "[data-anglesite-id=\"\(dataAnglesiteId)\"]" }
+        if let dataTestId, !dataTestId.isEmpty { return "[data-testid=\"\(dataTestId)\"]" }
+        if let id, !id.isEmpty { return "#\(id)" }
+        if let role, let ariaLabel, !role.isEmpty, !ariaLabel.isEmpty {
+            return "[role=\"\(role)\"][aria-label=\"\(ariaLabel)\"]"
+        }
+        return nil
+    }
+
+    /// A simple selector for one hop in a combinator chain — always succeeds (falls back to
+    /// `tag:nth-child(n)`), unlike `anchoredSelector` which only returns something when the
+    /// element is identifiable on its own.
+    private static func simpleSelector(for info: ElementInfo) -> String {
+        simpleSelector(tag: info.tag, classes: info.classes, nthChild: info.nthChild)
+    }
+    private static func simpleSelector(for ancestor: AncestorInfo) -> String {
+        simpleSelector(tag: ancestor.tag, classes: ancestor.classes, nthChild: ancestor.nthChild ?? 1)
+    }
+    private static func simpleSelector(tag: String, classes: [String], nthChild: Int) -> String {
+        let lowered = tag.lowercased()
+        let stableClasses = classes.filter { !$0.hasPrefix("astro-") }
+        if !stableClasses.isEmpty { return lowered + stableClasses.map { ".\($0)" }.joined() }
+        return "\(lowered):nth-child(\(nthChild))"
+    }
+}

--- a/Sources/AnglesiteCore/LiveRegionAnnouncer.swift
+++ b/Sources/AnglesiteCore/LiveRegionAnnouncer.swift
@@ -88,4 +88,29 @@ public enum LiveRegionAnnouncer {
     public static func deployStderrAnnouncement(previousStderrCount: Int, currentStderrCount: Int) -> String? {
         (previousStderrCount == 0 && currentStderrCount > 0) ? "Deploy log has errors" : nil
     }
+
+    // MARK: Experiment lifecycle
+
+    /// The announceable substrate of the experiment configure/start lifecycle (#1270 slice 5),
+    /// mapped from `ExperimentStatsModel.Step` the same way `DeployActivity` maps from
+    /// `DeployModel.Phase`. `.inactive` covers `.manual`/`.propose`/`.idle`-shaped states with
+    /// nothing worth announcing.
+    public enum ExperimentActivity: Equatable {
+        case inactive
+        case configuring
+        case starting
+        case running(name: String)
+        case failed(reason: String)
+    }
+
+    /// The announcement for an experiment lifecycle transition, or `nil`. Same "coarse transition,
+    /// not per-field" rule as `deployAnnouncement`.
+    public static func experimentAnnouncement(from old: ExperimentActivity, to new: ExperimentActivity) -> String? {
+        guard old != new else { return nil }
+        switch new {
+        case .running: return "Your test is live. I'll tell you when there's a clear answer."
+        case .failed(let reason): return "Couldn't start your test. \(reason)"
+        case .configuring, .starting, .inactive: return nil
+        }
+    }
 }

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -483,12 +483,16 @@ public struct NativeContentOperations: ContentOperationsService {
         do { try write(injected, to: root.appendingPathComponent(relPath)) }
         catch { return .failed(reason: "\(error)") }
 
+        let robotsChanged: Bool
         do {
-            try RobotsConfigFile.apply(
+            robotsChanged = try RobotsConfigFile.apply(
                 source: .page(file: relPath), noindex: true, disallowCrawl: false, path: route, under: root)
         } catch { return .failed(reason: "\(error)") }
 
         _ = await gitCommit(root, relPath, "anglesite: scaffold experiment variant \(route)")
+        if robotsChanged {
+            _ = await gitCommit(root, RobotsConfigFile.relativePath, "anglesite: update robots-config.json")
+        }
         return .created(filePath: relPath, identifier: route)
     }
 

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -457,6 +457,11 @@ public struct NativeContentOperations: ContentOperationsService {
     /// via `RobotsConfigFile` — the same mechanism the app's page inspector uses (#1093), so the
     /// variant is invisible to search from the moment it's written, with no separate "remember to
     /// noindex it" step. Fails rather than overwriting if the target route is already taken.
+    ///
+    /// - Returns: on success, `identifier` is the variant's **served** route —
+    ///   `/x/<experimentID>/<variantID>/`, with the trailing slash — because it is written straight
+    ///   into `anglesite.json`'s `experiments.active[].variant.page`, which
+    ///   `scripts/pre-deploy-check.ts` rejects without one. See ``ContentScaffold/servedRoute(_:)``.
     public func duplicatePageAsVariant(
         siteID: String, relativePath: String, experimentID: String, variantID: String
     ) async -> ContentCreateResult {
@@ -469,13 +474,21 @@ public struct NativeContentOperations: ContentOperationsService {
         do { contents = try FileDocumentIO.load(sourceAbs, fileManager: fileManager).contents }
         catch { return .failed(reason: "\(error)") }
 
+        // Two shapes of the same route, deliberately: `route` is the file-path form that decides
+        // where the `.astro` lands, `servedRoute` the trailing-slash runtime form that goes into
+        // `anglesite.json` and the canonical link. Mixing them up is what #1518's review caught —
+        // see `ContentScaffold.servedRoute(_:)` for why the gate rejects the slash-less form.
         let route = ContentScaffold.normalizeRoute("/x/\(experimentID)/\(variantID)")
+        let servedRoute = ContentScaffold.servedRoute(route)
         let relPath = ContentScaffold.pageRelativePath(normalizedRoute: route)
         guard !fileManager.fileExists(atPath: root.appendingPathComponent(relPath).path) else {
             return .failed(reason: "A variant page already exists at \(relPath)")
         }
 
-        let controlRoute = ContentScanner.routeFromPagePath(relativePath)
+        // `pre-deploy-check.ts` compares the built variant's `rel="canonical"` pathname against the
+        // experiment's `page` with `!==`, and `page` is the served (trailing-slash) control route —
+        // so the injected canonical has to carry the slash too or the SEO check fails the deploy.
+        let controlRoute = ContentScaffold.servedRoute(ContentScanner.routeFromPagePath(relativePath))
         guard let injected = Self.injectingCanonicalPath(controlRoute, into: contents) else {
             return .failed(reason: "Couldn't find a <BaseLayout> invocation to attach the variant's canonical link to")
         }
@@ -486,14 +499,14 @@ public struct NativeContentOperations: ContentOperationsService {
         let robotsChanged: Bool
         do {
             robotsChanged = try RobotsConfigFile.apply(
-                source: .page(file: relPath), noindex: true, disallowCrawl: false, path: route, under: root)
+                source: .page(file: relPath), noindex: true, disallowCrawl: false, path: servedRoute, under: root)
         } catch { return .failed(reason: "\(error)") }
 
-        _ = await gitCommit(root, relPath, "anglesite: scaffold experiment variant \(route)")
+        _ = await gitCommit(root, relPath, "anglesite: scaffold experiment variant \(servedRoute)")
         if robotsChanged {
             _ = await gitCommit(root, RobotsConfigFile.relativePath, "anglesite: update robots-config.json")
         }
-        return .created(filePath: relPath, identifier: route)
+        return .created(filePath: relPath, identifier: servedRoute)
     }
 
     /// Inserts `canonicalPath="<controlRoute>"` as the first attribute of the first `<BaseLayout`

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -449,6 +449,60 @@ public struct NativeContentOperations: ContentOperationsService {
         return .created(filePath: relPath, identifier: route)
     }
 
+    /// Scaffolds an A/B-test variant page from an existing control page (#1270 slice 5): reads the
+    /// control's contents, writes them to the deterministic route `/x/<experimentID>/<variantID>`
+    /// (never the collision-bumping "Copy 2" naming `duplicatePage` uses — an experiment's variant
+    /// route is part of its identity, not a display name), injects a `canonicalPath` prop into the
+    /// `<BaseLayout` invocation pointing back at the control route, and marks the new route noindex
+    /// via `RobotsConfigFile` — the same mechanism the app's page inspector uses (#1093), so the
+    /// variant is invisible to search from the moment it's written, with no separate "remember to
+    /// noindex it" step. Fails rather than overwriting if the target route is already taken.
+    public func duplicatePageAsVariant(
+        siteID: String, relativePath: String, experimentID: String, variantID: String
+    ) async -> ContentCreateResult {
+        guard let root = await siteDirectory(siteID) else { return .siteNotFound }
+        let sourceAbs = root.appendingPathComponent(relativePath)
+        guard fileManager.fileExists(atPath: sourceAbs.path) else {
+            return .failed(reason: "No page exists at \(relativePath)")
+        }
+        let contents: String
+        do { contents = try FileDocumentIO.load(sourceAbs, fileManager: fileManager).contents }
+        catch { return .failed(reason: "\(error)") }
+
+        let route = ContentScaffold.normalizeRoute("/x/\(experimentID)/\(variantID)")
+        let relPath = ContentScaffold.pageRelativePath(normalizedRoute: route)
+        guard !fileManager.fileExists(atPath: root.appendingPathComponent(relPath).path) else {
+            return .failed(reason: "A variant page already exists at \(relPath)")
+        }
+
+        let controlRoute = ContentScanner.routeFromPagePath(relativePath)
+        guard let injected = Self.injectingCanonicalPath(controlRoute, into: contents) else {
+            return .failed(reason: "Couldn't find a <BaseLayout> invocation to attach the variant's canonical link to")
+        }
+
+        do { try write(injected, to: root.appendingPathComponent(relPath)) }
+        catch { return .failed(reason: "\(error)") }
+
+        do {
+            try RobotsConfigFile.apply(
+                source: .page(file: relPath), noindex: true, disallowCrawl: false, path: route, under: root)
+        } catch { return .failed(reason: "\(error)") }
+
+        _ = await gitCommit(root, relPath, "anglesite: scaffold experiment variant \(route)")
+        return .created(filePath: relPath, identifier: route)
+    }
+
+    /// Inserts `canonicalPath="<controlRoute>"` as the first attribute of the first `<BaseLayout`
+    /// opening tag found, or `nil` if the source has no `<BaseLayout` invocation to attach to (an
+    /// `.astro` page not using the standard layout — out of scope for a v1 variant scaffold, matching
+    /// `PageTitleEditor.RewriteError.noEditableLocation`'s "never invent a location" stance).
+    static func injectingCanonicalPath(_ controlRoute: String, into contents: String) -> String? {
+        guard let range = contents.range(of: "<BaseLayout") else { return nil }
+        let escaped = controlRoute.replacingOccurrences(of: "\"", with: "&quot;")
+        return contents.replacingCharacters(
+            in: range, with: "<BaseLayout canonicalPath=\"\(escaped)\"")
+    }
+
     /// Duplicate an existing post within the same `collection`. Same retitle/collision/commit
     /// shape as `duplicatePage`, but derives a slug (not a route) and writes via
     /// `ContentScaffold.postRelativePath`.

--- a/Sources/AnglesiteCore/RobotsConfigStore.swift
+++ b/Sources/AnglesiteCore/RobotsConfigStore.swift
@@ -177,7 +177,7 @@ public enum RobotsConfigFile {
     /// through — is what keeps a stored entry matchable at build time (#1093). Idempotent: a route
     /// that already ends in `/` (collection entries, the home page's `/`) is returned unchanged.
     static func normalizedRoutePath(_ path: String) -> String {
-        path.hasSuffix("/") ? path : path + "/"
+        ContentScaffold.servedRoute(path)
     }
 
     /// Applies the desired noindex/disallowCrawl state for `source`, writing back only if an entry

--- a/Sources/AnglesiteLinux/PreviewWebView.swift
+++ b/Sources/AnglesiteLinux/PreviewWebView.swift
@@ -106,9 +106,9 @@ struct PreviewWebView: AdwaitaWidget {
                             .assumingMemoryBound(to: WebKitWebView.self)
                         webkit_web_view_evaluate_javascript(webView, script, -1, nil, nil, nil, nil, nil)
                     }
-                case .visibleElementsHandled, .canvasSelectionHandled, .computedStylesHandled, .placementPickHandled:
+                case .visibleElementsHandled, .canvasSelectionHandled, .computedStylesHandled, .placementPickHandled, .goalElementPickHandled:
                     return
-                case .visibleElementsDropped, .canvasSelectionDropped, .computedStylesDropped, .placementPickDropped:
+                case .visibleElementsDropped, .canvasSelectionDropped, .computedStylesDropped, .placementPickDropped, .goalElementPickDropped:
                     // Expected in the MVP shell: no annotation/canvas/placement consumers are
                     // wired yet (they arrive with the component editor / Effects gallery), so
                     // these land silently — unlike the macOS adapter, where a drop means broken

--- a/Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
+++ b/Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
@@ -5,8 +5,8 @@ import Foundation
 
 @MainActor
 @Suite struct ExperimentStatsModelTests {
-    @Test func canAnalyzeOnlyOnceBothVariantsHaveVisitors() {
-        let model = ExperimentStatsModel(siteID: "s1")
+    @Test func canAnalyzeOnlyOnceBothVariantsHaveVisitors() throws {
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: try tempDirectory(), currentRoute: "/")
         #expect(!model.canAnalyze)
         model.controlImpressions = 1000
         model.controlConversions = 50
@@ -16,8 +16,8 @@ import Foundation
         #expect(model.canAnalyze)
     }
 
-    @Test func analyzeProducesAResultAndSummary() {
-        let model = ExperimentStatsModel(siteID: "s1")
+    @Test func analyzeProducesAResultAndSummary() throws {
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: try tempDirectory(), currentRoute: "/")
         model.experimentName = "Hero headline"
         model.controlImpressions = 1000
         model.controlConversions = 50
@@ -28,8 +28,8 @@ import Foundation
         #expect(model.summary?.contains("Hero headline") == true)
     }
 
-    @Test func editAgainClearsTheResultButKeepsCounts() {
-        let model = ExperimentStatsModel(siteID: "s1")
+    @Test func editAgainClearsTheResultButKeepsCounts() throws {
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: try tempDirectory(), currentRoute: "/")
         model.controlImpressions = 1000
         model.controlConversions = 50
         model.treatmentImpressions = 1000
@@ -41,9 +41,67 @@ import Foundation
         #expect(model.controlImpressions == 1000)
     }
 
-    @Test func suggestionPlaybookIsAlwaysAvailable() {
-        let model = ExperimentStatsModel(siteID: "s1")
+    @Test func suggestionPlaybookIsAlwaysAvailable() throws {
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: try tempDirectory(), currentRoute: "/")
         #expect(!model.suggestions.isEmpty)
         #expect(model.suggestions == ExperimentStats.suggestionPlaybook)
+    }
+
+    @Test func withNoConfigStartsInManual() throws {
+        let tmp = try tempDirectory()
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        #expect(model.step == .manual)
+    }
+
+    @Test func withADraftExperimentStartsInConfigure() throws {
+        let tmp = try tempDirectory()
+        let experiment = DomainConfig.Experiments.Experiment(
+            id: "homepage-hero", name: "Hero headline", page: "/",
+            variant: .init(id: "b", name: "B", page: "/x/homepage-hero/b/"),
+            split: 0.5, goal: .init(kind: "pageview", path: "/contact/thanks/"), status: "draft")
+        DomainConfigStore.update(sourceDirectory: tmp) { $0.experiments = .init(active: [experiment]) }
+
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        guard case .configure(let draft) = model.step else {
+            Issue.record("expected .configure, got \(model.step)")
+            return
+        }
+        #expect(draft.id == "homepage-hero")
+    }
+
+    @Test func withARunningExperimentStartsInRunning() throws {
+        let tmp = try tempDirectory()
+        let experiment = DomainConfig.Experiments.Experiment(
+            id: "homepage-hero", name: "Hero headline", page: "/",
+            variant: .init(id: "b", name: "B", page: "/x/homepage-hero/b/"),
+            split: 0.5, goal: .init(kind: "pageview", path: "/contact/thanks/"),
+            status: "running", startedAt: "2026-08-01")
+        DomainConfigStore.update(sourceDirectory: tmp) { $0.experiments = .init(active: [experiment]) }
+
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        guard case .running(let running) = model.step else {
+            Issue.record("expected .running, got \(model.step)")
+            return
+        }
+        #expect(running.id == "homepage-hero")
+    }
+
+    @Test func proposeFromASuggestionMovesToConfigureWithASlugifiedID() throws {
+        let tmp = try tempDirectory()
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        model.propose(from: ExperimentStats.suggestionPlaybook[0]) // "Hero headline"
+        guard case .configure(let draft) = model.step else {
+            Issue.record("expected .configure, got \(model.step)")
+            return
+        }
+        #expect(draft.id == "hero-headline")
+        #expect(draft.name == "Hero headline")
+        #expect(draft.page == "/")
+    }
+
+    private func tempDirectory() throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        return tmp
     }
 }

--- a/Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
+++ b/Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
@@ -156,14 +156,24 @@ import Foundation
         #expect(!model.canStart) // no variantPage yet
     }
 
-    @Test func startWritesRunningStatusAndInvokesDeploy() throws {
+    // start/observeDeployPhase need a draft with both a scaffolded variant and a goal set, reached
+    // the same way settingAGoalPersistsTheDraftToConfig does above: a real fixture on disk plus
+    // scaffoldVariant()/setPageviewGoal(), not a test-only draft setter.
+    @Test func startWritesRunningStatusAndInvokesDeploy() async throws {
         let tmp = try tempDirectory()
+        try FileManager.default.createDirectory(
+            at: tmp.appendingPathComponent("src/pages"), withIntermediateDirectories: true)
+        try """
+        ---
+        import BaseLayout from "../layouts/BaseLayout.astro";
+        ---
+        <BaseLayout title="Home"><h1>Home</h1></BaseLayout>
+        """.write(to: tmp.appendingPathComponent("src/pages/index.astro"), atomically: true, encoding: .utf8)
+
         let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
         model.proposeCustom(name: "Hero headline")
-        guard case .configure(var draft) = model.step else { Issue.record("expected .configure"); return }
-        draft.variantPage = "/x/hero-headline/b"
-        draft.goalKind = "pageview"; draft.goalPath = "/thanks/"
-        model.applyDraftForTesting(draft)
+        await model.scaffoldVariant()
+        model.setPageviewGoal(path: "/thanks/")
 
         var deployCalled = false
         model.start(deploy: { _, _, _, _ in deployCalled = true })
@@ -174,14 +184,21 @@ import Foundation
         #expect(saved.experiments?.active?.first?.status == "running")
     }
 
-    @Test func deploySuccessMovesToRunning() throws {
+    @Test func deploySuccessMovesToRunning() async throws {
         let tmp = try tempDirectory()
+        try FileManager.default.createDirectory(
+            at: tmp.appendingPathComponent("src/pages"), withIntermediateDirectories: true)
+        try """
+        ---
+        import BaseLayout from "../layouts/BaseLayout.astro";
+        ---
+        <BaseLayout title="Home"><h1>Home</h1></BaseLayout>
+        """.write(to: tmp.appendingPathComponent("src/pages/index.astro"), atomically: true, encoding: .utf8)
+
         let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
         model.proposeCustom(name: "Hero headline")
-        guard case .configure(var draft) = model.step else { Issue.record("expected .configure"); return }
-        draft.variantPage = "/x/hero-headline/b"
-        draft.goalKind = "pageview"; draft.goalPath = "/thanks/"
-        model.applyDraftForTesting(draft)
+        await model.scaffoldVariant()
+        model.setPageviewGoal(path: "/thanks/")
         model.start(deploy: { _, _, _, _ in })
 
         model.observeDeployPhase(.succeeded(url: URL(string: "https://example.com")!, duration: 1))
@@ -190,14 +207,21 @@ import Foundation
         #expect(experiment.status == "running")
     }
 
-    @Test func deployFailureRevertsToConfigureWithoutClearingTheDraft() throws {
+    @Test func deployFailureRevertsToConfigureWithoutClearingTheDraft() async throws {
         let tmp = try tempDirectory()
+        try FileManager.default.createDirectory(
+            at: tmp.appendingPathComponent("src/pages"), withIntermediateDirectories: true)
+        try """
+        ---
+        import BaseLayout from "../layouts/BaseLayout.astro";
+        ---
+        <BaseLayout title="Home"><h1>Home</h1></BaseLayout>
+        """.write(to: tmp.appendingPathComponent("src/pages/index.astro"), atomically: true, encoding: .utf8)
+
         let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
         model.proposeCustom(name: "Hero headline")
-        guard case .configure(var draft) = model.step else { Issue.record("expected .configure"); return }
-        draft.variantPage = "/x/hero-headline/b"
-        draft.goalKind = "pageview"; draft.goalPath = "/thanks/"
-        model.applyDraftForTesting(draft)
+        await model.scaffoldVariant()
+        model.setPageviewGoal(path: "/thanks/")
         model.start(deploy: { _, _, _, _ in })
 
         model.observeDeployPhase(.failed(reason: "Network error", exitCode: nil))

--- a/Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
+++ b/Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
@@ -99,6 +99,63 @@ import Foundation
         #expect(draft.page == "/")
     }
 
+    @Test func scaffoldVariantWritesTheVariantPageAndUpdatesTheDraft() async throws {
+        let tmp = try tempDirectory()
+        try FileManager.default.createDirectory(
+            at: tmp.appendingPathComponent("src/pages"), withIntermediateDirectories: true)
+        try """
+        ---
+        import BaseLayout from "../layouts/BaseLayout.astro";
+        ---
+        <BaseLayout title="Home"><h1>Home</h1></BaseLayout>
+        """.write(to: tmp.appendingPathComponent("src/pages/index.astro"), atomically: true, encoding: .utf8)
+
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        model.proposeCustom(name: "Hero headline")
+        await model.scaffoldVariant()
+
+        guard case .configure(let draft) = model.step else {
+            Issue.record("expected .configure, got \(model.step)")
+            return
+        }
+        #expect(draft.variantPage == "/x/hero-headline/b")
+    }
+
+    // scaffoldVariant is async and file-backed (already covered above); this test isolates
+    // goal-setting + persistence by scaffolding a real variant via the same fixture shape rather
+    // than reaching for a test-only draft setter, keeping Draft's mutation surface private to the
+    // model's own methods.
+    @Test func settingAGoalPersistsTheDraftToConfig() async throws {
+        let tmp = try tempDirectory()
+        try FileManager.default.createDirectory(
+            at: tmp.appendingPathComponent("src/pages"), withIntermediateDirectories: true)
+        try """
+        ---
+        import BaseLayout from "../layouts/BaseLayout.astro";
+        ---
+        <BaseLayout title="Home"><h1>Home</h1></BaseLayout>
+        """.write(to: tmp.appendingPathComponent("src/pages/index.astro"), atomically: true, encoding: .utf8)
+
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        model.proposeCustom(name: "Hero headline")
+        await model.scaffoldVariant()
+
+        model.setPageviewGoal(path: "/contact/thanks/")
+
+        let saved = try DomainConfigStore(sourceDirectory: tmp).load()
+        #expect(saved.experiments?.active?.first?.goal.kind == "pageview")
+        #expect(saved.experiments?.active?.first?.status == "draft")
+    }
+
+    @Test func canStartOnlyOnceVariantAndGoalAreBothSet() throws {
+        let tmp = try tempDirectory()
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        model.proposeCustom(name: "Hero headline")
+        #expect(!model.canStart)
+        model.setScrollGoal(depth: 75)
+        #expect(!model.canStart) // no variantPage yet
+    }
+
     private func tempDirectory() throws -> URL {
         let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)

--- a/Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
+++ b/Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
@@ -421,6 +421,59 @@ import Foundation
         #expect(model.step == .manual)
     }
 
+    // MARK: - #1518 escape-hatch fix: returnToManual() must not open a door to overwriting a
+    // running experiment's config.
+
+    @Test func openProposeRefusesWhileAnExperimentIsRunning() async throws {
+        let tmp = try tempDirectory()
+        let running = DomainConfig.Experiments.Experiment(
+            id: "homepage-hero", name: "Hero headline", page: "/",
+            variant: .init(id: "b", name: "B", page: "/x/homepage-hero/b/"),
+            split: 0.5, goal: .init(kind: "pageview", path: "/contact/thanks/"),
+            status: "running", startedAt: "2026-08-01")
+        DomainConfigStore.update(sourceDirectory: tmp) { $0.experiments = .init(active: [running]) }
+
+        // Reached via returnToManual(), the only way to land on `.manual` while a running
+        // experiment still exists on disk (the model would otherwise start in `.running`).
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        guard case .running = model.step else { Issue.record("expected .running, got \(model.step)"); return }
+        model.returnToManual()
+        #expect(model.step == .manual)
+        #expect(model.runningExperiment?.id == "homepage-hero")
+
+        // The bug: tapping a "Test ideas" suggestion from here used to enter .propose, then
+        // .configure, and once scaffolded/goal-set would silently overwrite the running
+        // experiment's config entry with a brand-new draft, losing its "running" status and
+        // startedAt with no warning. `openPropose()` is the sole reachable entry point into
+        // .propose (ExperimentProposeView's buttons, which call propose(from:)/proposeCustom, are
+        // only ever shown once .propose is reached), so refusing it here closes the whole path.
+        model.openPropose()
+        #expect(model.step == .manual) // refused, not .propose
+
+        // The running experiment's config entry is untouched.
+        let saved = try DomainConfigStore(sourceDirectory: tmp).load()
+        #expect(saved.experiments?.active?.first?.id == "homepage-hero")
+        #expect(saved.experiments?.active?.first?.status == "running")
+    }
+
+    @Test func testIdeasStayReachableFromManualWhenNothingIsRunning() throws {
+        let tmp = try tempDirectory()
+        let draft = DomainConfig.Experiments.Experiment(
+            id: "homepage-hero", name: "Hero headline", page: "/",
+            variant: .init(id: "b", name: "B", page: "/x/homepage-hero/b/"),
+            split: 0.5, goal: .init(kind: "pageview", path: "/contact/thanks/"), status: "draft")
+        DomainConfigStore.update(sourceDirectory: tmp) { $0.experiments = .init(active: [draft]) }
+
+        // A draft (not running) config starts in .configure; return to manual and confirm
+        // openPropose() is NOT blocked, since nothing is actually running.
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        model.returnToManual()
+        #expect(model.step == .manual)
+        #expect(model.runningExperiment == nil)
+        model.openPropose()
+        #expect(model.step == .propose)
+    }
+
     private func tempDirectory() throws -> URL {
         let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)

--- a/Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
+++ b/Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
@@ -118,7 +118,7 @@ import Foundation
             Issue.record("expected .configure, got \(model.step)")
             return
         }
-        #expect(draft.variantPage == "/x/hero-headline/b")
+        #expect(draft.variantPage == "/x/hero-headline/b/")
     }
 
     // scaffoldVariant is async and file-backed (already covered above); this test isolates
@@ -176,7 +176,7 @@ import Foundation
         model.setPageviewGoal(path: "/thanks/")
 
         var deployCalled = false
-        model.start(deploy: { _, _, _, _ in deployCalled = true })
+        model.start(deploy: { deployCalled = true })
 
         guard case .starting = model.step else { Issue.record("expected .starting, got \(model.step)"); return }
         #expect(deployCalled)
@@ -199,7 +199,7 @@ import Foundation
         model.proposeCustom(name: "Hero headline")
         await model.scaffoldVariant()
         model.setPageviewGoal(path: "/thanks/")
-        model.start(deploy: { _, _, _, _ in })
+        model.start(deploy: {})
 
         model.observeDeployPhase(.succeeded(url: URL(string: "https://example.com")!, duration: 1))
 
@@ -222,14 +222,203 @@ import Foundation
         model.proposeCustom(name: "Hero headline")
         await model.scaffoldVariant()
         model.setPageviewGoal(path: "/thanks/")
-        model.start(deploy: { _, _, _, _ in })
+        model.start(deploy: {})
 
         model.observeDeployPhase(.failed(reason: "Network error", exitCode: nil))
 
         guard case .configure(let reverted) = model.step else { Issue.record("expected .configure, got \(model.step)"); return }
-        #expect(reverted.variantPage == "/x/hero-headline/b")
+        #expect(reverted.variantPage == "/x/hero-headline/b/")
         let saved = try DomainConfigStore(sourceDirectory: tmp).load()
         #expect(saved.experiments?.active?.first?.status == "draft")
+    }
+
+    // MARK: - #1518 whole-branch review fixes
+
+    /// Mirrors `Resources/Template/scripts/pre-deploy-check.ts`'s
+    /// `experimentPathProblem(path, { requireTrailingSlash: true })`, which the gate applies to
+    /// every `experiments.active[]` entry's `page`, `variant.page`, and (for `pageview`) goal
+    /// `path` — draft entries included. Anything this model writes into `anglesite.json` has to
+    /// pass it, or the site's *every* subsequent deploy fails, not just the experiment's.
+    private func experimentPathProblem(_ path: String?) -> String? {
+        guard let path, !path.isEmpty else { return "must be a non-empty string" }
+        if !path.hasPrefix("/") { return #"must start with "/""# }
+        if path.contains("..") { return #"must not contain "..""# }
+        if path.contains("%") { return "must not contain percent-encoding" }
+        if !path.hasSuffix("/") { return #"must end with "/""# }
+        return nil
+    }
+
+    @Test func aConfiguredDraftSatisfiesThePreDeployPathContract() async throws {
+        let tmp = try tempDirectory()
+        try FileManager.default.createDirectory(
+            at: tmp.appendingPathComponent("src/pages"), withIntermediateDirectories: true)
+        try """
+        ---
+        import BaseLayout from "../layouts/BaseLayout.astro";
+        ---
+        <BaseLayout title="Pricing"><h1>Pricing</h1></BaseLayout>
+        """.write(to: tmp.appendingPathComponent("src/pages/pricing.astro"), atomically: true, encoding: .utf8)
+
+        // `preview.activeRoute`/`ContentScanner.routeFromPagePath` hand over the slash-less form…
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/pricing")
+        model.proposeCustom(name: "Hero headline")
+        await model.scaffoldVariant()
+        model.setPageviewGoal(path: "/thanks") // …and the owner can type one too.
+
+        guard case .configure(let draft) = model.step, let experiment = draft.asExperiment else {
+            Issue.record("expected a complete .configure draft, got \(model.step)")
+            return
+        }
+        #expect(experimentPathProblem(experiment.page) == nil)
+        #expect(experimentPathProblem(experiment.variant.page) == nil)
+        #expect(experimentPathProblem(experiment.goal.path) == nil)
+        #expect(experiment.page == "/pricing/")
+        #expect(experiment.variant.page == "/x/hero-headline/b/")
+        // The slash is a URL convention only — the scaffold still resolved the control page's file.
+        #expect(FileManager.default.fileExists(
+            atPath: tmp.appendingPathComponent("src/pages/x/hero-headline/b.astro").path))
+    }
+
+    @Test func aSlashLessConfigEntryIsHealedByTheNextWrite() throws {
+        let tmp = try tempDirectory()
+        // The shape a pre-fix build would have left on disk.
+        let stale = DomainConfig.Experiments.Experiment(
+            id: "hero-headline", name: "Hero headline", page: "/pricing",
+            variant: .init(id: "b", name: "B", page: "/x/hero-headline/b"),
+            split: 0.5, goal: .init(kind: "pageview", path: "/thanks"), status: "draft")
+        DomainConfigStore.update(sourceDirectory: tmp) { $0.experiments = .init(active: [stale]) }
+
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        guard case .configure(let draft) = model.step, let healed = draft.asExperiment else {
+            Issue.record("expected a complete .configure draft, got \(model.step)")
+            return
+        }
+        #expect(experimentPathProblem(healed.page) == nil)
+        #expect(experimentPathProblem(healed.variant.page) == nil)
+        #expect(experimentPathProblem(healed.goal.path) == nil)
+    }
+
+    @Test func aRouteKindGoalPathKeepsItsSlashLessShape() throws {
+        let tmp = try tempDirectory()
+        // `pre-deploy-check.ts` deliberately does NOT require a trailing slash for `route` goals
+        // (API/action endpoints, per worker.ts's ROUTES table) — normalizing them would break them.
+        let entry = DomainConfig.Experiments.Experiment(
+            id: "hero-headline", name: "Hero headline", page: "/pricing/",
+            variant: .init(id: "b", name: "B", page: "/x/hero-headline/b/"),
+            split: 0.5, goal: .init(kind: "route", path: "/api/contact"), status: "draft")
+        DomainConfigStore.update(sourceDirectory: tmp) { $0.experiments = .init(active: [entry]) }
+
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        guard case .configure(let draft) = model.step, let round = draft.asExperiment else {
+            Issue.record("expected a complete .configure draft, got \(model.step)")
+            return
+        }
+        #expect(round.goal.path == "/api/contact")
+    }
+
+    @Test func theRootRouteStaysASingleSlash() throws {
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: try tempDirectory(), currentRoute: "/")
+        model.proposeCustom(name: "Hero headline")
+        guard case .configure(let draft) = model.step else {
+            Issue.record("expected .configure, got \(model.step)")
+            return
+        }
+        #expect(draft.page == "/")
+    }
+
+    @Test func scaffoldVariantSurfacesWhyItFailed() async throws {
+        let tmp = try tempDirectory() // no src/pages/index.astro to duplicate
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        model.proposeCustom(name: "Hero headline")
+        await model.scaffoldVariant()
+
+        #expect(model.scaffoldFailureReason?.contains("src/pages/index.astro") == true)
+        guard case .configure(let draft) = model.step else {
+            Issue.record("expected .configure, got \(model.step)")
+            return
+        }
+        #expect(draft.variantPage == nil)
+    }
+
+    @Test func startRefusesWhenTheDeployCouldNotRun() async throws {
+        let tmp = try tempDirectory()
+        try FileManager.default.createDirectory(
+            at: tmp.appendingPathComponent("src/pages"), withIntermediateDirectories: true)
+        try """
+        ---
+        import BaseLayout from "../layouts/BaseLayout.astro";
+        ---
+        <BaseLayout title="Home"><h1>Home</h1></BaseLayout>
+        """.write(to: tmp.appendingPathComponent("src/pages/index.astro"), atomically: true, encoding: .utf8)
+
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        model.proposeCustom(name: "Hero headline")
+        await model.scaffoldVariant()
+        model.setPageviewGoal(path: "/thanks/")
+
+        var deployCalled = false
+        model.start(unavailableReason: "Sign in to Cloudflare first.", deploy: { deployCalled = true })
+
+        #expect(!deployCalled)
+        guard case .configure = model.step else { Issue.record("expected .configure, got \(model.step)"); return }
+        #expect(model.startFailureReason == "Sign in to Cloudflare first.")
+        // Nothing may claim the test is live when no deploy was even attempted.
+        let saved = try DomainConfigStore(sourceDirectory: tmp).load()
+        #expect(saved.experiments?.active?.first?.status == "draft")
+    }
+
+    @Test func aDeployParkedOnAConfirmationRollsTheStartBack() async throws {
+        let tmp = try tempDirectory()
+        try FileManager.default.createDirectory(
+            at: tmp.appendingPathComponent("src/pages"), withIntermediateDirectories: true)
+        try """
+        ---
+        import BaseLayout from "../layouts/BaseLayout.astro";
+        ---
+        <BaseLayout title="Home"><h1>Home</h1></BaseLayout>
+        """.write(to: tmp.appendingPathComponent("src/pages/index.astro"), atomically: true, encoding: .utf8)
+
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        model.proposeCustom(name: "Hero headline")
+        await model.scaffoldVariant()
+        model.setPageviewGoal(path: "/thanks/")
+        model.start(deploy: {})
+
+        model.observeDeployPhase(.workerNameConflict(name: "my-site"))
+
+        guard case .configure = model.step else { Issue.record("expected .configure, got \(model.step)"); return }
+        let saved = try DomainConfigStore(sourceDirectory: tmp).load()
+        #expect(saved.experiments?.active?.first?.status == "draft")
+    }
+
+    @Test func returnToManualIsReachableFromEveryStepButStarting() async throws {
+        let tmp = try tempDirectory()
+        try FileManager.default.createDirectory(
+            at: tmp.appendingPathComponent("src/pages"), withIntermediateDirectories: true)
+        try """
+        ---
+        import BaseLayout from "../layouts/BaseLayout.astro";
+        ---
+        <BaseLayout title="Home"><h1>Home</h1></BaseLayout>
+        """.write(to: tmp.appendingPathComponent("src/pages/index.astro"), atomically: true, encoding: .utf8)
+
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        #expect(!model.canReturnToManual) // already there
+        model.openPropose()
+        #expect(model.canReturnToManual)
+        model.proposeCustom(name: "Hero headline")
+        #expect(model.canReturnToManual)
+        await model.scaffoldVariant()
+        model.setPageviewGoal(path: "/thanks/")
+        model.start(deploy: {})
+        #expect(!model.canReturnToManual) // a deploy is in flight
+        model.returnToManual()
+        guard case .starting = model.step else { Issue.record("expected .starting, got \(model.step)"); return }
+
+        model.observeDeployPhase(.succeeded(url: URL(string: "https://example.com")!, duration: 1))
+        #expect(model.canReturnToManual)
+        model.returnToManual()
+        #expect(model.step == .manual)
     }
 
     private func tempDirectory() throws -> URL {

--- a/Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
+++ b/Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
@@ -156,6 +156,58 @@ import Foundation
         #expect(!model.canStart) // no variantPage yet
     }
 
+    @Test func startWritesRunningStatusAndInvokesDeploy() throws {
+        let tmp = try tempDirectory()
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        model.proposeCustom(name: "Hero headline")
+        guard case .configure(var draft) = model.step else { Issue.record("expected .configure"); return }
+        draft.variantPage = "/x/hero-headline/b"
+        draft.goalKind = "pageview"; draft.goalPath = "/thanks/"
+        model.applyDraftForTesting(draft)
+
+        var deployCalled = false
+        model.start(deploy: { _, _, _, _ in deployCalled = true })
+
+        guard case .starting = model.step else { Issue.record("expected .starting, got \(model.step)"); return }
+        #expect(deployCalled)
+        let saved = try DomainConfigStore(sourceDirectory: tmp).load()
+        #expect(saved.experiments?.active?.first?.status == "running")
+    }
+
+    @Test func deploySuccessMovesToRunning() throws {
+        let tmp = try tempDirectory()
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        model.proposeCustom(name: "Hero headline")
+        guard case .configure(var draft) = model.step else { Issue.record("expected .configure"); return }
+        draft.variantPage = "/x/hero-headline/b"
+        draft.goalKind = "pageview"; draft.goalPath = "/thanks/"
+        model.applyDraftForTesting(draft)
+        model.start(deploy: { _, _, _, _ in })
+
+        model.observeDeployPhase(.succeeded(url: URL(string: "https://example.com")!, duration: 1))
+
+        guard case .running(let experiment) = model.step else { Issue.record("expected .running, got \(model.step)"); return }
+        #expect(experiment.status == "running")
+    }
+
+    @Test func deployFailureRevertsToConfigureWithoutClearingTheDraft() throws {
+        let tmp = try tempDirectory()
+        let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+        model.proposeCustom(name: "Hero headline")
+        guard case .configure(var draft) = model.step else { Issue.record("expected .configure"); return }
+        draft.variantPage = "/x/hero-headline/b"
+        draft.goalKind = "pageview"; draft.goalPath = "/thanks/"
+        model.applyDraftForTesting(draft)
+        model.start(deploy: { _, _, _, _ in })
+
+        model.observeDeployPhase(.failed(reason: "Network error", exitCode: nil))
+
+        guard case .configure(let reverted) = model.step else { Issue.record("expected .configure, got \(model.step)"); return }
+        #expect(reverted.variantPage == "/x/hero-headline/b")
+        let saved = try DomainConfigStore(sourceDirectory: tmp).load()
+        #expect(saved.experiments?.active?.first?.status == "draft")
+    }
+
     private func tempDirectory() throws -> URL {
         let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)

--- a/Tests/AnglesiteAppTests/GoalElementPickControllerTests.swift
+++ b/Tests/AnglesiteAppTests/GoalElementPickControllerTests.swift
@@ -1,0 +1,61 @@
+// Tests/AnglesiteAppTests/GoalElementPickControllerTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteAppCore
+@testable import AnglesiteCore
+
+@MainActor
+@Suite struct GoalElementPickControllerTests {
+    private func elementInfo(id: String?) -> ElementInfo {
+        ElementInfo(tag: "SECTION", id: id, classes: [], nthChild: 1, ancestors: [],
+                    dataAnglesiteId: nil, dataTestId: nil, role: nil, ariaLabel: nil, textContent: nil)
+    }
+
+    @Test func startPickingEntersOverlayModeAndSetsPicking() {
+        let controller = GoalElementPickController()
+        var entered = false
+        controller.startPicking(enterOverlayMode: { entered = true }, exitOverlayMode: {})
+        #expect(entered)
+        #expect(controller.state == .picking)
+    }
+
+    @Test func startPickingIsANoOpWhenAlreadyPicking() {
+        let controller = GoalElementPickController()
+        var enterCount = 0
+        controller.startPicking(enterOverlayMode: { enterCount += 1 }, exitOverlayMode: {})
+        controller.startPicking(enterOverlayMode: { enterCount += 1 }, exitOverlayMode: {})
+        #expect(enterCount == 1)
+    }
+
+    @Test func cancelExitsOverlayModeAndReturnsToIdle() {
+        let controller = GoalElementPickController()
+        var exited = false
+        controller.startPicking(enterOverlayMode: {}, exitOverlayMode: { exited = true })
+        controller.cancel()
+        #expect(exited)
+        #expect(controller.state == .idle)
+    }
+
+    @Test func handlePickBuildsASelectorAndExitsOverlayMode() {
+        let controller = GoalElementPickController()
+        var exited = false
+        controller.startPicking(enterOverlayMode: {}, exitOverlayMode: { exited = true })
+        controller.handlePick(GoalElementPickMessage(path: "/", element: elementInfo(id: "reviews")))
+        #expect(exited)
+        #expect(controller.state == .succeeded(selector: "#reviews"))
+    }
+
+    @Test func handlePickIsANoOpWhenNotPicking() {
+        let controller = GoalElementPickController()
+        controller.handlePick(GoalElementPickMessage(path: "/", element: elementInfo(id: "reviews")))
+        #expect(controller.state == .idle)
+    }
+
+    @Test func acknowledgeReturnsATerminalStateToIdle() {
+        let controller = GoalElementPickController()
+        controller.startPicking(enterOverlayMode: {}, exitOverlayMode: {})
+        controller.handlePick(GoalElementPickMessage(path: "/", element: elementInfo(id: "reviews")))
+        controller.acknowledge()
+        #expect(controller.state == .idle)
+    }
+}

--- a/Tests/AnglesiteBridgeCoreTests/AnglesiteMessageDispatcherTests.swift
+++ b/Tests/AnglesiteBridgeCoreTests/AnglesiteMessageDispatcherTests.swift
@@ -194,6 +194,36 @@ struct AnglesiteMessageDispatcherTests {
             return
         }
     }
+
+    @Test("Dispatch routes pick-goal-element to its handler") func routesGoalElementPickToHandler() async {
+        let router = RecordingRouter(reply: EditReply(id: "-", status: .failed, message: "unused"))
+        let received = LockIsolated<GoalElementPickMessage?>(nil)
+        let body: [String: Any] = [
+            "type": "anglesite:pick-goal-element", "path": "/about/",
+            "selector": ["tag": "SECTION", "nthChild": 1, "ancestors": [] as [[String: Any]]],
+        ]
+        let result = await AnglesiteMessageDispatcher.dispatch(
+            body: body, via: router,
+            onGoalElementPick: { msg in received.setValue(msg) })
+        guard case .goalElementPickHandled = result else {
+            Issue.record("expected .goalElementPickHandled, got \(result)")
+            return
+        }
+        #expect(received.value?.path == "/about/")
+    }
+
+    @Test("Pick-goal-element messages without a handler are dropped, not rejected") func goalElementPickDroppedWithoutHandler() async {
+        let router = RecordingRouter(reply: EditReply(id: "-", status: .failed, message: "unused"))
+        let body: [String: Any] = [
+            "type": "anglesite:pick-goal-element", "path": "/",
+            "selector": ["tag": "DIV", "nthChild": 1, "ancestors": [] as [[String: Any]]],
+        ]
+        let result = await AnglesiteMessageDispatcher.dispatch(body: body, via: router)
+        guard case .goalElementPickDropped = result else {
+            Issue.record("expected .goalElementPickDropped, got \(result)")
+            return
+        }
+    }
 }
 
 private actor RecordingRouter: EditRouter {

--- a/Tests/AnglesiteCoreTests/GoalElementPickMessageTests.swift
+++ b/Tests/AnglesiteCoreTests/GoalElementPickMessageTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct GoalElementPickMessageTests {
+    @Test func decodesAWellFormedBody() {
+        let body: [String: Any] = [
+            "type": "anglesite:pick-goal-element",
+            "path": "/",
+            "selector": ["tag": "SECTION", "nthChild": 2, "ancestors": []],
+        ]
+        switch GoalElementPickMessage.decode(from: body) {
+        case .success(let message):
+            #expect(message.path == "/")
+            #expect(message.element.tag == "SECTION")
+        case .failure(let error):
+            Issue.record("expected success, got \(error)")
+        }
+    }
+
+    @Test func rejectsAnotherMessageTypeAsWrongType() {
+        let body: [String: Any] = ["type": "anglesite:pick-placement", "path": "/", "selector": [:]]
+        #expect(GoalElementPickMessage.decode(from: body) == .failure(.wrongType))
+    }
+
+    @Test func rejectsMissingSelectorAsMalformed() {
+        let body: [String: Any] = ["type": "anglesite:pick-goal-element", "path": "/"]
+        #expect(GoalElementPickMessage.decode(from: body) == .failure(.malformed))
+    }
+}

--- a/Tests/AnglesiteCoreTests/GoalSelectorBuilderTests.swift
+++ b/Tests/AnglesiteCoreTests/GoalSelectorBuilderTests.swift
@@ -1,0 +1,56 @@
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct GoalSelectorBuilderTests {
+    @Test func prefersDataAnglesiteId() {
+        let info = ElementInfo(
+            tag: "DIV", id: "reviews", classes: ["astro-abc123", "card"], nthChild: 2,
+            ancestors: [], dataAnglesiteId: "reviews-section", dataTestId: nil,
+            role: nil, ariaLabel: nil, textContent: nil)
+        #expect((try? GoalSelectorBuilder.build(for: info).get()) == "[data-anglesite-id=\"reviews-section\"]")
+    }
+
+    @Test func fallsBackToIdWhenNoDataAttributes() {
+        let info = ElementInfo(
+            tag: "SECTION", id: "pricing", classes: [], nthChild: 1,
+            ancestors: [], dataAnglesiteId: nil, dataTestId: nil,
+            role: nil, ariaLabel: nil, textContent: nil)
+        #expect((try? GoalSelectorBuilder.build(for: info).get()) == "#pricing")
+    }
+
+    @Test func fallsBackToRoleAndAriaLabel() {
+        let info = ElementInfo(
+            tag: "NAV", id: nil, classes: [], nthChild: 1,
+            ancestors: [], dataAnglesiteId: nil, dataTestId: nil,
+            role: "navigation", ariaLabel: "Primary", textContent: nil)
+        #expect((try? GoalSelectorBuilder.build(for: info).get()) == "[role=\"navigation\"][aria-label=\"Primary\"]")
+    }
+
+    @Test func filtersAstroScopedHashClassesAndUsesStableClasses() {
+        let info = ElementInfo(
+            tag: "DIV", id: nil, classes: ["astro-xY9z1", "testimonial-card"], nthChild: 1,
+            ancestors: [], dataAnglesiteId: nil, dataTestId: nil,
+            role: nil, ariaLabel: nil, textContent: nil)
+        #expect((try? GoalSelectorBuilder.build(for: info).get()) == "div.testimonial-card")
+    }
+
+    @Test func fallsBackToTagAndNthChildWithAncestorChain() {
+        let ancestor = AncestorInfo(tag: "SECTION", id: "testimonials", classes: [], nthChild: 3, role: nil, ariaLabel: nil)
+        let info = ElementInfo(
+            tag: "P", id: nil, classes: ["astro-only"], nthChild: 2,
+            ancestors: [ancestor], dataAnglesiteId: nil, dataTestId: nil,
+            role: nil, ariaLabel: nil, textContent: nil)
+        #expect((try? GoalSelectorBuilder.build(for: info).get()) == "#testimonials > p:nth-child(2)")
+    }
+
+    @Test func noStableIdentifierAnywhereInChainFails() {
+        let ancestor = AncestorInfo(tag: "DIV", id: nil, classes: ["astro-x"], nthChild: 1, role: nil, ariaLabel: nil)
+        let info = ElementInfo(
+            tag: "SPAN", id: nil, classes: ["astro-y"], nthChild: 1,
+            ancestors: [ancestor], dataAnglesiteId: nil, dataTestId: nil,
+            role: nil, ariaLabel: nil, textContent: nil)
+        // No ancestor to anchor on and the leaf has no stable identifier either: falls back to a
+        // bare tag:nth-child chain rather than failing — still buildable, just less specific.
+        #expect((try? GoalSelectorBuilder.build(for: info).get()) == "div:nth-child(1) > span:nth-child(1)")
+    }
+}

--- a/Tests/AnglesiteCoreTests/LiveRegionAnnouncerTests.swift
+++ b/Tests/AnglesiteCoreTests/LiveRegionAnnouncerTests.swift
@@ -116,4 +116,20 @@ struct LiveRegionAnnouncerTests {
     func deployNoStderrIsSilent() {
         #expect(LiveRegionAnnouncer.deployStderrAnnouncement(previousStderrCount: 0, currentStderrCount: 0) == nil)
     }
+
+    // MARK: Experiment lifecycle
+
+    @Test func experimentStartRunningIsAnnounced() {
+        let announcement = LiveRegionAnnouncer.experimentAnnouncement(from: .configuring, to: .running(name: "Hero headline"))
+        #expect(announcement == "Your test is live. I'll tell you when there's a clear answer.")
+    }
+
+    @Test func experimentDeployFailureIsAnnounced() {
+        let announcement = LiveRegionAnnouncer.experimentAnnouncement(from: .starting, to: .failed(reason: "Deploy blocked"))
+        #expect(announcement == "Couldn't start your test. Deploy blocked")
+    }
+
+    @Test func noAnnouncementForANonTransition() {
+        #expect(LiveRegionAnnouncer.experimentAnnouncement(from: .configuring, to: .configuring) == nil)
+    }
 }

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -971,7 +971,7 @@ struct NativeContentOperationsDuplicateAsVariantTests {
             return
         }
         #expect(filePath == "src/pages/x/homepage-hero/b.astro")
-        #expect(identifier == "/x/homepage-hero/b")
+        #expect(identifier == "/x/homepage-hero/b/")
     }
 
     @Test("duplicatePageAsVariant injects canonicalPath pointing at the control route")
@@ -990,7 +990,7 @@ struct NativeContentOperationsDuplicateAsVariantTests {
 
         let written = try String(
             contentsOf: root.appendingPathComponent("src/pages/x/homepage-hero/b.astro"), encoding: .utf8)
-        #expect(written.contains("<BaseLayout canonicalPath=\"/pricing\" title=\"Pricing\">"))
+        #expect(written.contains("<BaseLayout canonicalPath=\"/pricing/\" title=\"Pricing\">"))
     }
 
     @Test("duplicatePageAsVariant writes a noindex robots-config entry")
@@ -1041,6 +1041,43 @@ struct NativeContentOperationsDuplicateAsVariantTests {
         // claimed as committed.
         let config = RobotsConfigFile.read(under: root)
         #expect(config.noindex.contains { $0.path == "/x/homepage-hero/b/" })
+    }
+
+    // Encodes `Resources/Template/scripts/pre-deploy-check.ts`'s
+    // `experimentPathProblem(path, { requireTrailingSlash: true })` — the contract every
+    // `experiments.active[]` entry's `page`/`variant.page` must satisfy, for *draft* entries as
+    // much as running ones. `identifier` here is written straight into `variant.page`, so a
+    // slash-less value fails the gate and blocks every subsequent deploy of the whole site (#1518).
+    private func experimentPathProblem(_ path: String) -> String? {
+        if path.isEmpty { return "must be a non-empty string" }
+        if !path.hasPrefix("/") { return #"must start with "/""# }
+        if path.contains("..") { return #"must not contain "..""# }
+        if path.contains("%") { return "must not contain percent-encoding" }
+        if !path.hasSuffix("/") { return #"must end with "/""# }
+        return nil
+    }
+
+    @Test("duplicatePageAsVariant's identifier satisfies the pre-deploy gate's path contract")
+    func identifierSatisfiesThePreDeployPathContract() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let controlRelPath = "src/pages/pricing.astro"
+        let abs = root.appendingPathComponent(controlRelPath)
+        try FileManager.default.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try controlContents.write(to: abs, atomically: true, encoding: .utf8)
+
+        let ops = NativeContentOperations(siteDirectory: { _ in root }, gitCommit: { _, _, _ in "deadbeef" })
+
+        let result = await ops.duplicatePageAsVariant(
+            siteID: "s1", relativePath: controlRelPath, experimentID: "homepage-hero", variantID: "b")
+
+        guard case .created(let filePath, let identifier) = result else {
+            Issue.record("expected .created, got \(result)")
+            return
+        }
+        #expect(experimentPathProblem(identifier) == nil)
+        // …while the file path stays the slash-less form: it's a filesystem location, not a URL.
+        #expect(filePath == "src/pages/x/homepage-hero/b.astro")
     }
 
     @Test("duplicatePageAsVariant fails on route collision")

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -1011,6 +1011,38 @@ struct NativeContentOperationsDuplicateAsVariantTests {
         #expect(config.noindex.contains { $0.path == "/x/homepage-hero/b/" })
     }
 
+    @Test("duplicatePageAsVariant commits the robots-config.json change alongside the page")
+    func commitsRobotsConfigChange() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let controlRelPath = "src/pages/pricing.astro"
+        let abs = root.appendingPathComponent(controlRelPath)
+        try FileManager.default.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try controlContents.write(to: abs, atomically: true, encoding: .utf8)
+
+        let spy = NativeContentOperationsTests.Spy()
+        let ops = NativeContentOperations(
+            siteDirectory: { _ in root },
+            gitCommit: { proj, rel, msg in await spy.record(proj, rel, msg); return "deadbeef" })
+
+        let result = await ops.duplicatePageAsVariant(
+            siteID: "s1", relativePath: controlRelPath, experimentID: "homepage-hero", variantID: "b")
+
+        guard case .created = result else {
+            Issue.record("expected .created, got \(result)")
+            return
+        }
+        let calls = await spy.calls
+        #expect(calls.count == 2)
+        #expect(calls.contains { $0.1 == "src/pages/x/homepage-hero/b.astro" })
+        #expect(calls.contains { $0.1 == RobotsConfigFile.relativePath })
+
+        // The robots-config write itself must have actually landed on disk too, not just been
+        // claimed as committed.
+        let config = RobotsConfigFile.read(under: root)
+        #expect(config.noindex.contains { $0.path == "/x/homepage-hero/b/" })
+    }
+
     @Test("duplicatePageAsVariant fails on route collision")
     func failsOnRouteCollision() async throws {
         let root = try makeRoot()

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -933,6 +933,109 @@ struct NativeContentOperationsDuplicateTests {
     }
 }
 
+@Suite("NativeContentOperations.duplicatePageAsVariant")
+struct NativeContentOperationsDuplicateAsVariantTests {
+    private func makeRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("native-content-ops-variant-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private let controlContents = """
+    ---
+    import BaseLayout from "../layouts/BaseLayout.astro";
+    ---
+
+    <BaseLayout title="Pricing">
+      <h1>Pricing</h1>
+    </BaseLayout>
+    """
+
+    @Test("duplicatePageAsVariant writes a deterministic route")
+    func writesADeterministicRoute() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let controlRelPath = "src/pages/pricing.astro"
+        let abs = root.appendingPathComponent(controlRelPath)
+        try FileManager.default.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try controlContents.write(to: abs, atomically: true, encoding: .utf8)
+
+        let ops = NativeContentOperations(siteDirectory: { _ in root }, gitCommit: { _, _, _ in "deadbeef" })
+
+        let result = await ops.duplicatePageAsVariant(
+            siteID: "s1", relativePath: controlRelPath, experimentID: "homepage-hero", variantID: "b")
+
+        guard case .created(let filePath, let identifier) = result else {
+            Issue.record("expected .created, got \(result)")
+            return
+        }
+        #expect(filePath == "src/pages/x/homepage-hero/b.astro")
+        #expect(identifier == "/x/homepage-hero/b")
+    }
+
+    @Test("duplicatePageAsVariant injects canonicalPath pointing at the control route")
+    func injectsCanonicalPathPointingAtControl() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let controlRelPath = "src/pages/pricing.astro"
+        let abs = root.appendingPathComponent(controlRelPath)
+        try FileManager.default.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try controlContents.write(to: abs, atomically: true, encoding: .utf8)
+
+        let ops = NativeContentOperations(siteDirectory: { _ in root }, gitCommit: { _, _, _ in "deadbeef" })
+
+        _ = await ops.duplicatePageAsVariant(
+            siteID: "s1", relativePath: controlRelPath, experimentID: "homepage-hero", variantID: "b")
+
+        let written = try String(
+            contentsOf: root.appendingPathComponent("src/pages/x/homepage-hero/b.astro"), encoding: .utf8)
+        #expect(written.contains("<BaseLayout canonicalPath=\"/pricing\" title=\"Pricing\">"))
+    }
+
+    @Test("duplicatePageAsVariant writes a noindex robots-config entry")
+    func writesANoindexRobotsConfigEntry() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let controlRelPath = "src/pages/pricing.astro"
+        let abs = root.appendingPathComponent(controlRelPath)
+        try FileManager.default.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try controlContents.write(to: abs, atomically: true, encoding: .utf8)
+
+        let ops = NativeContentOperations(siteDirectory: { _ in root }, gitCommit: { _, _, _ in "deadbeef" })
+
+        _ = await ops.duplicatePageAsVariant(
+            siteID: "s1", relativePath: controlRelPath, experimentID: "homepage-hero", variantID: "b")
+
+        let config = RobotsConfigFile.read(under: root)
+        #expect(config.noindex.contains { $0.path == "/x/homepage-hero/b/" })
+    }
+
+    @Test("duplicatePageAsVariant fails on route collision")
+    func failsOnRouteCollision() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let controlRelPath = "src/pages/pricing.astro"
+        let abs = root.appendingPathComponent(controlRelPath)
+        try FileManager.default.createDirectory(at: abs.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "content".write(to: abs, atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("src/pages/x/homepage-hero"), withIntermediateDirectories: true)
+        try "existing".write(
+            to: root.appendingPathComponent("src/pages/x/homepage-hero/b.astro"), atomically: true, encoding: .utf8)
+
+        let ops = NativeContentOperations(siteDirectory: { _ in root }, gitCommit: { _, _, _ in "deadbeef" })
+
+        let result = await ops.duplicatePageAsVariant(
+            siteID: "s1", relativePath: controlRelPath, experimentID: "homepage-hero", variantID: "b")
+
+        guard case .failed = result else {
+            Issue.record("expected .failed on route collision, got \(result)")
+            return
+        }
+    }
+}
+
 @Suite("NativeContentOperations.createComponent")
 struct NativeContentOperationsComponentTests {
     private func makeRoot() throws -> URL {

--- a/docs/superpowers/plans/2026-08-18-ab-slice5-configure-start-ui.md
+++ b/docs/superpowers/plans/2026-08-18-ab-slice5-configure-start-ui.md
@@ -1,0 +1,2118 @@
+# A/B slice 5: configure/start lifecycle UI — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the Experiment Results sheet (#769) with a propose → configure → start → running lifecycle, so a site owner can turn an A/B test idea into a live, deployed experiment without leaving the app — per issue [#1518](https://github.com/Anglesite/Anglesite/issues/1518) and the design at `docs/superpowers/specs/2026-08-18-ab-slice5-configure-start-ui-design.md`.
+
+**Architecture:** `ExperimentStatsModel` gains an enum-driven `Step` (propose/configure/starting/running, alongside the unchanged `.manual` #769 fallback) backed by `DomainConfig.Experiments` read/write-through. Configure adds a variant-scaffold function in `AnglesiteCore` and a goal picker whose `visible` kind reuses the Effects Gallery's click-to-place JS↔Swift bridge pattern (a new `GoalElementPickController`/`GoalElementPickMessage` pair) plus a new pure CSS-selector builder. Start writes `status: "running"` and calls the existing `DeployModel.deploy(...)` — no new deploy machinery. A template-side gate extension verifies a picked `visible` selector actually resolves in the built HTML.
+
+**Tech Stack:** Swift 6.4 / SwiftUI (AnglesiteApp, AnglesiteCore, AnglesiteBridge, AnglesiteBridgeCore), TypeScript/vitest (JS/edit-overlay), TypeScript/`node:test` (Resources/Template/scripts).
+
+## Global Constraints
+
+- Read `CONTRIBUTING.md` in this worktree before starting any task — issue claiming, commit format, and PR requirements are mandatory, not optional.
+- This work happens in the existing worktree at `/Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/clever-feistel-56818c` on branch `claude/issue-1518-b22c1b` — every task's steps assume `cd` there first; do not create a nested worktree.
+- Conventional commits, subject line ≤72 characters, reference `#1518` where natural (see `CONTRIBUTING.md` ▸ "Commits and pull requests").
+- No new third-party dependencies (`CONTRIBUTING.md`: "New dependencies need explicit approval in an issue first") — Task 13's HTML selector check is deliberately regex-based (matching the existing `findCanonicalHref`/`hasNoindexRobotsMeta` idiom in `pre-deploy-check.ts`), not a new HTML-parsing package.
+- Goal-picker and lifecycle copy is consequence-phrased throughout — no "selector", "IntersectionObserver", "kind", or other implementation jargon in any owner-facing string (master spec `docs/superpowers/specs/2026-08-16-edge-ab-testing-design.md` §10 item 5).
+- Every new interactive SwiftUI control follows the house label/value/hint accessibility pattern (`SyncStatusView.swift:30-34`) and, for selectable rows, `.isSelected` via `.accessibilityAddTraits` on a button-per-row layout (`LicenseGateSheetView.swift:169-195`), not a `Picker`.
+- Swift tests use Swift Testing (`import Testing`, `@Test`, `#expect`), matching `ExperimentStatsModelTests.swift`/`EmailSetupModelTests.swift` — not XCTest.
+- After any task that touches `Sources/AnglesiteApp` or `Sources/AnglesiteCore`, run `swift test --package-path .` before committing (`Resources/Template/` changes also require this per `CONTRIBUTING.md`).
+- After any task that touches `JS/edit-overlay/`, run `npm run lint && npm run typecheck && npm test` from `JS/edit-overlay/`.
+- After any task that touches `Resources/Template/scripts/`, run `npx tsx --test Resources/Template/scripts/<file>.test.ts` (or the specific test file for the touched module).
+
+---
+
+### Task 1: `GoalSelectorBuilder` — pure CSS-selector builder
+
+**Files:**
+- Create: `Sources/AnglesiteCore/GoalSelectorBuilder.swift`
+- Test: `Tests/AnglesiteCoreTests/GoalSelectorBuilderTests.swift`
+
+**Interfaces:**
+- Consumes: `ElementInfo`/`AncestorInfo` (already defined in `Sources/AnglesiteCore/PlacementPickMessage.swift`, same module).
+- Produces: `GoalSelectorBuilder.build(for: ElementInfo) -> Result<String, GoalSelectorBuilder.BuildError>` — consumed by Task 10 (`GoalElementPickController`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/GoalSelectorBuilderTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct GoalSelectorBuilderTests {
+    @Test func prefersDataAnglesiteId() {
+        let info = ElementInfo(
+            tag: "DIV", id: "reviews", classes: ["astro-abc123", "card"], nthChild: 2,
+            ancestors: [], dataAnglesiteId: "reviews-section", dataTestId: nil,
+            role: nil, ariaLabel: nil, textContent: nil)
+        #expect(try? GoalSelectorBuilder.build(for: info).get() == "[data-anglesite-id=\"reviews-section\"]")
+    }
+
+    @Test func fallsBackToIdWhenNoDataAttributes() {
+        let info = ElementInfo(
+            tag: "SECTION", id: "pricing", classes: [], nthChild: 1,
+            ancestors: [], dataAnglesiteId: nil, dataTestId: nil,
+            role: nil, ariaLabel: nil, textContent: nil)
+        #expect(try? GoalSelectorBuilder.build(for: info).get() == "#pricing")
+    }
+
+    @Test func fallsBackToRoleAndAriaLabel() {
+        let info = ElementInfo(
+            tag: "NAV", id: nil, classes: [], nthChild: 1,
+            ancestors: [], dataAnglesiteId: nil, dataTestId: nil,
+            role: "navigation", ariaLabel: "Primary", textContent: nil)
+        #expect(try? GoalSelectorBuilder.build(for: info).get() == "[role=\"navigation\"][aria-label=\"Primary\"]")
+    }
+
+    @Test func filtersAstroScopedHashClassesAndUsesStableClasses() {
+        let info = ElementInfo(
+            tag: "DIV", id: nil, classes: ["astro-xY9z1", "testimonial-card"], nthChild: 1,
+            ancestors: [], dataAnglesiteId: nil, dataTestId: nil,
+            role: nil, ariaLabel: nil, textContent: nil)
+        #expect(try? GoalSelectorBuilder.build(for: info).get() == "div.testimonial-card")
+    }
+
+    @Test func fallsBackToTagAndNthChildWithAncestorChain() {
+        let ancestor = AncestorInfo(tag: "SECTION", id: "testimonials", classes: [], nthChild: 3, role: nil, ariaLabel: nil)
+        let info = ElementInfo(
+            tag: "P", id: nil, classes: ["astro-only"], nthChild: 2,
+            ancestors: [ancestor], dataAnglesiteId: nil, dataTestId: nil,
+            role: nil, ariaLabel: nil, textContent: nil)
+        #expect(try? GoalSelectorBuilder.build(for: info).get() == "#testimonials > p:nth-child(2)")
+    }
+
+    @Test func noStableIdentifierAnywhereInChainFails() {
+        let ancestor = AncestorInfo(tag: "DIV", id: nil, classes: ["astro-x"], nthChild: 1, role: nil, ariaLabel: nil)
+        let info = ElementInfo(
+            tag: "SPAN", id: nil, classes: ["astro-y"], nthChild: 1,
+            ancestors: [ancestor], dataAnglesiteId: nil, dataTestId: nil,
+            role: nil, ariaLabel: nil, textContent: nil)
+        // No ancestor to anchor on and the leaf has no stable identifier either: falls back to a
+        // bare tag:nth-child chain rather than failing — still buildable, just less specific.
+        #expect(try? GoalSelectorBuilder.build(for: info).get() == "div:nth-child(1) > span:nth-child(1)")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter GoalSelectorBuilderTests`
+Expected: FAIL — `GoalSelectorBuilder` doesn't exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+```swift
+// Sources/AnglesiteCore/GoalSelectorBuilder.swift
+import Foundation
+
+/// Builds a literal CSS-selector string for the A/B testing "visible" goal (#1270 slice 5) from
+/// the same `ElementInfo`/`AncestorInfo` payload `PlacementPickMessage` already decodes. Reuses
+/// the proven priority order documented in `JS/edit-overlay/src/selector.ts`
+/// (`data-anglesite-id` > `data-testid` > `#id` > `role`/`aria-label` > stable classes >
+/// `tag:nth-child`) — nothing before this emitted a literal selector string; the two adjacent
+/// mechanisms (the sidecar's `selector.mjs`, `PlacementMatcher`) resolve to a source-file patch
+/// location or a `PageModel` node id instead. Astro's dev-time `astro-*` scoped-class hashes are
+/// filtered before the class fallback is tried, since they don't survive `astro build`.
+public enum GoalSelectorBuilder {
+    public enum BuildError: Error, Equatable {}
+
+    /// Anchors on the nearest ancestor (searching nearest-first) with a stable single-element
+    /// identifier, then walks down to the leaf with `>` combinators, using each hop's own
+    /// simple-selector. If no ancestor anchors, walks the *entire* chain (root-first) the same
+    /// way — always succeeds; the result may just be a longer nth-child chain.
+    public static func build(for element: ElementInfo) -> Result<String, BuildError> {
+        if let leaf = anchoredSelector(tag: element.tag, id: element.id, classes: element.classes,
+                                        dataAnglesiteId: element.dataAnglesiteId, dataTestId: element.dataTestId,
+                                        role: element.role, ariaLabel: element.ariaLabel, nthChild: element.nthChild) {
+            return .success(leaf)
+        }
+        // No anchor at the leaf: find the nearest ancestor (search reversed — ancestors is
+        // root-first) that anchors, then join from there down through to the leaf.
+        for (index, ancestor) in element.ancestors.enumerated().reversed() {
+            if let anchor = anchoredSelector(tag: ancestor.tag, id: ancestor.id, classes: ancestor.classes ?? [],
+                                              dataAnglesiteId: nil, dataTestId: nil,
+                                              role: ancestor.role, ariaLabel: ancestor.ariaLabel, nthChild: ancestor.nthChild) {
+                let remaining = element.ancestors[(index + 1)...].map { simpleSelector(for: $0) } + [simpleSelector(for: element)]
+                return .success(([anchor] + remaining).joined(separator: " > "))
+            }
+        }
+        // No anchor anywhere: full chain from the root-most ancestor down to the leaf.
+        let chain = element.ancestors.map { simpleSelector(for: $0) } + [simpleSelector(for: element)]
+        return .success(chain.joined(separator: " > "))
+    }
+
+    /// A simple selector that alone identifies the element (a data attribute, `#id`, or
+    /// `role`+`aria-label` pair) — or `nil` if it has none, meaning the caller must fall back to
+    /// stable classes or `tag:nth-child` (never "anchoring" material on their own).
+    private static func anchoredSelector(
+        tag: String, id: String?, classes: [String], dataAnglesiteId: String?, dataTestId: String?,
+        role: String?, ariaLabel: String?, nthChild: Int
+    ) -> String? {
+        if let dataAnglesiteId, !dataAnglesiteId.isEmpty { return "[data-anglesite-id=\"\(dataAnglesiteId)\"]" }
+        if let dataTestId, !dataTestId.isEmpty { return "[data-testid=\"\(dataTestId)\"]" }
+        if let id, !id.isEmpty { return "#\(id)" }
+        if let role, let ariaLabel, !role.isEmpty, !ariaLabel.isEmpty {
+            return "[role=\"\(role)\"][aria-label=\"\(ariaLabel)\"]"
+        }
+        return nil
+    }
+
+    /// A simple selector for one hop in a combinator chain — always succeeds (falls back to
+    /// `tag:nth-child(n)`), unlike `anchoredSelector` which only returns something when the
+    /// element is identifiable on its own.
+    private static func simpleSelector(for info: ElementInfo) -> String {
+        simpleSelector(tag: info.tag, classes: info.classes, nthChild: info.nthChild)
+    }
+    private static func simpleSelector(for ancestor: AncestorInfo) -> String {
+        simpleSelector(tag: ancestor.tag, classes: ancestor.classes ?? [], nthChild: ancestor.nthChild ?? 1)
+    }
+    private static func simpleSelector(tag: String, classes: [String], nthChild: Int) -> String {
+        let lowered = tag.lowercased()
+        let stableClasses = classes.filter { !$0.hasPrefix("astro-") }
+        if !stableClasses.isEmpty { return lowered + stableClasses.map { ".\($0)" }.joined() }
+        return "\(lowered):nth-child(\(nthChild))"
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter GoalSelectorBuilderTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/GoalSelectorBuilder.swift Tests/AnglesiteCoreTests/GoalSelectorBuilderTests.swift
+git commit -m "feat(#1518): add GoalSelectorBuilder for visible-goal targeting"
+```
+
+---
+
+### Task 2: `GoalElementPickMessage` + dispatcher wiring
+
+**Files:**
+- Create: `Sources/AnglesiteCore/GoalElementPickMessage.swift`
+- Modify: `Sources/AnglesiteBridgeCore/AnglesiteMessageDispatcher.swift`
+- Test: `Tests/AnglesiteCoreTests/GoalElementPickMessageTests.swift`
+- Test: `Tests/AnglesiteBridgeCoreTests/AnglesiteMessageDispatcherTests.swift` (add cases to existing suite — read the file first to match its exact style)
+
+**Interfaces:**
+- Consumes: nothing new (mirrors `PlacementPickMessage`, `Sources/AnglesiteCore/PlacementPickMessage.swift`).
+- Produces: `GoalElementPickMessage` struct + `.decode(from:)`; `AnglesiteMessageDispatcher.GoalElementPickHandler = @Sendable (GoalElementPickMessage) async -> Void`; new `dispatch(...)` parameter `onGoalElementPick:`; new `DispatchResult` cases `.goalElementPickHandled`/`.goalElementPickDropped`; new `RejectionReason` case `.goalElementPickDecode(...)`. Consumed by Task 3 (`AnglesiteScriptHandler`).
+
+- [ ] **Step 1: Write the failing test for the message type**
+
+```swift
+// Tests/AnglesiteCoreTests/GoalElementPickMessageTests.swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct GoalElementPickMessageTests {
+    @Test func decodesAWellFormedBody() {
+        let body: [String: Any] = [
+            "type": "anglesite:pick-goal-element",
+            "path": "/",
+            "selector": ["tag": "SECTION", "nthChild": 2, "ancestors": []],
+        ]
+        switch GoalElementPickMessage.decode(from: body) {
+        case .success(let message):
+            #expect(message.path == "/")
+            #expect(message.element.tag == "SECTION")
+        case .failure(let error):
+            Issue.record("expected success, got \(error)")
+        }
+    }
+
+    @Test func rejectsAnotherMessageTypeAsWrongType() {
+        let body: [String: Any] = ["type": "anglesite:pick-placement", "path": "/", "selector": [:]]
+        #expect(GoalElementPickMessage.decode(from: body) == .failure(.wrongType))
+    }
+
+    @Test func rejectsMissingSelectorAsMalformed() {
+        let body: [String: Any] = ["type": "anglesite:pick-goal-element", "path": "/"]
+        #expect(GoalElementPickMessage.decode(from: body) == .failure(.malformed))
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter GoalElementPickMessageTests`
+Expected: FAIL — `GoalElementPickMessage` doesn't exist yet.
+
+- [ ] **Step 3: Implement `GoalElementPickMessage`**
+
+```swift
+// Sources/AnglesiteCore/GoalElementPickMessage.swift
+import Foundation
+
+/// The overlay's goal-element-pick mode (Task 4) reporting a click on an arbitrary element while
+/// the owner is choosing the target for an A/B experiment's "visible" goal (#1270 slice 5).
+/// Structurally identical to `PlacementPickMessage` (same `ElementInfo` payload, same "no reply
+/// sent to the page" contract) but a distinct message type/handler — this pick feeds
+/// `GoalSelectorBuilder`, not `PlacementMatcher`/an applied edit.
+public struct GoalElementPickMessage: Sendable, Equatable {
+    public static let messageType = "anglesite:pick-goal-element"
+
+    public let path: String
+    public let element: ElementInfo
+
+    public init(path: String, element: ElementInfo) {
+        self.path = path
+        self.element = element
+    }
+
+    public static func decode(from body: Any) -> Result<GoalElementPickMessage, ComponentCanvasDecodeError> {
+        guard let dict = body as? [String: Any], dict["type"] as? String == messageType else {
+            return .failure(.wrongType)
+        }
+        guard let path = dict["path"] as? String,
+              let selectorDict = dict["selector"] as? [String: Any],
+              let element = ElementInfo.decode(from: selectorDict) else {
+            return .failure(.malformed)
+        }
+        return .success(GoalElementPickMessage(path: path, element: element))
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter GoalElementPickMessageTests`
+Expected: PASS
+
+- [ ] **Step 5: Read the dispatcher file, then wire the new message type in**
+
+Read `Sources/AnglesiteBridgeCore/AnglesiteMessageDispatcher.swift` in full first — it has a `PlacementPickHandler` typealias, an `onPlacementPick` parameter on `dispatch(...)`, a `case EditMessage.MessageType...`-style `switch typeStr` branch for `PlacementPickMessage.messageType`, `DispatchResult` cases `.placementPickHandled`/`.placementPickDropped`, and a `RejectionReason` case `.placementPickDecode`. Add the mirror for `GoalElementPickMessage` at each of those four sites, following the exact same shape:
+
+```swift
+// Sources/AnglesiteBridgeCore/AnglesiteMessageDispatcher.swift — additive changes only
+
+// 1. New typealias, alongside `PlacementPickHandler`:
+public typealias GoalElementPickHandler = @Sendable (GoalElementPickMessage) async -> Void
+
+// 2. New case in `DispatchResult`, alongside `.placementPickHandled`/`.placementPickDropped`:
+case goalElementPickHandled
+case goalElementPickDropped
+
+// 3. New case in `RejectionReason`, alongside `.placementPickDecode`:
+case goalElementPickDecode(ComponentCanvasDecodeError)
+
+// 4. New parameter on `dispatch(...)`, alongside `onPlacementPick:`:
+onGoalElementPick: GoalElementPickHandler? = nil
+
+// 5. New branch in the `switch typeStr` body, alongside the `PlacementPickMessage.messageType` case:
+case GoalElementPickMessage.messageType:
+    switch GoalElementPickMessage.decode(from: body) {
+    case .success(let message):
+        guard let onGoalElementPick else { return .rejected(.notAnObject) } // unreachable in practice; see note below
+        await onGoalElementPick(message)
+        return .goalElementPickHandled
+    case .failure(let error):
+        return .rejected(.goalElementPickDecode(error))
+    }
+```
+
+Before writing branch 5, re-read the *actual* `PlacementPickMessage.messageType` branch — it almost certainly returns `.placementPickDropped` (not a rejection) when `onPlacementPick` is nil, matching `DispatchResult`'s doc comment ("arrived but no handler is installed"). Match that exactly instead of the placeholder shown above — this plan intentionally shows the wrong micro-behavior here as a flag: copy the real nil-handler branch from `PlacementPickMessage`'s case, don't invent a new one.
+
+- [ ] **Step 6: Add dispatcher tests mirroring the existing placement-pick tests**
+
+Open `Tests/AnglesiteBridgeCoreTests/AnglesiteMessageDispatcherTests.swift`, find the placement-pick test(s) (search for `placementPick`), and add the mirror for goal-element-pick: one test that a well-formed `anglesite:pick-goal-element` body with a handler installed calls it and returns `.goalElementPickHandled`; one test that the same body with no handler installed returns `.goalElementPickDropped`.
+
+- [ ] **Step 7: Run the full dispatcher test suite**
+
+Run: `swift test --package-path . --filter AnglesiteMessageDispatcherTests`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/AnglesiteCore/GoalElementPickMessage.swift Sources/AnglesiteBridgeCore/AnglesiteMessageDispatcher.swift Tests/AnglesiteCoreTests/GoalElementPickMessageTests.swift Tests/AnglesiteBridgeCoreTests/AnglesiteMessageDispatcherTests.swift
+git commit -m "feat(#1518): wire anglesite:pick-goal-element through the message dispatcher"
+```
+
+---
+
+### Task 3: `AnglesiteScriptHandler` — `onGoalElementPick` wiring
+
+**Files:**
+- Modify: `Sources/AnglesiteBridge/AnglesiteScriptHandler.swift`
+
+**Interfaces:**
+- Consumes: `AnglesiteMessageDispatcher.GoalElementPickHandler` (Task 2).
+- Produces: `AnglesiteScriptHandler.GoalElementPickHandler` typealias; `init(...)` and `dispatch(...)`/`userContentController(...)` all accept/forward `onGoalElementPick:`. Consumed by Task 15 (`PreviewView`/`SiteWindow` wiring).
+
+- [ ] **Step 1: Add the typealias and thread the parameter**
+
+Mirror every place `onPlacementPick`/`PlacementPickHandler` appears in `Sources/AnglesiteBridge/AnglesiteScriptHandler.swift` (the `public typealias PlacementPickHandler = ...` near the top, the `private let onPlacementPick`, the `init` parameter, the `static func dispatch` parameter and forwarded call, and the `userContentController` local capture + forwarded call) and add the exact same shape for `onGoalElementPick: AnglesiteMessageDispatcher.GoalElementPickHandler` / `AnglesiteScriptHandler.GoalElementPickHandler`. Also add the two new `DispatchResult` switch cases (`.goalElementPickHandled` → `return`, `.goalElementPickDropped` → log the same shape as `.placementPickDropped`'s log line, with `"goal-element-pick"` in the message).
+
+- [ ] **Step 2: Build**
+
+Run: `swift build --package-path .`
+Expected: builds clean — this task has no new tests of its own (it's pure plumbing over Task 2's already-tested dispatcher); Task 2's dispatcher tests plus Task 15's later integration are the coverage for this path.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
+git commit -m "feat(#1518): thread onGoalElementPick through AnglesiteScriptHandler"
+```
+
+---
+
+### Task 4: JS edit-overlay — goal-element pick mode
+
+**Files:**
+- Modify: `JS/edit-overlay/src/messages.ts`
+- Modify: `JS/edit-overlay/src/overlay.ts`
+- Test: `JS/edit-overlay/test/overlay-goal-pick.test.ts` (new file, mirroring `JS/edit-overlay/test/overlay-placement-pick.test.ts`)
+
+**Interfaces:**
+- Consumes: `elementInfoFor` (`JS/edit-overlay/src/selector.ts`, unchanged).
+- Produces: `postGoalElementPick` (messages.ts); `installGoalPickMode(win)` returning `{enter, exit}`, exposed as `window.anglesite._enterGoalPickMode`/`_exitGoalPickMode` (overlay.ts). Consumed by Task 15's `evaluateJavaScript` calls.
+
+- [ ] **Step 1: Read the existing placement-pick test for the pattern to mirror**
+
+Read `JS/edit-overlay/test/overlay-placement-pick.test.ts` in full before writing Step 2 — match its DOM setup, `postMessage` stubbing, and assertion style exactly.
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+// JS/edit-overlay/test/overlay-goal-pick.test.ts
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { installGoalPickMode, GOAL_PICK_HOVER_CLASS } from "../src/overlay.js";
+
+describe("installGoalPickMode", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `<section id="reviews"><p>Great product</p></section>`;
+  });
+
+  it("does nothing on click before enter() is called", () => {
+    const posted: unknown[] = [];
+    const win = { webkit: { messageHandlers: { anglesite: { postMessage: (m: unknown) => posted.push(m) } } } } as any;
+    installGoalPickMode(win);
+    document.querySelector("p")!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(posted).toHaveLength(0);
+  });
+
+  it("posts anglesite:pick-goal-element for the clicked element while active", () => {
+    const posted: unknown[] = [];
+    const win = { webkit: { messageHandlers: { anglesite: { postMessage: (m: unknown) => posted.push(m) } } } } as any;
+    const controls = installGoalPickMode(win);
+    controls.enter();
+    document.querySelector("p")!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(posted).toHaveLength(1);
+    expect((posted[0] as any).type).toBe("anglesite:pick-goal-element");
+    expect((posted[0] as any).selector.tag).toBe("P");
+  });
+
+  it("stops posting after exit()", () => {
+    const posted: unknown[] = [];
+    const win = { webkit: { messageHandlers: { anglesite: { postMessage: (m: unknown) => posted.push(m) } } } } as any;
+    const controls = installGoalPickMode(win);
+    controls.enter();
+    controls.exit();
+    document.querySelector("p")!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(posted).toHaveLength(0);
+  });
+
+  it("adds a hover outline class to the candidate element while active, and clears it on mouseout", () => {
+    const win = { webkit: { messageHandlers: { anglesite: { postMessage: vi.fn() } } } } as any;
+    const controls = installGoalPickMode(win);
+    controls.enter();
+    const p = document.querySelector("p")!;
+    p.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    expect(p.classList.contains(GOAL_PICK_HOVER_CLASS)).toBe(true);
+    p.dispatchEvent(new MouseEvent("mouseout", { bubbles: true }));
+    expect(p.classList.contains(GOAL_PICK_HOVER_CLASS)).toBe(false);
+  });
+
+  it("exposes window.anglesite._enterGoalPickMode/_exitGoalPickMode", () => {
+    const win = { webkit: { messageHandlers: { anglesite: { postMessage: vi.fn() } } } } as any;
+    installGoalPickMode(win);
+    expect(typeof win.anglesite._enterGoalPickMode).toBe("function");
+    expect(typeof win.anglesite._exitGoalPickMode).toBe("function");
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd JS/edit-overlay && npm test -- overlay-goal-pick`
+Expected: FAIL — `installGoalPickMode`/`GOAL_PICK_HOVER_CLASS` don't exist yet.
+
+- [ ] **Step 4: Add `postGoalElementPick` to messages.ts**
+
+```typescript
+// JS/edit-overlay/src/messages.ts — add alongside PlacementPickMessage/postPlacementPick
+
+export interface GoalElementPickMessage {
+  id: string;
+  type: "anglesite:pick-goal-element";
+  path: string;
+  selector: ElementInfo;
+}
+
+/** Posts a goal-element-pick report to native — same "no reply" contract as
+ *  `postPlacementPick`; the app resolves the pick into a CSS selector and updates its own UI. */
+export function postGoalElementPick(
+  message: GoalElementPickMessage,
+  win: WebKitWindow = window as unknown as WebKitWindow,
+): boolean {
+  const handler = win.webkit?.messageHandlers?.anglesite;
+  if (!handler) return false;
+  handler.postMessage(message);
+  return true;
+}
+```
+
+- [ ] **Step 5: Implement `installGoalPickMode` in overlay.ts**
+
+```typescript
+// JS/edit-overlay/src/overlay.ts — add near installPlacementPickMode; also add
+// `postGoalElementPick` to the existing `import { ... } from "./messages.js"` block.
+
+export const GOAL_PICK_HOVER_CLASS = "anglesite-goal-pick-hover";
+
+export interface GoalPickControls {
+  enter(): void;
+  exit(): void;
+}
+
+/** Goal-element-pick mode (#1270 slice 5): while active, hovering any element outlines it and a
+ *  click reports its `ElementInfo` via `anglesite:pick-goal-element` instead of the normal
+ *  click-to-edit path — same exclusivity contract as `installPlacementPickMode`, entered only via
+ *  an explicit native call. Adds hover feedback placement-pick mode doesn't have, since "point at
+ *  the reviews section" is materially harder to do accurately with no visual confirmation of the
+ *  candidate element before clicking. */
+export function installGoalPickMode(win: Window & typeof globalThis = window): GoalPickControls {
+  let active = false;
+  let hovered: Element | null = null;
+
+  const clearHover = () => {
+    hovered?.classList.remove(GOAL_PICK_HOVER_CLASS);
+    hovered = null;
+  };
+
+  document.addEventListener("mouseover", (ev) => {
+    if (!active) return;
+    const target = ev.target as Element | null;
+    if (!target || target.nodeType !== 1) return;
+    if (hovered && hovered !== target) hovered.classList.remove(GOAL_PICK_HOVER_CLASS);
+    target.classList.add(GOAL_PICK_HOVER_CLASS);
+    hovered = target;
+  });
+  document.addEventListener("mouseout", (ev) => {
+    if (!active) return;
+    const target = ev.target as Element | null;
+    if (target === hovered) clearHover();
+  });
+
+  const clickHandler = (ev: MouseEvent) => {
+    if (!active) return;
+    const target = ev.target as Element | null;
+    if (!target || target.nodeType !== 1) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    clearHover();
+    postGoalElementPick(
+      {
+        id: nextEditID(),
+        type: "anglesite:pick-goal-element",
+        path: location.pathname,
+        selector: elementInfoFor(target),
+      },
+      win as unknown as Parameters<typeof postGoalElementPick>[1],
+    );
+  };
+  document.addEventListener("click", clickHandler, { capture: true });
+
+  const anglesiteWin = win as unknown as { anglesite?: { _enterGoalPickMode?: () => void; _exitGoalPickMode?: () => void } };
+  anglesiteWin.anglesite = anglesiteWin.anglesite ?? {};
+  const controls: GoalPickControls = {
+    enter: () => { active = true; },
+    exit: () => { active = false; clearHover(); },
+  };
+  anglesiteWin.anglesite._enterGoalPickMode = controls.enter;
+  anglesiteWin.anglesite._exitGoalPickMode = controls.exit;
+  return controls;
+}
+```
+
+Also add a style rule for `GOAL_PICK_HOVER_CLASS` inside `installStyles()`'s joined array, matching `HOVER_CLASS`'s existing rule shape (e.g. a distinct outline color so it's visually distinguishable from ordinary click-to-edit hover — `outline: 2px dashed rgba(255, 149, 0, 0.9); outline-offset: 2px; cursor: pointer;`), and call `installGoalPickMode(window)` from `install()` alongside the existing `installPlacementPickMode(window)` call.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd JS/edit-overlay && npm test -- overlay-goal-pick`
+Expected: PASS
+
+- [ ] **Step 7: Lint and typecheck**
+
+Run: `cd JS/edit-overlay && npm run lint && npm run typecheck`
+Expected: clean
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add JS/edit-overlay/src/messages.ts JS/edit-overlay/src/overlay.ts JS/edit-overlay/test/overlay-goal-pick.test.ts
+git commit -m "feat(#1518): add goal-element pick mode to the edit overlay"
+```
+
+---
+
+### Task 5: `NativeContentOperations.duplicatePageAsVariant`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/NativeContentOperations.swift` (add the method next to `duplicatePage`, so it can reach that file's `private` `write(_:to:)`/`gitCommit(...)`/`siteDirectory(_:)` helpers)
+- Test: `Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift` (add cases to the existing suite — read it first for the exact fixture/temp-directory pattern already used for `duplicatePage`)
+
+**Interfaces:**
+- Consumes: `ContentScaffold.normalizeRoute`/`slugify`/`pageRelativePath` (`ContentScaffold.swift`), `ContentScanner.routeFromPagePath` (`ContentScanner.swift:66`), `RobotsConfigFile.apply` (`RobotsConfigStore.swift:191-215`), `FileDocumentIO.load` (`FileDocumentIO.swift:30`).
+- Produces: `NativeContentOperations.duplicatePageAsVariant(siteID:relativePath:experimentID:variantID:) async -> ContentCreateResult`. Consumed by Task 12 (`ExperimentStatsModel`'s configure step).
+
+- [ ] **Step 1: Read the existing `duplicatePage` tests to match the fixture pattern**
+
+Read the `duplicatePage` test(s) in `Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift` in full — note how they build a temp site directory, what `siteDirectory(_:)` resolves against, and how they assert on `ContentCreateResult`.
+
+- [ ] **Step 2: Write the failing tests**
+
+```swift
+// Add to Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift — reuse this suite's
+// existing temp-site-directory helper (whatever it's actually called after Step 1's read)
+// instead of the placeholder `makeTempSite` name below if the real helper differs.
+
+@Test func duplicatePageAsVariantWritesADeterministicRoute() async throws {
+    let (ops, root) = try makeTempSite()
+    let controlRelPath = "src/pages/pricing.astro"
+    let controlContents = """
+    ---
+    import BaseLayout from "../layouts/BaseLayout.astro";
+    ---
+
+    <BaseLayout title="Pricing">
+      <h1>Pricing</h1>
+    </BaseLayout>
+    """
+    try controlContents.write(
+        to: root.appendingPathComponent(controlRelPath), atomically: true, encoding: .utf8)
+
+    let result = await ops.duplicatePageAsVariant(
+        siteID: "s1", relativePath: controlRelPath, experimentID: "homepage-hero", variantID: "b")
+
+    guard case .created(let filePath, let identifier) = result else {
+        Issue.record("expected .created, got \(result)")
+        return
+    }
+    #expect(filePath == "src/pages/x/homepage-hero/b.astro")
+    #expect(identifier == "/x/homepage-hero/b")
+}
+
+@Test func duplicatePageAsVariantInjectsCanonicalPathPointingAtControl() async throws {
+    let (ops, root) = try makeTempSite()
+    let controlRelPath = "src/pages/pricing.astro"
+    try """
+    ---
+    import BaseLayout from "../layouts/BaseLayout.astro";
+    ---
+
+    <BaseLayout title="Pricing">
+      <h1>Pricing</h1>
+    </BaseLayout>
+    """.write(to: root.appendingPathComponent(controlRelPath), atomically: true, encoding: .utf8)
+
+    _ = await ops.duplicatePageAsVariant(
+        siteID: "s1", relativePath: controlRelPath, experimentID: "homepage-hero", variantID: "b")
+
+    let written = try String(
+        contentsOf: root.appendingPathComponent("src/pages/x/homepage-hero/b.astro"), encoding: .utf8)
+    #expect(written.contains("<BaseLayout canonicalPath=\"/pricing\" title=\"Pricing\">"))
+}
+
+@Test func duplicatePageAsVariantWritesANoindexRobotsConfigEntry() async throws {
+    let (ops, root) = try makeTempSite()
+    let controlRelPath = "src/pages/pricing.astro"
+    try """
+    ---
+    import BaseLayout from "../layouts/BaseLayout.astro";
+    ---
+
+    <BaseLayout title="Pricing">
+      <h1>Pricing</h1>
+    </BaseLayout>
+    """.write(to: root.appendingPathComponent(controlRelPath), atomically: true, encoding: .utf8)
+
+    _ = await ops.duplicatePageAsVariant(
+        siteID: "s1", relativePath: controlRelPath, experimentID: "homepage-hero", variantID: "b")
+
+    let config = RobotsConfigFile.read(under: root)
+    #expect(config.noindex.contains { $0.path == "/x/homepage-hero/b/" })
+}
+
+@Test func duplicatePageAsVariantFailsOnRouteCollision() async throws {
+    let (ops, root) = try makeTempSite()
+    let controlRelPath = "src/pages/pricing.astro"
+    try "content".write(to: root.appendingPathComponent(controlRelPath), atomically: true, encoding: .utf8)
+    try FileManager.default.createDirectory(
+        at: root.appendingPathComponent("src/pages/x/homepage-hero"), withIntermediateDirectories: true)
+    try "existing".write(
+        to: root.appendingPathComponent("src/pages/x/homepage-hero/b.astro"), atomically: true, encoding: .utf8)
+
+    let result = await ops.duplicatePageAsVariant(
+        siteID: "s1", relativePath: controlRelPath, experimentID: "homepage-hero", variantID: "b")
+
+    guard case .failed = result else {
+        Issue.record("expected .failed on route collision, got \(result)")
+        return
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter NativeContentOperationsTests`
+Expected: FAIL — `duplicatePageAsVariant` doesn't exist yet.
+
+- [ ] **Step 4: Implement `duplicatePageAsVariant`**
+
+```swift
+// Sources/AnglesiteCore/NativeContentOperations.swift — add immediately after duplicatePage(...)
+
+/// Scaffolds an A/B-test variant page from an existing control page (#1270 slice 5): reads the
+/// control's contents, writes them to the deterministic route `/x/<experimentID>/<variantID>`
+/// (never the collision-bumping "Copy 2" naming `duplicatePage` uses — an experiment's variant
+/// route is part of its identity, not a display name), injects a `canonicalPath` prop into the
+/// `<BaseLayout` invocation pointing back at the control route, and marks the new route noindex
+/// via `RobotsConfigFile` — the same mechanism the app's page inspector uses (#1093), so the
+/// variant is invisible to search from the moment it's written, with no separate "remember to
+/// noindex it" step. Fails rather than overwriting if the target route is already taken.
+public func duplicatePageAsVariant(
+    siteID: String, relativePath: String, experimentID: String, variantID: String
+) async -> ContentCreateResult {
+    guard let root = await siteDirectory(siteID) else { return .siteNotFound }
+    let sourceAbs = root.appendingPathComponent(relativePath)
+    guard fileManager.fileExists(atPath: sourceAbs.path) else {
+        return .failed(reason: "No page exists at \(relativePath)")
+    }
+    let contents: String
+    do { contents = try FileDocumentIO.load(sourceAbs, fileManager: fileManager).contents }
+    catch { return .failed(reason: "\(error)") }
+
+    let route = ContentScaffold.normalizeRoute("/x/\(experimentID)/\(variantID)")
+    let relPath = ContentScaffold.pageRelativePath(normalizedRoute: route)
+    guard !fileManager.fileExists(atPath: root.appendingPathComponent(relPath).path) else {
+        return .failed(reason: "A variant page already exists at \(relPath)")
+    }
+
+    let controlRoute = ContentScanner.routeFromPagePath(relativePath)
+    guard let injected = Self.injectingCanonicalPath(controlRoute, into: contents) else {
+        return .failed(reason: "Couldn't find a <BaseLayout> invocation to attach the variant's canonical link to")
+    }
+
+    do { try write(injected, to: root.appendingPathComponent(relPath)) }
+    catch { return .failed(reason: "\(error)") }
+
+    do {
+        try RobotsConfigFile.apply(
+            source: .page(file: relPath), noindex: true, disallowCrawl: false, path: route, under: root)
+    } catch { return .failed(reason: "\(error)") }
+
+    _ = await gitCommit(root, relPath, "anglesite: scaffold experiment variant \(route)")
+    return .created(filePath: relPath, identifier: route)
+}
+
+/// Inserts `canonicalPath="<controlRoute>"` as the first attribute of the first `<BaseLayout`
+/// opening tag found, or `nil` if the source has no `<BaseLayout` invocation to attach to (an
+/// `.astro` page not using the standard layout — out of scope for a v1 variant scaffold, matching
+/// `PageTitleEditor.RewriteError.noEditableLocation`'s "never invent a location" stance).
+static func injectingCanonicalPath(_ controlRoute: String, into contents: String) -> String? {
+    guard let range = contents.range(of: "<BaseLayout") else { return nil }
+    let escaped = controlRoute.replacingOccurrences(of: "\"", with: "&quot;")
+    return contents.replacingCharacters(
+        in: range, with: "<BaseLayout canonicalPath=\"\(escaped)\"")
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter NativeContentOperationsTests`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/NativeContentOperations.swift Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+git commit -m "feat(#1518): add duplicatePageAsVariant for A/B test scaffolding"
+```
+
+---
+
+### Task 6: `BaseLayout.astro` — `canonicalPath` override prop
+
+**Files:**
+- Modify: `Resources/Template/src/layouts/BaseLayout.astro`
+- Test: check for an existing `BaseLayout` build/snapshot test (search `Resources/Template` for `BaseLayout.test` or similar before writing Step 1) and add a case there; if none exists, this task's verification is Step 3's manual build check plus Task 13's gate test, which exercises this prop end-to-end.
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `Props.canonicalPath?: string` on `BaseLayout`. Consumed by Task 5's scaffolded variant pages.
+
+- [ ] **Step 1: Search for existing BaseLayout tests**
+
+Run: `find Resources/Template -iname "*baselayout*test*"`
+If a file is found, read it and add a case asserting that a page passing `canonicalPath="/pricing"` renders `<link rel="canonical" href=".../pricing">` instead of its own URL. If none is found, skip to Step 2 — this prop is exercised indirectly by Task 13's dist-content gate test, which is the real regression backstop for it.
+
+- [ ] **Step 2: Add the prop**
+
+```astro
+---
+// Resources/Template/src/layouts/BaseLayout.astro — inside `interface Props { ... }`, add:
+  /**
+   * Overrides the canonical URL this page advertises, as a root-relative path (e.g. `/pricing`).
+   * Omit for ordinary pages, which canonicalize to their own URL. Set by a scaffolded A/B-test
+   * variant page (#1270 slice 5) to point back at the control page it was duplicated from — a
+   * variant must never rank in search as a distinct page from its control.
+   */
+  canonicalPath?: string;
+---
+```
+
+```astro
+---
+// Resources/Template/src/layouts/BaseLayout.astro — replace the existing single-line `canonical`
+// computation (around line 100) with:
+const { canonicalPath } = Astro.props;
+const canonical = canonicalPath
+  ? new URL(canonicalPath, Astro.site ?? Astro.url).href
+  : new URL(Astro.url.pathname, Astro.site ?? Astro.url).href;
+---
+```
+
+- [ ] **Step 3: Build the template and confirm no regression**
+
+Run: `cd Resources/Template && npm run build`
+Expected: builds clean; every existing page (none of which pass `canonicalPath`) renders byte-identical canonical links to before this change.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Resources/Template/src/layouts/BaseLayout.astro
+git commit -m "feat(#1518): add canonicalPath override prop to BaseLayout"
+```
+
+---
+
+### Task 7: Sitemap excludes noindexed routes
+
+**Files:**
+- Modify: `Resources/Template/src/lib/sitemap-data.ts`
+- Test: `Resources/Template/src/lib/sitemap.test.ts` (add cases — read the file first for its existing fixture/assertion pattern)
+
+**Interfaces:**
+- Consumes: `readRobotsConfig` (`Resources/Template/src/lib/robots-config.ts`, already imported by `BaseLayout.astro`).
+- Produces: `staticPaths()` (private to `sitemap-data.ts`) now excludes noindexed routes. No public signature change — `getSitemapUrls` keeps its existing signature.
+
+- [ ] **Step 1: Read the existing sitemap test file**
+
+Read `Resources/Template/src/lib/sitemap.test.ts` in full to match its fixture/mocking style for `import.meta.glob`-backed page files and for reading/writing `src/data/robots-config.json`.
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+// Add to Resources/Template/src/lib/sitemap.test.ts — adapt the exact mocking mechanism to
+// whatever Step 1 found `PAGE_FILES`/`getSitemapUrls` already use in this file's existing tests.
+test("excludes a route with a noindex robots-config entry from the sitemap", async () => {
+  // Arrange: a robots-config.json with one noindexed route, matching an existing page fixture.
+  // (Reuse this file's existing fixture-writing helper for src/data/robots-config.json, or write
+  // one directly to the temp cwd this suite already sets up, if Step 1 found no reusable helper.)
+  await writeRobotsConfig({ noindex: [{ path: "/x/homepage-hero/b/" }], disallow: [], extra: [] });
+
+  const urls = await getSitemapUrls("https://example.com");
+
+  expect(urls.some((u) => u.loc.includes("/x/homepage-hero/b"))).toBe(false);
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd Resources/Template && npx tsx --test src/lib/sitemap.test.ts` (or the project's actual test invocation for this file, per `Tests` section of `CONTRIBUTING.md` — confirm with `cat package.json`'s `scripts.test` if unsure)
+Expected: FAIL — the noindexed route still appears in `urls`.
+
+- [ ] **Step 4: Implement the filter**
+
+```typescript
+// Resources/Template/src/lib/sitemap-data.ts
+import { readRobotsConfig } from "./robots-config.ts";
+
+function withTrailingSlash(path: string): string {
+  return path.endsWith("/") ? path : path + "/";
+}
+
+/** Routes for the pages that exist in this site, dynamic routes and 404 excluded, and any route
+ *  the site has marked noindex (#1270 slice 5's gate requirement: a scaffolded A/B-test variant
+ *  page must never appear in the sitemap — this is the general mechanism, not experiment-specific,
+ *  since a noindexed page belongs in neither search results nor the sitemap that feeds them). */
+function staticPaths(): string[] {
+  const noindexed = new Set(
+    readRobotsConfig(process.cwd()).noindex.map((entry) => withTrailingSlash(entry.path)));
+  return Object.keys(PAGE_FILES)
+    .map(routePathForPage)
+    .filter((path): path is string => path !== undefined)
+    .filter((path) => !noindexed.has(withTrailingSlash(path)));
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd Resources/Template && npx tsx --test src/lib/sitemap.test.ts`
+Expected: PASS — and confirm no existing sitemap test regressed (full file run).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Resources/Template/src/lib/sitemap-data.ts Resources/Template/src/lib/sitemap.test.ts
+git commit -m "feat(#1518): exclude noindexed routes from the sitemap"
+```
+
+---
+
+### Task 8: `checkExperiments` — visible-goal dist selector-resolution check
+
+**Files:**
+- Modify: `Resources/Template/scripts/pre-deploy-check.ts`
+- Test: `Resources/Template/scripts/pre-deploy-check.test.ts`
+
+**Interfaces:**
+- Consumes: `checkExperiments`'s existing `controlHtmlContent`/`variantHtmlContent`/`distPathFor`/`Issue` (already defined in this file, per the read in this plan's research phase — `checkExperiments` at `pre-deploy-check.ts:846`).
+- Produces: no new exported symbol — extends `checkExperiments`'s existing body with one more check inside its `goal.kind === "visible"` branch (dist-check section, after line ~1077 in the current file).
+
+- [ ] **Step 1: Read the existing `checkExperiments` client-goal-beacon block for the pattern to mirror**
+
+Re-read `pre-deploy-check.ts` lines ~1079–1107 (the `CLIENT_GOAL_KINDS.has(goal.kind)` block) immediately before writing code — the new check's shape (iterate `[control, variant]` × `[html, roleLabel, distPath]`, push an `Issue` per failing arm) should match it closely.
+
+- [ ] **Step 2: Write the failing tests**
+
+```typescript
+// Add to Resources/Template/scripts/pre-deploy-check.test.ts, near the existing checkExperiments
+// tests (search for `checkExperiments(` to find them and match their exact fixture-building style
+// for `active` entries and HTML content strings).
+
+test("checkExperiments flags a visible-goal selector that matches neither built page", () => {
+  const active = [{
+    id: "homepage-hero", name: "Hero", page: "/", split: 0.5, status: "running", startedAt: "2026-08-01",
+    variant: { id: "b", name: "B", page: "/x/homepage-hero/b/" },
+    goal: { kind: "visible", selector: "#reviews" },
+  }];
+  const config = JSON.stringify({ version: 1, experiments: { active } });
+  const distFiles = new Set(["dist/index.html", "dist/x/homepage-hero/b/index.html"]);
+  const controlHtml = "<html><body><h1>Home</h1></body></html>";
+  const variantHtml = "<html><body><h1>Home (variant)</h1></body></html>";
+
+  const issues = checkExperiments(config, distFiles, variantHtml, null, controlHtml);
+
+  assert.ok(issues.some((i) => i.category === "experiments-goal-beacon" && i.message.includes("#reviews")));
+});
+
+test("checkExperiments passes a visible-goal selector present in both built pages", () => {
+  const active = [{
+    id: "homepage-hero", name: "Hero", page: "/", split: 0.5, status: "running", startedAt: "2026-08-01",
+    variant: { id: "b", name: "B", page: "/x/homepage-hero/b/" },
+    goal: { kind: "visible", selector: "#reviews" },
+  }];
+  const config = JSON.stringify({ version: 1, experiments: { active } });
+  const distFiles = new Set(["dist/index.html", "dist/x/homepage-hero/b/index.html"]);
+  const controlHtml = '<html><body><section id="reviews">Great</section></body></html>';
+  const variantHtml = '<html><body><section id="reviews">Great</section></body></html>';
+
+  const issues = checkExperiments(config, distFiles, variantHtml, null, controlHtml);
+
+  assert.ok(!issues.some((i) => i.category === "experiments-goal-beacon" && i.message.includes("reviews")));
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd Resources/Template && npx tsx --test scripts/pre-deploy-check.test.ts`
+Expected: FAIL — the first test finds no matching issue yet (the check doesn't exist).
+
+- [ ] **Step 4: Implement the check**
+
+```typescript
+// Resources/Template/scripts/pre-deploy-check.ts — inside checkExperiments, immediately after the
+// existing CLIENT_GOAL_KINDS block (after the closing brace around line 1107), before `return issues;`
+
+  // A "visible" goal's selector must actually resolve against BOTH built pages — the owner picks
+  // it against the dev-server preview (Anglesite app, #1270 slice 5), which is not guaranteed to
+  // match the production build's DOM 1:1 (Astro's dev-time scoped-class hashes, in particular). A
+  // selector that only ever matched the preview is a goal that silently never fires — the same
+  // failure class the beacon-tag check above guards against.
+  if (goal.kind === "visible" && typeof goal.selector === "string") {
+    const selector = goal.selector as string;
+    for (const [html, roleLabel, distPath] of [
+      [controlHtmlContent, "control page", distPathFor(page)],
+      [variantHtmlContent, "variant page", distPathFor(variantPage)],
+    ] as const) {
+      if (html !== null && !selectorLikelyMatchesHtml(html, selector)) {
+        issues.push({
+          severity: "error",
+          category: "experiments-goal-beacon",
+          message: `Running experiment's "visible" goal selector (${JSON.stringify(selector)}) doesn't match anything in the built ${roleLabel} ("${roleLabel === "control page" ? page : variantPage}") — this goal can never fire.`,
+          file: distPath,
+          remediation: "Re-pick the element in the app, or hand-edit the selector to match markup that exists in the built page.",
+        });
+      }
+    }
+  }
+```
+
+```typescript
+// Resources/Template/scripts/pre-deploy-check.ts — new helper function, near
+// findCanonicalHref/hasNoindexRobotsMeta (same regex-tag-isolation idiom, deliberately not a full
+// CSS selector engine — see this plan's Global Constraints on new dependencies). Only checks the
+// selector's LAST (leaf/target) simple-selector component, since that's the element the beacon's
+// `document.querySelector` ultimately needs to find visible on screen — the combinator chain's
+// ancestor relationships aren't independently verified, a documented, deliberate simplification.
+
+const LEAF_ATTR_PATTERN = /^\[([\w-]+)="([^"]*)"\]$/;
+const LEAF_ID_PATTERN = /^#([\w-]+)$/;
+const LEAF_ROLE_ARIA_PATTERN = /^\[role="([^"]*)"\]\[aria-label="([^"]*)"\]$/;
+const LEAF_TAG_CLASSES_PATTERN = /^([a-z0-9]+)((?:\.[\w-]+)*)$/;
+
+function selectorLikelyMatchesHtml(html: string, selector: string): boolean {
+  const leaf = selector.split(" > ").pop() ?? selector;
+  const tagPattern = /<[a-zA-Z][^>]*>/g;
+  let m: RegExpExecArray | null;
+
+  const attrMatch = leaf.match(LEAF_ATTR_PATTERN);
+  const idMatch = leaf.match(LEAF_ID_PATTERN);
+  const roleAriaMatch = leaf.match(LEAF_ROLE_ARIA_PATTERN);
+  const tagClassesMatch = leaf.match(LEAF_TAG_CLASSES_PATTERN);
+
+  while ((m = tagPattern.exec(html)) !== null) {
+    const tag = m[0];
+    if (attrMatch && new RegExp(`\\b${attrMatch[1]}\\s*=\\s*["']${escapeRegExp(attrMatch[2])}["']`).test(tag)) return true;
+    if (idMatch && new RegExp(`\\bid\\s*=\\s*["']${escapeRegExp(idMatch[1])}["']`).test(tag)) return true;
+    if (roleAriaMatch
+        && new RegExp(`\\brole\\s*=\\s*["']${escapeRegExp(roleAriaMatch[1])}["']`).test(tag)
+        && new RegExp(`\\baria-label\\s*=\\s*["']${escapeRegExp(roleAriaMatch[2])}["']`).test(tag)) return true;
+    if (tagClassesMatch) {
+      const [, tagName, dotClasses] = tagClassesMatch;
+      const classes = dotClasses.split(".").filter(Boolean);
+      const tagMatches = new RegExp(`^<${tagName}\\b`, "i").test(tag);
+      const classMatch = tag.match(/\bclass\s*=\s*["']([^"']*)["']/i);
+      const tagClasses = classMatch ? classMatch[1].split(/\s+/) : [];
+      if (tagMatches && classes.every((c) => tagClasses.includes(c))) return true;
+      if (tagMatches && classes.length === 0) return true; // bare tag:nth-child(n) fallback
+    }
+  }
+  return false;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd Resources/Template && npx tsx --test scripts/pre-deploy-check.test.ts`
+Expected: PASS — and confirm the full `pre-deploy-check.test.ts` suite still passes (no regression in the existing `checkExperiments` cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Resources/Template/scripts/pre-deploy-check.ts Resources/Template/scripts/pre-deploy-check.test.ts
+git commit -m "feat(#1518): gate-check visible-goal selectors against built HTML"
+```
+
+---
+
+### Task 9: `LiveRegionAnnouncer` — experiment lifecycle transitions
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/LiveRegionAnnouncer.swift`
+- Test: `Tests/AnglesiteCoreTests/LiveRegionAnnouncerTests.swift` (add cases — read the file first for its existing pattern)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `LiveRegionAnnouncer.ExperimentActivity` enum + `LiveRegionAnnouncer.experimentAnnouncement(from:to:) -> String?`. Consumed by Task 14 (`ExperimentStatsSheetView`'s `.onChange(of: model.step)`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Add to Tests/AnglesiteCoreTests/LiveRegionAnnouncerTests.swift
+@Test func experimentStartRunningIsAnnounced() {
+    let announcement = LiveRegionAnnouncer.experimentAnnouncement(from: .configuring, to: .running(name: "Hero headline"))
+    #expect(announcement == "Your test is live. I'll tell you when there's a clear answer.")
+}
+
+@Test func experimentDeployFailureIsAnnounced() {
+    let announcement = LiveRegionAnnouncer.experimentAnnouncement(from: .starting, to: .failed(reason: "Deploy blocked"))
+    #expect(announcement == "Couldn't start your test. Deploy blocked")
+}
+
+@Test func noAnnouncementForANonTransition() {
+    #expect(LiveRegionAnnouncer.experimentAnnouncement(from: .configuring, to: .configuring) == nil)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter LiveRegionAnnouncerTests`
+Expected: FAIL — `ExperimentActivity`/`experimentAnnouncement` don't exist yet.
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/AnglesiteCore/LiveRegionAnnouncer.swift — add a new `// MARK: Experiment lifecycle`
+// section, following the same shape as `// MARK: Deploy` above it.
+
+/// The announceable substrate of the experiment configure/start lifecycle (#1270 slice 5),
+/// mapped from `ExperimentStatsModel.Step` the same way `DeployActivity` maps from
+/// `DeployModel.Phase`. `.inactive` covers `.manual`/`.propose`/`.idle`-shaped states with
+/// nothing worth announcing.
+public enum ExperimentActivity: Equatable {
+    case inactive
+    case configuring
+    case starting
+    case running(name: String)
+    case failed(reason: String)
+}
+
+/// The announcement for an experiment lifecycle transition, or `nil`. Same "coarse transition,
+/// not per-field" rule as `deployAnnouncement`.
+public static func experimentAnnouncement(from old: ExperimentActivity, to new: ExperimentActivity) -> String? {
+    guard old != new else { return nil }
+    switch new {
+    case .running: return "Your test is live. I'll tell you when there's a clear answer."
+    case .failed(let reason): return "Couldn't start your test. \(reason)"
+    case .configuring, .starting, .inactive: return nil
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter LiveRegionAnnouncerTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/LiveRegionAnnouncer.swift Tests/AnglesiteCoreTests/LiveRegionAnnouncerTests.swift
+git commit -m "feat(#1518): announce experiment lifecycle transitions"
+```
+
+---
+
+### Task 10: `GoalElementPickController`
+
+**Files:**
+- Create: `Sources/AnglesiteApp/GoalElementPickController.swift`
+- Test: `Tests/AnglesiteAppTests/GoalElementPickControllerTests.swift`
+
+**Interfaces:**
+- Consumes: `GoalSelectorBuilder.build(for:)` (Task 1), `GoalElementPickMessage` (Task 2).
+- Produces: `GoalElementPickController` with `state: State { idle, picking, succeeded(selector: String), failed(String) }`, `startPicking(enterOverlayMode:exitOverlayMode:)`, `cancel()`, `acknowledge()`, `handlePick(_:)`. Consumed by Task 12 (`ExperimentStatsModel`) and Task 15 (`SiteWindow` wiring).
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteAppTests/GoalElementPickControllerTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteAppCore
+@testable import AnglesiteCore
+
+@MainActor
+@Suite struct GoalElementPickControllerTests {
+    private func elementInfo(id: String?) -> ElementInfo {
+        ElementInfo(tag: "SECTION", id: id, classes: [], nthChild: 1, ancestors: [],
+                    dataAnglesiteId: nil, dataTestId: nil, role: nil, ariaLabel: nil, textContent: nil)
+    }
+
+    @Test func startPickingEntersOverlayModeAndSetsPicking() {
+        let controller = GoalElementPickController()
+        var entered = false
+        controller.startPicking(enterOverlayMode: { entered = true }, exitOverlayMode: {})
+        #expect(entered)
+        #expect(controller.state == .picking)
+    }
+
+    @Test func startPickingIsANoOpWhenAlreadyPicking() {
+        let controller = GoalElementPickController()
+        var enterCount = 0
+        controller.startPicking(enterOverlayMode: { enterCount += 1 }, exitOverlayMode: {})
+        controller.startPicking(enterOverlayMode: { enterCount += 1 }, exitOverlayMode: {})
+        #expect(enterCount == 1)
+    }
+
+    @Test func cancelExitsOverlayModeAndReturnsToIdle() {
+        let controller = GoalElementPickController()
+        var exited = false
+        controller.startPicking(enterOverlayMode: {}, exitOverlayMode: { exited = true })
+        controller.cancel()
+        #expect(exited)
+        #expect(controller.state == .idle)
+    }
+
+    @Test func handlePickBuildsASelectorAndExitsOverlayMode() {
+        let controller = GoalElementPickController()
+        var exited = false
+        controller.startPicking(enterOverlayMode: {}, exitOverlayMode: { exited = true })
+        controller.handlePick(GoalElementPickMessage(path: "/", element: elementInfo(id: "reviews")))
+        #expect(exited)
+        #expect(controller.state == .succeeded(selector: "#reviews"))
+    }
+
+    @Test func handlePickIsANoOpWhenNotPicking() {
+        let controller = GoalElementPickController()
+        controller.handlePick(GoalElementPickMessage(path: "/", element: elementInfo(id: "reviews")))
+        #expect(controller.state == .idle)
+    }
+
+    @Test func acknowledgeReturnsATerminalStateToIdle() {
+        let controller = GoalElementPickController()
+        controller.startPicking(enterOverlayMode: {}, exitOverlayMode: {})
+        controller.handlePick(GoalElementPickMessage(path: "/", element: elementInfo(id: "reviews")))
+        controller.acknowledge()
+        #expect(controller.state == .idle)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter GoalElementPickControllerTests`
+Expected: FAIL — `GoalElementPickController` doesn't exist yet.
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/AnglesiteApp/GoalElementPickController.swift
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives the click-to-select flow for an A/B experiment's "visible" goal (#1270 slice 5):
+/// enters the overlay's goal-pick mode, waits for a click, and builds a CSS selector from it via
+/// `GoalSelectorBuilder`. Simpler than `EffectPlacementController` — no page-model fetch or
+/// applied edit, just a synchronous pure computation on the reported `ElementInfo`. One instance
+/// per `ExperimentStatsModel` (Task 12).
+@MainActor
+@Observable
+public final class GoalElementPickController {
+    public enum State: Equatable {
+        case idle
+        case picking
+        case succeeded(selector: String)
+        case failed(String)
+    }
+
+    public private(set) var state: State = .idle
+    private var exitOverlayMode: (() -> Void)?
+
+    public init() {}
+
+    public func startPicking(enterOverlayMode: @escaping () -> Void, exitOverlayMode: @escaping () -> Void) {
+        guard case .idle = state else { return }
+        self.exitOverlayMode = exitOverlayMode
+        state = .picking
+        enterOverlayMode()
+    }
+
+    public func cancel() {
+        guard case .picking = state else { return }
+        exitOverlayMode?()
+        exitOverlayMode = nil
+        state = .idle
+    }
+
+    /// Dismisses a terminal state (`.succeeded`/`.failed`) back to `.idle` — mirrors
+    /// `EffectPlacementController.acknowledge()`'s reasoning: without this, `startPicking`'s
+    /// `.idle` guard would refuse every pick after the first for the rest of this instance's life.
+    public func acknowledge() {
+        switch state {
+        case .succeeded, .failed: state = .idle
+        case .idle, .picking: return
+        }
+    }
+
+    public func handlePick(_ message: GoalElementPickMessage) {
+        guard case .picking = state else { return }
+        exitOverlayMode?()
+        exitOverlayMode = nil
+        switch GoalSelectorBuilder.build(for: message.element) {
+        case .success(let selector): state = .succeeded(selector: selector)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter GoalElementPickControllerTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/GoalElementPickController.swift Tests/AnglesiteAppTests/GoalElementPickControllerTests.swift
+git commit -m "feat(#1518): add GoalElementPickController for the visible-goal picker"
+```
+
+---
+
+### Task 11: `ExperimentStatsModel` — Step enum, config loading, propose
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/ExperimentStatsModel.swift`
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift:724-726` (`presentExperimentStats()` needs to pass `sourceDirectory`)
+- Test: `Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift` (extend the existing suite)
+
+**Interfaces:**
+- Consumes: `DomainConfigStore(sourceDirectory:).load()` (`DomainConfigStore.swift:40`), `DomainConfig.Experiments.Experiment` (`DomainConfig.swift:218-249`), `ContentScaffold.slugify` (`ContentScaffold.swift:36`).
+- Produces: `ExperimentStatsModel.Step` enum, `ExperimentStatsModel.Draft` struct, `init(siteID:sourceDirectory:currentRoute:)`, `propose(from:)`/`proposeCustom(name:)`, `goalPickController: GoalElementPickController` (Task 10). Consumed by Task 12 (configure actions, same model), Task 14 (views), Task 15 (`SiteWindowModel` wiring).
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Add to Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift — note the existing tests all
+// construct `ExperimentStatsModel(siteID: "s1")`; after this task, the initializer gains
+// `sourceDirectory`/`currentRoute` parameters, so update those existing call sites too (with
+// defaulted params if that's the least-invasive way to keep them compiling, decided during
+// implementation — but the model's actual step-resolution logic must be exercised with a real
+// temp directory, not defaults, in the NEW tests below).
+
+@Test func withNoConfigStartsInManual() throws {
+    let tmp = try tempDirectory()
+    let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+    #expect(model.step == .manual)
+}
+
+@Test func withADraftExperimentStartsInConfigure() throws {
+    let tmp = try tempDirectory()
+    let experiment = DomainConfig.Experiments.Experiment(
+        id: "homepage-hero", name: "Hero headline", page: "/",
+        variant: .init(id: "b", name: "B", page: "/x/homepage-hero/b/"),
+        split: 0.5, goal: .init(kind: "pageview", path: "/contact/thanks/"), status: "draft")
+    DomainConfigStore.update(sourceDirectory: tmp) { $0.experiments = .init(active: [experiment]) }
+
+    let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+    guard case .configure(let draft) = model.step else {
+        Issue.record("expected .configure, got \(model.step)")
+        return
+    }
+    #expect(draft.id == "homepage-hero")
+}
+
+@Test func withARunningExperimentStartsInRunning() throws {
+    let tmp = try tempDirectory()
+    let experiment = DomainConfig.Experiments.Experiment(
+        id: "homepage-hero", name: "Hero headline", page: "/",
+        variant: .init(id: "b", name: "B", page: "/x/homepage-hero/b/"),
+        split: 0.5, goal: .init(kind: "pageview", path: "/contact/thanks/"),
+        status: "running", startedAt: "2026-08-01")
+    DomainConfigStore.update(sourceDirectory: tmp) { $0.experiments = .init(active: [experiment]) }
+
+    let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+    guard case .running(let running) = model.step else {
+        Issue.record("expected .running, got \(model.step)")
+        return
+    }
+    #expect(running.id == "homepage-hero")
+}
+
+@Test func proposeFromASuggestionMovesToConfigureWithASlugifiedID() throws {
+    let tmp = try tempDirectory()
+    let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+    model.propose(from: ExperimentStats.suggestionPlaybook[0]) // "Hero headline"
+    guard case .configure(let draft) = model.step else {
+        Issue.record("expected .configure, got \(model.step)")
+        return
+    }
+    #expect(draft.id == "hero-headline")
+    #expect(draft.name == "Hero headline")
+    #expect(draft.page == "/")
+}
+
+private func tempDirectory() throws -> URL {
+    let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+    return tmp
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter ExperimentStatsModelTests`
+Expected: FAIL — `Step`/`Draft`/the new `init`/`propose(from:)` don't exist yet.
+
+- [ ] **Step 3: Implement the Step enum, Draft struct, loading, and propose**
+
+```swift
+// Sources/AnglesiteApp/ExperimentStatsModel.swift — replace the file's contents with the
+// existing #769 manual-entry properties/methods UNCHANGED, plus the following additions.
+
+@Observable @MainActor
+final class ExperimentStatsModel: Identifiable {
+    let id = UUID()
+    let siteID: String
+    let sourceDirectory: URL
+    let currentRoute: String
+
+    enum Step: Equatable {
+        case manual
+        case propose
+        case configure(Draft)
+        case starting
+        case running(DomainConfig.Experiments.Experiment)
+    }
+
+    struct Draft: Equatable {
+        var id: String
+        var name: String
+        var page: String
+        var variantID: String = "b"
+        var variantName: String
+        var variantPage: String?
+        var goalKind: String?
+        var goalPath: String?
+        var goalDepth: Int?
+        var goalSelector: String?
+
+        /// A `draft`-status `DomainConfig.Experiments.Experiment` once the variant is scaffolded
+        /// and a goal is picked — `nil` while either is still missing, matching `canStart`'s gate
+        /// in Task 13.
+        var asExperiment: DomainConfig.Experiments.Experiment? {
+            guard let variantPage, let goalKind else { return nil }
+            let goal = DomainConfig.Experiments.Experiment.Goal(
+                kind: goalKind, path: goalPath, depth: goalDepth, selector: goalSelector)
+            return DomainConfig.Experiments.Experiment(
+                id: id, name: name, page: page,
+                variant: .init(id: variantID, name: variantName, page: variantPage),
+                split: 0.5, goal: goal, status: "draft")
+        }
+    }
+
+    private(set) var step: Step
+    let goalPickController = GoalElementPickController()
+
+    // #769 manual-entry fields — unchanged from before this task.
+    var experimentName: String = ""
+    var controlName: String = "Original"
+    var controlImpressions: Int = 0
+    var controlConversions: Int = 0
+    var treatmentName: String = "Variant"
+    var treatmentImpressions: Int = 0
+    var treatmentConversions: Int = 0
+    private(set) var result: ExperimentStats.Result?
+    private(set) var hasSufficientData = false
+    private(set) var sampleRatioMismatch = false
+    let suggestions = ExperimentStats.suggestionPlaybook
+
+    init(siteID: String, sourceDirectory: URL, currentRoute: String) {
+        self.siteID = siteID
+        self.sourceDirectory = sourceDirectory
+        self.currentRoute = currentRoute
+        self.step = Self.resolveInitialStep(sourceDirectory: sourceDirectory)
+    }
+
+    private static func resolveInitialStep(sourceDirectory: URL) -> Step {
+        guard let config = try? DomainConfigStore(sourceDirectory: sourceDirectory).load(),
+              let active = config.experiments?.active?.first else {
+            return .manual
+        }
+        if active.status == "running" { return .running(active) }
+        return .configure(Draft(
+            id: active.id, name: active.name, page: active.page,
+            variantID: active.variant.id, variantName: active.variant.name, variantPage: active.variant.page,
+            goalKind: active.goal.kind, goalPath: active.goal.path,
+            goalDepth: active.goal.depth, goalSelector: active.goal.selector))
+    }
+
+    func openPropose() {
+        guard case .manual = step else { return }
+        step = .propose
+    }
+
+    func propose(from suggestion: ExperimentStats.Suggestion) {
+        proposeCustom(name: suggestion.title)
+    }
+
+    func proposeCustom(name: String) {
+        let slug = ContentScaffold.slugify(name)
+        step = .configure(Draft(id: slug, name: name, page: currentRoute, variantName: "\(name) — variant"))
+    }
+
+    // ... canAnalyze/analyze()/summary/editAgain() unchanged from before this task ...
+}
+```
+
+- [ ] **Step 4: Update `SiteWindowModel.presentExperimentStats()`**
+
+```swift
+// Sources/AnglesiteApp/SiteWindowModel.swift:724-726 — replace with:
+func presentExperimentStats() {
+    guard experimentStatsModel == nil, let site else { return }
+    experimentStatsModel = ExperimentStatsModel(
+        siteID: site.id, sourceDirectory: site.sourceDirectory, currentRoute: preview.activeRoute ?? "/")
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter ExperimentStatsModelTests`
+Expected: PASS. Also run the full app-target suite once to confirm `SiteWindowModel`'s call-site update didn't break anything else: `swift test --package-path .`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ExperimentStatsModel.swift Sources/AnglesiteApp/SiteWindowModel.swift Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
+git commit -m "feat(#1518): add lifecycle Step and propose to ExperimentStatsModel"
+```
+
+---
+
+### Task 12: `ExperimentStatsModel` — configure actions
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/ExperimentStatsModel.swift`
+- Test: `Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift`
+
+**Interfaces:**
+- Consumes: `NativeContentOperations.duplicatePageAsVariant` (Task 5), `DomainConfigStore.update(sourceDirectory:_:)` (`DomainConfigStore+Update.swift:31-35`), `GoalElementPickController.state` (Task 10).
+- Produces: `scaffoldVariant() async`, `setPageviewGoal(path:)`, `setScrollGoal(depth:)`, `applyPickedVisibleGoal()`, `canStart: Bool`. Consumed by Task 13 (start), Task 14 (views).
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Add to Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
+@Test func scaffoldVariantWritesTheVariantPageAndUpdatesTheDraft() async throws {
+    let tmp = try tempDirectory()
+    try FileManager.default.createDirectory(
+        at: tmp.appendingPathComponent("src/pages"), withIntermediateDirectories: true)
+    try """
+    ---
+    import BaseLayout from "../layouts/BaseLayout.astro";
+    ---
+    <BaseLayout title="Home"><h1>Home</h1></BaseLayout>
+    """.write(to: tmp.appendingPathComponent("src/pages/index.astro"), atomically: true, encoding: .utf8)
+
+    let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+    model.proposeCustom(name: "Hero headline")
+    await model.scaffoldVariant()
+
+    guard case .configure(let draft) = model.step else {
+        Issue.record("expected .configure, got \(model.step)")
+        return
+    }
+    #expect(draft.variantPage == "/x/hero-headline/b")
+}
+
+@Test func settingAGoalPersistsTheDraftToConfig() throws {
+    let tmp = try tempDirectory()
+    let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+    model.proposeCustom(name: "Hero headline")
+    // scaffoldVariant is async and file-backed; for this test, set variantPage directly to
+    // isolate goal-setting + persistence from the scaffold step already covered above.
+    guard case .configure(var draft) = model.step else { Issue.record("expected .configure"); return }
+    draft.variantPage = "/x/hero-headline/b"
+    model.applyDraftForTesting(draft) // test-only setter; see Step 3's note on exposing this
+
+    model.setPageviewGoal(path: "/contact/thanks/")
+
+    let saved = try DomainConfigStore(sourceDirectory: tmp).load()
+    #expect(saved.experiments?.active?.first?.goal.kind == "pageview")
+    #expect(saved.experiments?.active?.first?.status == "draft")
+}
+
+@Test func canStartOnlyOnceVariantAndGoalAreBothSet() throws {
+    let tmp = try tempDirectory()
+    let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+    model.proposeCustom(name: "Hero headline")
+    #expect(!model.canStart)
+    model.setScrollGoal(depth: 75)
+    #expect(!model.canStart) // no variantPage yet
+}
+```
+
+Note on `applyDraftForTesting`: if threading a test-only setter feels wrong once you're in the code, an equally valid alternative is to make the second test above `async` and call the real `scaffoldVariant()` against a temp fixture (same shape as the first test) instead of a synthetic draft — pick whichever keeps `Draft`'s mutation surface entirely private to the model's own methods, which is the better invariant to protect. Either way, no production code should exist solely to make a test possible.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter ExperimentStatsModelTests`
+Expected: FAIL — the new methods don't exist yet.
+
+- [ ] **Step 3: Implement configure actions**
+
+```swift
+// Sources/AnglesiteApp/ExperimentStatsModel.swift — add to the class
+
+private let contentOps = NativeContentOperations()
+
+func scaffoldVariant() async {
+    guard case .configure(var draft) = step, draft.variantPage == nil else { return }
+    let controlRelPath = "src/pages\(draft.page == "/" ? "/index" : draft.page).astro"
+    let result = await contentOps.duplicatePageAsVariant(
+        siteID: siteID, relativePath: controlRelPath, experimentID: draft.id, variantID: draft.variantID)
+    guard case .created(_, let route) = result else { return }
+    draft.variantPage = route
+    step = .configure(draft)
+    persistDraft(draft)
+}
+
+func setPageviewGoal(path: String) {
+    updateDraftGoal { $0.goalKind = "pageview"; $0.goalPath = path; $0.goalDepth = nil; $0.goalSelector = nil }
+}
+
+func setScrollGoal(depth: Int) {
+    updateDraftGoal { $0.goalKind = "scroll"; $0.goalDepth = depth; $0.goalPath = nil; $0.goalSelector = nil }
+}
+
+/// Call after `goalPickController.state` reaches `.succeeded(selector:)` — the sheet view's
+/// `.onChange(of: goalPickController.state)` is the caller (Task 14).
+func applyPickedVisibleGoal() {
+    guard case .succeeded(let selector) = goalPickController.state else { return }
+    updateDraftGoal { $0.goalKind = "visible"; $0.goalSelector = selector; $0.goalPath = nil; $0.goalDepth = nil }
+    goalPickController.acknowledge()
+}
+
+private func updateDraftGoal(_ mutate: (inout Draft) -> Void) {
+    guard case .configure(var draft) = step else { return }
+    mutate(&draft)
+    step = .configure(draft)
+    persistDraft(draft)
+}
+
+private func persistDraft(_ draft: Draft) {
+    guard let experiment = draft.asExperiment else { return }
+    DomainConfigStore.update(sourceDirectory: sourceDirectory) { $0.experiments = .init(active: [experiment]) }
+}
+
+var canStart: Bool {
+    guard case .configure(let draft) = step else { return false }
+    return draft.asExperiment != nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter ExperimentStatsModelTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ExperimentStatsModel.swift Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
+git commit -m "feat(#1518): add configure actions to ExperimentStatsModel"
+```
+
+---
+
+### Task 13: `ExperimentStatsModel` — start + deploy observation
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/ExperimentStatsModel.swift`
+- Test: `Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift`
+
+**Interfaces:**
+- Consumes: `DeployModel.Phase` (`DeployModel.swift:22-31`), `DeployModel.deploy(siteID:siteDirectory:configDirectory:currentRoutes:...)` (`DeployModel.swift:275-282`).
+- Produces: `ExperimentStatsModel.start(deploy: (String, URL, URL, [String]) -> Void)`, `observeDeployPhase(_:)`. Consumed by Task 14 (views/`.onChange` wiring), Task 15 (`SiteWindow` passing the real `DeployModel`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Add to Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
+@Test func startWritesRunningStatusAndInvokesDeploy() throws {
+    let tmp = try tempDirectory()
+    let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+    model.proposeCustom(name: "Hero headline")
+    guard case .configure(var draft) = model.step else { Issue.record("expected .configure"); return }
+    draft.variantPage = "/x/hero-headline/b"
+    draft.goalKind = "pageview"; draft.goalPath = "/thanks/"
+    model.applyDraftForTesting(draft)
+
+    var deployCalled = false
+    model.start(deploy: { _, _, _, _ in deployCalled = true })
+
+    guard case .starting = model.step else { Issue.record("expected .starting, got \(model.step)"); return }
+    #expect(deployCalled)
+    let saved = try DomainConfigStore(sourceDirectory: tmp).load()
+    #expect(saved.experiments?.active?.first?.status == "running")
+}
+
+@Test func deploySuccessMovesToRunning() throws {
+    let tmp = try tempDirectory()
+    let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+    model.proposeCustom(name: "Hero headline")
+    guard case .configure(var draft) = model.step else { Issue.record("expected .configure"); return }
+    draft.variantPage = "/x/hero-headline/b"
+    draft.goalKind = "pageview"; draft.goalPath = "/thanks/"
+    model.applyDraftForTesting(draft)
+    model.start(deploy: { _, _, _, _ in })
+
+    model.observeDeployPhase(.succeeded(url: URL(string: "https://example.com")!, duration: 1))
+
+    guard case .running(let experiment) = model.step else { Issue.record("expected .running, got \(model.step)"); return }
+    #expect(experiment.status == "running")
+}
+
+@Test func deployFailureRevertsToConfigureWithoutClearingTheDraft() throws {
+    let tmp = try tempDirectory()
+    let model = ExperimentStatsModel(siteID: "s1", sourceDirectory: tmp, currentRoute: "/")
+    model.proposeCustom(name: "Hero headline")
+    guard case .configure(var draft) = model.step else { Issue.record("expected .configure"); return }
+    draft.variantPage = "/x/hero-headline/b"
+    draft.goalKind = "pageview"; draft.goalPath = "/thanks/"
+    model.applyDraftForTesting(draft)
+    model.start(deploy: { _, _, _, _ in })
+
+    model.observeDeployPhase(.failed(reason: "Network error", exitCode: nil))
+
+    guard case .configure(let reverted) = model.step else { Issue.record("expected .configure, got \(model.step)"); return }
+    #expect(reverted.variantPage == "/x/hero-headline/b")
+    let saved = try DomainConfigStore(sourceDirectory: tmp).load()
+    #expect(saved.experiments?.active?.first?.status == "draft")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter ExperimentStatsModelTests`
+Expected: FAIL — `start(deploy:)`/`observeDeployPhase(_:)` don't exist yet.
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/AnglesiteApp/ExperimentStatsModel.swift — add to the class
+
+/// Flips the draft's status to `running`, persists it, and invokes `deploy` — a closure rather
+/// than a direct `DeployModel` dependency so this model stays testable without constructing one
+/// (`DeployModel` pulls in token/license/container machinery none of this model's own logic
+/// needs). `SiteWindow` (Task 15) supplies the real `DeployModel.deploy(...)` call; the view's
+/// own `.onChange(of: deployModel.phase)` then calls `observeDeployPhase(_:)` below.
+func start(deploy: (String, URL, URL, [String]) -> Void) {
+    guard case .configure(let draft) = step, var experiment = draft.asExperiment else { return }
+    experiment.status = "running"
+    experiment.startedAt = ISO8601DateFormatter().string(from: Date()).prefix(10).description
+    DomainConfigStore.update(sourceDirectory: sourceDirectory) { $0.experiments = .init(active: [experiment]) }
+    step = .starting
+    deploy(siteID, sourceDirectory, sourceDirectory, [experiment.page, experiment.variant.page])
+}
+
+/// Called from the sheet view's `.onChange(of: deployModel.phase)` while `step == .starting`.
+/// Any phase other than a clean success reverts to `.configure` with the draft intact and its
+/// config entry rolled back to `"draft"` — a failed start must never leave `anglesite.json`
+/// claiming a test is live when the deploy that would make it so never landed.
+func observeDeployPhase(_ phase: DeployModel.Phase) {
+    guard case .starting = step else { return }
+    switch phase {
+    case .succeeded:
+        guard let config = try? DomainConfigStore(sourceDirectory: sourceDirectory).load(),
+              let running = config.experiments?.active?.first else { return }
+        step = .running(running)
+    case .failed(let reason, _):
+        revertToConfigureAfterFailedStart(reason: reason)
+    case .blocked:
+        revertToConfigureAfterFailedStart(reason: "The pre-deploy check found issues that need fixing first.")
+    case .idle, .running, .workerNameConflict, .webmentionPaidPlanConfirmationNeeded, .domainConfigDrift:
+        return
+    }
+}
+
+private func revertToConfigureAfterFailedStart(reason: String) {
+    guard case .starting = step,
+          let config = try? DomainConfigStore(sourceDirectory: sourceDirectory).load(),
+          let entry = config.experiments?.active?.first else { return }
+    DomainConfigStore.update(sourceDirectory: sourceDirectory) { config in
+        var reverted = entry
+        reverted.status = "draft"
+        reverted.startedAt = nil
+        config.experiments = .init(active: [reverted])
+    }
+    step = .configure(Draft(
+        id: entry.id, name: entry.name, page: entry.page,
+        variantID: entry.variant.id, variantName: entry.variant.name, variantPage: entry.variant.page,
+        goalKind: entry.goal.kind, goalPath: entry.goal.path,
+        goalDepth: entry.goal.depth, goalSelector: entry.goal.selector))
+    startFailureReason = reason
+}
+
+private(set) var startFailureReason: String?
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter ExperimentStatsModelTests`
+Expected: PASS. Then run the full suite once: `swift test --package-path .`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ExperimentStatsModel.swift Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
+git commit -m "feat(#1518): add start and deploy-phase observation to ExperimentStatsModel"
+```
+
+---
+
+### Task 14: Views — propose/configure/running + sheet wiring
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/ExperimentStatsSheetView.swift`
+- Create: `Sources/AnglesiteApp/ExperimentProposeView.swift`
+- Create: `Sources/AnglesiteApp/ExperimentConfigureView.swift`
+- Create: `Sources/AnglesiteApp/ExperimentRunningStatusView.swift`
+
+**Interfaces:**
+- Consumes: `ExperimentStatsModel.Step`/`.Draft` (Task 11-13), `GoalElementPickController.state` (Task 10), `LiveRegionAnnouncer.experimentAnnouncement` (Task 9).
+- Produces: the three new views; `ExperimentStatsSheetView` switches on `model.step`. Consumed by Task 15 (needs `deployModel`/pick-mode closures threaded in from `SiteWindow`).
+
+This task is UI-only (no unit tests — SwiftUI view bodies aren't practically unit-testable here, matching this codebase's existing convention of no tests for `ExperimentStatsSheetView`/`EmailSetupSheetView` themselves). Verification is a manual smoke pass in Step 4.
+
+- [ ] **Step 1: Rewrite `ExperimentStatsSheetView` to switch on `model.step`**
+
+```swift
+// Sources/AnglesiteApp/ExperimentStatsSheetView.swift
+import SwiftUI
+import AnglesiteCore
+
+struct ExperimentStatsSheetView: View {
+    @Bindable var model: ExperimentStatsModel
+    var deployModel: DeployModel
+    var onDone: () -> Void
+    var enterGoalPickMode: () -> Void
+    var exitGoalPickMode: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch model.step {
+                case .manual:
+                    manualForm
+                case .propose:
+                    ExperimentProposeView(model: model)
+                case .configure:
+                    ExperimentConfigureView(model: model, enterGoalPickMode: enterGoalPickMode, exitGoalPickMode: exitGoalPickMode)
+                case .starting:
+                    ProgressView("Starting your test…")
+                case .running(let experiment):
+                    ExperimentRunningStatusView(experiment: experiment)
+                }
+            }
+            .formStyle(.grouped)
+            .navigationTitle("Experiment Results")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { onDone() }
+                }
+            }
+        }
+        .frame(minWidth: 520, idealWidth: 560, minHeight: 480, idealHeight: 620)
+        .onChange(of: model.step) { oldStep, newStep in
+            guard AppSettings.shared.announcesLiveUpdates else { return }
+            // `newStep`'s activity needs `model.startFailureReason` too: a failed deploy reverts
+            // `step` from `.starting` back to `.configure`, which on its own is indistinguishable
+            // from a fresh, never-started `.configure` — losing the failure announcement entirely
+            // if `activity(for:)` looked at `step` alone. Consumed here (read, not cleared) since
+            // `experimentAnnouncement` already dedupes on `old != new`.
+            if let announcement = LiveRegionAnnouncer.experimentAnnouncement(
+                from: activity(for: oldStep, failureReason: nil),
+                to: activity(for: newStep, failureReason: model.startFailureReason)) {
+                AccessibilityNotification.Announcement(announcement).post()
+            }
+        }
+        .onChange(of: deployModel.phase) { _, newPhase in
+            model.observeDeployPhase(newPhase)
+        }
+        .onChange(of: model.goalPickController.state) { _, newState in
+            if case .succeeded = newState { model.applyPickedVisibleGoal() }
+        }
+    }
+
+    private func activity(for step: ExperimentStatsModel.Step, failureReason: String?) -> LiveRegionAnnouncer.ExperimentActivity {
+        switch step {
+        case .manual, .propose: return .inactive
+        case .configure:
+            // A `.configure` step reached via `observeDeployPhase`'s revert carries a
+            // `startFailureReason`; a `.configure` step reached via propose/scaffold/goal-setting
+            // never sets one (Task 12's methods don't touch it) — so this alone distinguishes the
+            // two without `step` needing its own dedicated `.justFailed` case.
+            if let failureReason { return .failed(reason: failureReason) }
+            return .inactive
+        case .starting: return .starting
+        case .running(let e): return .running(name: e.name)
+        }
+    }
+
+    // manualForm: move the ENTIRE existing #769 body (Section("Experiment") through the
+    // "Test ideas" ForEach) into this computed property unchanged, except the "Test ideas"
+    // section's rows each gain `.onTapGesture { model.openPropose() }` — the one behavioral
+    // change to the manual form: tapping a suggestion now moves into the lifecycle instead of
+    // being inert text. Read the CURRENT file (pre-Task-11) before writing this property so the
+    // moved code is copied verbatim except for that one addition.
+    @ViewBuilder
+    private var manualForm: some View {
+        // ... existing #769 Form content, verbatim, plus the tap gesture noted above ...
+    }
+}
+```
+
+- [ ] **Step 2: `ExperimentProposeView`**
+
+```swift
+// Sources/AnglesiteApp/ExperimentProposeView.swift
+import SwiftUI
+import AnglesiteCore
+
+struct ExperimentProposeView: View {
+    @Bindable var model: ExperimentStatsModel
+    @State private var customName = ""
+
+    var body: some View {
+        Form {
+            Section("What should we test?") {
+                ForEach(model.suggestions, id: \.title) { suggestion in
+                    Button {
+                        model.propose(from: suggestion)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(suggestion.title).font(.callout.weight(.medium))
+                            Text(suggestion.rationale).font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(suggestion.title)
+                    .accessibilityHint(suggestion.rationale)
+                }
+            }
+            Section("Or describe your own idea") {
+                TextField("What are you testing?", text: $customName)
+                Button("Start with this idea") { model.proposeCustom(name: customName) }
+                    .disabled(customName.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: `ExperimentConfigureView`**
+
+```swift
+// Sources/AnglesiteApp/ExperimentConfigureView.swift
+import SwiftUI
+import AnglesiteCore
+
+struct ExperimentConfigureView: View {
+    @Bindable var model: ExperimentStatsModel
+    var enterGoalPickMode: () -> Void
+    var exitGoalPickMode: () -> Void
+
+    @State private var scrollDepth: Double = 75
+    @State private var pageviewPath: String = ""
+
+    private var draft: ExperimentStatsModel.Draft? {
+        guard case .configure(let draft) = model.step else { return nil }
+        return draft
+    }
+
+    var body: some View {
+        Form {
+            if let draft {
+                Section(draft.name) {
+                    if draft.variantPage == nil {
+                        Button("Create the variant page") {
+                            Task { await model.scaffoldVariant() }
+                        }
+                    } else {
+                        LabeledContent("Variant page", value: draft.variantPage ?? "")
+                        Text("Edit its content from the page editor, then choose what counts as a win below.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                Section("What counts as a win?") {
+                    goalOptionRow(
+                        title: "Counts when a visitor reaches a page",
+                        isSelected: draft.goalKind == "pageview") {
+                        TextField("Page (e.g. /contact/thanks/)", text: $pageviewPath)
+                        Button("Use this page") { model.setPageviewGoal(path: pageviewPath) }
+                            .disabled(pageviewPath.isEmpty)
+                    }
+                    goalOptionRow(
+                        title: "Counts when a visitor scrolls partway down",
+                        isSelected: draft.goalKind == "scroll") {
+                        Slider(value: $scrollDepth, in: 1...100, step: 1) {
+                            Text("Scroll depth")
+                        }
+                        Button("Use \(Int(scrollDepth))% scrolled") { model.setScrollGoal(depth: Int(scrollDepth)) }
+                    }
+                    goalOptionRow(
+                        title: "Counts when a visitor sees something on the page",
+                        isSelected: draft.goalKind == "visible") {
+                        Button(model.goalPickController.state == .picking ? "Click the element in the preview…" : "Choose in the preview") {
+                            model.goalPickController.startPicking(enterOverlayMode: enterGoalPickMode, exitOverlayMode: exitGoalPickMode)
+                        }
+                        .disabled(model.goalPickController.state == .picking)
+                        if case .failed(let reason) = model.goalPickController.state {
+                            Text(reason).font(.caption).foregroundStyle(.orange)
+                        }
+                    }
+                }
+                Section {
+                    Button("Start your test") {
+                        model.start(deploy: { _, _, _, _ in }) // Task 15 supplies the real deploy call
+                    }
+                    .disabled(!model.canStart)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func goalOptionRow<Content: View>(title: String, isSelected: Bool, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading) {
+            Label(title, systemImage: isSelected ? "checkmark.circle.fill" : "circle")
+                .accessibilityAddTraits(isSelected ? .isSelected : [])
+            content()
+        }
+    }
+}
+```
+
+- [ ] **Step 4: `ExperimentRunningStatusView`**
+
+```swift
+// Sources/AnglesiteApp/ExperimentRunningStatusView.swift
+import SwiftUI
+import AnglesiteCore
+
+struct ExperimentRunningStatusView: View {
+    let experiment: DomainConfig.Experiments.Experiment
+
+    var body: some View {
+        Form {
+            Section(experiment.name) {
+                LabeledContent("Status") {
+                    Text("Live")
+                }
+                .accessibilityLabel("Status")
+                .accessibilityValue("Live")
+                if let startedAt = experiment.startedAt {
+                    LabeledContent("Started", value: startedAt)
+                }
+                Text("Your test is live. Visitors will see one version or the other; I'll tell you when there's a clear answer.")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Build**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: builds clean. (Task 15 still needs to update the `ExperimentStatsSheetView` call site in `SiteWindow.swift` for the new `deployModel`/`enterGoalPickMode`/`exitGoalPickMode` parameters — this build may fail at that one call site until Task 15 lands; if so, that's expected and gets fixed there, not here.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ExperimentStatsSheetView.swift Sources/AnglesiteApp/ExperimentProposeView.swift Sources/AnglesiteApp/ExperimentConfigureView.swift Sources/AnglesiteApp/ExperimentRunningStatusView.swift
+git commit -m "feat(#1518): add propose/configure/running views to the Experiment Results sheet"
+```
+
+---
+
+### Task 15: `SiteWindow`/`SiteWindowModel` wiring
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift:936-937` (sheet call site), `:69` region of `PreviewView.swift` construction site (~line 1188-1195)
+- Modify: `Sources/AnglesiteApp/PreviewView.swift` (new `onGoalElementPick` param)
+- Modify: `Sources/AnglesiteApp/ComponentEditorCanvasPane.swift:219` (pass `onGoalElementPick: nil` explicitly if the parameter isn't defaulted — check after Task 3/this task's `AnglesiteScriptHandler` signature)
+
+**Interfaces:**
+- Consumes: everything from Tasks 10-14.
+- Produces: fully wired feature — this is the integration task with no new public API of its own.
+
+- [ ] **Step 1: Add `onGoalElementPick` to `PreviewView`**
+
+```swift
+// Sources/AnglesiteApp/PreviewView.swift — add near `onPlacementPick` (both the doc comment and
+// default-no-op shape should mirror it):
+var onGoalElementPick: AnglesiteScriptHandler.GoalElementPickHandler = { _ in }
+```
+
+And thread it into the `AnglesiteScriptHandler(...)` construction at line 69:
+
+```swift
+let handler = AnglesiteScriptHandler(
+    router: router, onVisibleElements: onVisibleElements,
+    onPlacementPick: onPlacementPick, onGoalElementPick: onGoalElementPick)
+```
+
+- [ ] **Step 2: Wire the closures in `SiteWindow.swift`'s `previewPane(for:)`**
+
+```swift
+// Sources/AnglesiteApp/SiteWindow.swift — inside previewPane(for:)'s PreviewView(...) call
+// (around line 1188), add alongside the existing onPlacementPick:
+onGoalElementPick: { message in
+    model.experimentStatsModel?.goalPickController.handlePick(message)
+},
+```
+
+- [ ] **Step 3: Pass `deployModel` and the goal-pick enter/exit closures into the sheet**
+
+```swift
+// Sources/AnglesiteApp/SiteWindow.swift:936-937 — replace with:
+.sheet(item: $bindableModel.experimentStatsModel) { statsModel in
+    ExperimentStatsSheetView(
+        model: statsModel,
+        deployModel: model.deploy,
+        onDone: { model.experimentStatsModel = nil },
+        enterGoalPickMode: {
+            model.preview.webView?.evaluateJavaScript("window.anglesite?._enterGoalPickMode?.()")
+        },
+        exitGoalPickMode: {
+            model.preview.webView?.evaluateJavaScript("window.anglesite?._exitGoalPickMode?.()")
+        }
+    )
+}
+```
+
+- [ ] **Step 4: Wire `start()`'s deploy closure to the real `DeployModel`**
+
+In `ExperimentConfigureView.swift` (Task 14 Step 3), the `Button("Start your test")` action currently calls `model.start(deploy: { _, _, _, _ in })` with a stub. Replace it with the real deploy call — this needs `deployModel` threaded into `ExperimentConfigureView` the same way it's already threaded into `ExperimentStatsSheetView` (Task 14 Step 1). Add a `var deployModel: DeployModel` param to `ExperimentConfigureView`, pass it from `ExperimentStatsSheetView`'s `case .configure:` branch, and change the button action to:
+
+```swift
+Button("Start your test") {
+    model.start(deploy: { siteID, siteDirectory, configDirectory, routes in
+        deployModel.deploy(siteID: siteID, siteDirectory: siteDirectory, configDirectory: configDirectory, currentRoutes: routes)
+    })
+}
+.disabled(!model.canStart)
+```
+
+- [ ] **Step 5: Confirm `ComponentEditorCanvasPane.swift`'s `AnglesiteScriptHandler(...)` call still compiles**
+
+Read `Sources/AnglesiteApp/ComponentEditorCanvasPane.swift:219` — if `onGoalElementPick` was given a default `= nil` in Task 3 (the plan's `init` mirrors `onPlacementPick`, which does have one), this call site needs no change. Confirm by building; if it fails to compile, add `onGoalElementPick: nil` explicitly to that call site.
+
+- [ ] **Step 6: Build and run the full local test suite**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Run: `swift test --package-path .`
+Expected: both clean.
+
+- [ ] **Step 7: Manual smoke test**
+
+Per `docs/testing-macos-app.md`, launch the built app against a real (or fixture) site, open Website ▸ Experiment Results…, and walk propose → configure → pick a `visible` goal by clicking an element in the live preview → start, confirming: the variant page appears in the Navigator, the goal picker's hover outline shows in the preview during picking, and the sheet reaches the running-status view after a successful (or intentionally-failed, to check the revert path) deploy. This is the one path in this plan with no automated DOM to assert against (per the design doc §8), so it needs a real look before merging.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/AnglesiteApp/PreviewView.swift Sources/AnglesiteApp/SiteWindow.swift Sources/AnglesiteApp/ExperimentConfigureView.swift Sources/AnglesiteApp/ComponentEditorCanvasPane.swift
+git commit -m "feat(#1518): wire configure/start lifecycle UI into SiteWindow"
+```
+
+---
+
+## After all tasks
+
+- Re-read `CONTRIBUTING.md` ▸ "Commits and pull requests" before opening the PR — use `.github/PULL_REQUEST_TEMPLATE.md`'s exact headings (Summary, Paired PR check, Test plan), note in "Paired PR check" that this is app/template-only with no MCP schema change, and include `Closes #1518` per the template's closing-keyword requirement.
+- Confirm the `🛠️ In Progress` label stays on issue #1518 (already applied) — don't remove it; the PR's closing keyword drops it out of the claimed-issue search on merge.
+- Run the full verification sweep once more before opening the PR: `swift test --package-path .`, `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`, `cd JS/edit-overlay && npm run lint && npm run typecheck && npm test`, and the `Resources/Template` test command(s) used in Tasks 6-8.

--- a/docs/superpowers/specs/2026-08-18-ab-slice5-configure-start-ui-design.md
+++ b/docs/superpowers/specs/2026-08-18-ab-slice5-configure-start-ui-design.md
@@ -1,0 +1,209 @@
+# A/B slice 5: configure/start lifecycle UI — design (#1518)
+
+**Status:** approved design, pre-implementation.
+**Issue:** [#1518](https://github.com/Anglesite/Anglesite/issues/1518), slice 5 of 6 from
+[#1270](https://github.com/Anglesite/Anglesite/issues/1270)'s approved design
+(`docs/superpowers/specs/2026-08-16-edge-ab-testing-design.md`, hereafter "the master
+spec" — §5 "Experiment lifecycle" and §10 item 5 define this slice's scope). This
+document fills in the implementation-level decisions the master spec deliberately left
+to the slice: sheet architecture, the variant-scaffold function, and — the one piece
+not anticipated by existing code — how an owner picks an on-page element for the
+`visible` goal kind without seeing CSS-selector jargon.
+
+Depends on slice 3 (#1515, merged — `DomainConfig.Experiments`, deploy-path wiring) and
+is independent of slice 4 (#1516, results pipeline — `ExperimentEventsD1Client`, still
+open). Slice 5 does not block on slice 4: the "running" step shows declared config
+state (id/name/status/started date) with no live visitor/conversion counts, exactly as
+this doc's §6 specifies.
+
+## 1. Architecture
+
+`ExperimentStatsModel` (`Sources/AnglesiteApp/ExperimentStatsModel.swift`) gains an
+enum-driven step, the same shape as `EmailSetupModel`'s already-shipped
+`Step { ecosystem, appleTier, details, ... }` pattern:
+
+```swift
+enum Step {
+    case manual                        // today's #769 form, unchanged
+    case propose                       // playbook suggestions, interactive
+    case configure(ExperimentDraft)    // variant scaffold + goal picker
+    case starting                      // config write + deploy in flight
+    case running(DomainConfig.Experiments.Experiment)  // declared status only
+}
+```
+
+One sheet, one model, one menu command (`WebsiteCommands.swift:123`) — no new window
+class, matching the master spec §5's "all UI extends the existing Experiment Results
+sheet surface."
+
+The model gains a `sourceDirectory: URL` dependency it doesn't have today (currently
+only `siteID`), to load/write `DomainConfig.Experiments` through
+`DomainConfigStore.update(sourceDirectory:_:)` and to call `DeployModel.deploy(...)` for
+the start step — mirroring `EmailSetupModel`'s existing `sourceDirectory` + ops-seam
+pattern.
+
+**Step resolution on open:** load config; a `running` or `draft` entry in
+`experiments.active` jumps straight to `.running`/`.configure`; no entry falls back to
+`.manual` with the playbook section now tappable to enter `.propose`. Since the schema
+allows at most one active experiment (master spec §2), there's never an ambiguous
+starting state.
+
+## 2. Propose
+
+The existing static "Test ideas" list (`ExperimentStatsSheetView.swift:35-42`,
+currently read-only text) becomes a list of tappable rows plus an "or describe your own
+idea" text field. Selecting one creates an `ExperimentDraft` (page = the sheet's site
+route context, suggestion title/rationale carried through as the default experiment
+name) and moves to `.configure`. Nothing persists yet, per master spec §5's Propose row
+("Nothing persisted").
+
+## 3. Configure
+
+### Variant scaffold
+
+New `AnglesiteCore` function, `duplicatePageAsVariant(siteID:relativePath:experimentID:variantID:) async -> ContentCreateResult`, built on `NativeContentOperations.duplicatePage`'s
+read/write/commit shape (`NativeContentOperations.swift:414-450`) but differing in two
+ways `duplicatePage` doesn't support:
+
+- **Deterministic target route** — `/x/<experimentId>/<variantId>/` (master spec §2),
+  not `duplicatePage`'s "Title Copy" / "Copy 2" collision-bumping naming.
+- **Frontmatter injection** — `rel=canonical` → the control page's URL, `noindex`, and
+  sitemap exclusion, none of which `duplicatePage` or `ContentScaffold.renderPage`
+  (template-from-`PageTemplate`, not content-copy) do today. These three are also gate
+  requirements (master spec §6), so the scaffold function is the single place that
+  guarantees they're always present — no separate "remember to add noindex" step for a
+  hand author to skip.
+
+After scaffolding, the sheet hands off to the ordinary page editor (Navigator `.route`
+entry for the new variant page) for content edits — master spec §5's "owner edits the
+variant — the same editing surfaces as any page." The configure step's own UI is the
+goal picker plus a "done editing, continue" affordance; it does not embed an editor.
+
+### Goal picker
+
+Three consequence-phrased options, no kind names, no `IntersectionObserver`/selector
+vocabulary anywhere in the UI (master spec §10 item 5):
+
+- **"Counts when a visitor reaches ___"** (`pageview`) — a page picker scoped to the
+  site's existing routes.
+- **"Counts when a visitor scrolls about ___ of the way down"** (`scroll`) — a percent
+  stepper, 1–100.
+- **"Counts when a visitor sees ___ on the page"** (`visible`) — click-to-select in the
+  live preview (below).
+
+### Click-to-select (`visible` goal)
+
+Reuses `EffectPlacementController`'s exact state machine (`idle → picking → applying →
+succeeded/failed`, Esc-to-cancel via `.onExitCommand`, HUD banner text swapped for goal
+language) and the JS-side exclusive pick-mode gate
+(`installPlacementPickMode()`/`_enterPlacementMode`/`_exitPlacementMode`,
+`overlay.ts:119-158`) already shipped for the Effects Gallery. Two net-new pieces, both
+flagged by the preview-architecture survey as genuinely absent from the codebase today:
+
+1. **A new message type** (or a new terminal-handler branch on the existing
+   `anglesite:pick-placement` message, decided during implementation by whichever
+   requires less duplication) carrying the same `ElementInfo` payload
+   (`selector.ts`'s `elementInfoFor`) that placement-pick already collects.
+2. **A CSS-selector-string builder** — nothing today emits a literal selector; the two
+   adjacent mechanisms (`selector.mjs` in the sibling repo, `PlacementMatcher.swift`)
+   resolve to a source-file patch location or a `PageModel` node id, not selector text.
+   The new builder reuses the *proven priority order* from both (`data-anglesite-id` →
+   `data-testid` → `#id` → role/aria-label → stable classes → `tag:nth-child`), filters
+   Astro's dev-time `astro-*` scoped-class hashes (already flagged as needed,
+   `selector.ts:6`), and joins the ancestor chain into a `>`-combinator selector.
+
+Hover feedback on the candidate element while picking (not present in placement-pick
+today) is added as a small `mouseover` handler inside `installPlacementPickMode`'s
+active branch, mirroring `attachHover`'s existing pattern — worth the small addition
+since "point at the reviews section" is meaningfully harder without a hover outline
+confirming what's about to be selected.
+
+**Known limitation, stated explicitly rather than silently accepted:** the picker runs
+against the Astro **dev-server** DOM (via the live preview), while the beacon matches
+the selector against the **production build's** DOM. These are not guaranteed
+identical. §4 below closes this gap with a gate check rather than leaving it as a
+runtime surprise.
+
+Draft state (variant route, goal config) is written through
+`DomainConfigStore.update(sourceDirectory:)` as `status: "draft"` as soon as the goal is
+picked — not deferred to Start — so closing and reopening the sheet mid-configure
+resumes where the owner left off.
+
+## 4. Pre-deploy gate extension
+
+`checkExperiments` (already partially built per the survey — `experiments-artifact.ts`,
+`experiments-paths.ts` exist) gains a check for `visible`-goal experiments: after
+`dist/` is built, confirm the picked selector resolves to at least one element in both
+the control and variant pages' built HTML. This closes the dev-DOM-vs-build-DOM gap
+from §3 — a selector that only matched dev-server markup (e.g. a scoped class that
+doesn't survive the production build) fails the deploy instead of shipping a goal that
+silently never fires. Consistent with the master spec §6's existing posture ("a test
+that 404s its own arm burns traffic silently... exactly the class of misconfiguration
+SRM would only catch a week later") — this is the same failure class, one gate.
+
+## 5. Start
+
+"Start" (owner-initiated, one tap) writes `status: "running"` + `startedAt` via
+`DomainConfigStore.update(sourceDirectory:)`, then calls the existing
+`DeployModel.deploy(siteID:siteDirectory:configDirectory:currentRoutes:...)` — no new
+deploy machinery. `DeployCoordinator.resolveRunningExperiments` and the D1/Worker
+provisioning gated on `hasRunningExperiment` are already wired end-to-end from slice 3.
+Copy per master spec §5: "Your test is live. Visitors will see one version or the
+other; I'll tell you when there's a clear answer."
+
+Deploy failure (blocked by the gate, network error, etc.) reverts the step to
+`.configure` with the draft intact — `status` is not written to `"running"` until
+deploy succeeds, so a failed start never leaves the config in a state claiming a test
+is live when it isn't.
+
+## 6. Running status
+
+Shows id, name, started date, and status only — sourced entirely from
+`DomainConfig.Experiments`, no D1 read. This is a deliberate, temporary gap: live
+visitor/conversion counts are slice 4's (#1516) `ExperimentEventsD1Client` responsibility, not
+this slice's. When #1516 ships, the `.running` case gains a live-count subview; this
+slice's job is only to make sure a running experiment is visible and identifiable in
+the sheet, not to duplicate #769's manual-entry counting for it.
+
+`LiveRegionAnnouncer` gains a lifecycle-transition case (e.g. `configuring → running`),
+posted from `.onChange(of: model.step)` in the sheet view, following
+`DeployDrawerView`'s existing `.onChange(of: model.phase)` pattern
+(`DeployDrawerView.swift:253-259`) gated the same way on `AppSettings.shared.announcesLiveUpdates`.
+
+## 7. Accessibility
+
+Every new interactive element (playbook row, goal-picker option, start button,
+running-status display) follows the house label/value/hint pattern
+(`SyncStatusView.swift:30-34`) and, for the goal-picker's selectable options,
+`.isSelected` via `.accessibilityAddTraits` on a button-per-row layout
+(`LicenseGateSheetView.swift:169-195`'s pattern) rather than a `Picker`/checkmark
+layout, for the same one-element-per-row screen-reader reason documented there.
+
+## 8. Testing
+
+- **Swift:** `ExperimentStatsModel` step transitions (propose → configure → starting →
+  running, and the resume-from-draft path) with a stubbed `DomainConfigStore`; the new
+  selector-builder function against representative `ElementInfo` fixtures (id present,
+  id absent/stable-class-only, id absent/nth-child-fallback, `astro-*` hash filtering);
+  `duplicatePageAsVariant`'s frontmatter injection (canonical/noindex/sitemap
+  exclusion) and deterministic-route behavior (including the collision-with-existing-
+  route case, which `pathProblem`-style validation should reject rather than silently
+  overwrite).
+- **JS (edit-overlay, vitest):** the new pick-mode message type/handler, hover-outline
+  behavior, Esc-to-cancel.
+- **Template (`npx tsx --test`):** the `checkExperiments` dist/-selector-resolution
+  check, both the matches and the no-match-fails-the-gate cases.
+- **Manual/E2E:** not required for CI per master spec §8; a live click-to-select run
+  against a real dev-server preview is worth doing once by hand before merge, since it's
+  the one path with no automated DOM to assert against.
+
+## 9. Out of scope (this slice)
+
+- Live D1 visitor/conversion counts on the running-status view — slice 4 (#1516).
+- Conclude (promote/keep/discard) — slice 6.
+- `route` goal kind's picker UI — the master spec ties it to the Cloudflare-native
+  contact form (free-services slice 2) landing first; this slice's goal picker offers
+  `pageview`/`scroll`/`visible` only. Adding `route` later is additive to the same
+  picker, not a redesign.
+- Auto-generated variant copy — explicitly out of scope for the whole feature (master
+  spec §11).


### PR DESCRIPTION
Closes #1518

## Summary

- Extends the Experiment Results sheet (#769, manual-entry only) with a full propose → configure → start → running lifecycle: pick a test idea (or your own), scaffold a variant page, choose a goal (page reached, scroll depth, or click-to-select an on-page element), start the test, and see it live — all without leaving the app.
- The "visible" goal kind gets a click-to-select flow in the live preview (new `GoalSelectorBuilder` + `GoalElementPickController` + JS pick mode, mirroring the existing Effects Gallery's click-to-place pattern), and a new pre-deploy gate check confirms the picked selector actually resolves in the *built* HTML, not just the dev preview.
- The pre-existing #769 manual-entry form is preserved byte-for-byte as the `.manual` fallback — sites with no declared experiment behave exactly as before.
- A 15-task implementation plan executed via subagent-driven development, each task independently reviewed (several with fix rounds), followed by a whole-branch review that caught two Critical cross-task integration bugs (an experiment-route trailing-slash mismatch that would have blocked *every* future deploy of a site with a draft experiment, and a wrong `DeployModel.deploy` call that would have corrupted worker/route state) — both fixed and independently re-verified, along with five Important gaps and one follow-up data-loss bug found during re-review.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

No MCP message schema changes — this is app + template only.

## Test plan

- [x] `swift test --package-path .` — full suite passes (4090+ tests across all targets, 0 failures)
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- [ ] Manual smoke (UI-touching): **partially done, flagged for reviewer attention.** The app was built, launched, and confirmed to stay alive with no crash after provisioning this worktree's container boot artifacts. The live click-to-select-in-preview flow and a real deploy start/success/failure walkthrough were **not** completed — this session's terminal lacks the Screen Recording permission needed to see the app (`screencapture` returns a black frame, the documented signature of that missing grant), and the click-to-select interaction has no accessibility-identifier surface to drive blindly without visual feedback. Recommend a human — or an agent session with Screen Recording granted — walk through propose → configure → pick a "visible" goal by clicking an element in the preview → start, before merging.

## Design & implementation records

- Design: `docs/superpowers/specs/2026-08-18-ab-slice5-configure-start-ui-design.md`
- Plan: `docs/superpowers/plans/2026-08-18-ab-slice5-configure-start-ui.md`
- Full execution ledger (every task, review, fix round, and adjudication): `.superpowers/sdd/2026-08-18-ab-slice5-configure-start-ui/progress.md`