### PR TITLE
Push contacts allowlist to Worker SOCIAL_KV (#1567)

### DIFF
--- a/Sources/AnglesiteApp/ContactsModel.swift
+++ b/Sources/AnglesiteApp/ContactsModel.swift
@@ -43,6 +43,9 @@ final class ContactsModel {
     /// is the real Cloudflare push.
     private let pushAllowlist: @Sendable (URL) async -> Void
     private var configDirectory: URL?
+    /// Chains each fired push behind the previous one so pushes execute in the order they were
+    /// fired (FIFO) even though each does a real network round trip — see `firePushAllowlist()`.
+    private var pushTask: Task<Void, Never>?
 
     init(
         contactsProvider: ContactsProviding = SystemContactsProvider(),
@@ -175,13 +178,23 @@ final class ContactsModel {
         "\(suggestion.candidateURL.absoluteString)|\(suggestion.systemContactName)"
     }
 
-    /// Fires the allowlist push as a detached `Task` so `add`/`update`/`remove` return as soon as
-    /// the local write (and reload) finish — the push is best-effort and must never block a UI
-    /// action on a network round trip (#1567 design §3/§4). A failed local write still fires this:
-    /// `knownMeURLs()` is re-read fresh inside the push, so it always reflects whatever's actually
-    /// on disk regardless of whether this particular call succeeded.
+    /// Fires the allowlist push as an unstructured `Task` so `add`/`update`/`remove` return as
+    /// soon as the local write (and reload) finish — the push is best-effort and must never block
+    /// a UI action on a network round trip (#1567 design §3/§4). A failed local write still fires
+    /// this: `knownMeURLs()` is re-read fresh inside the push, so it always reflects whatever's
+    /// actually on disk regardless of whether this particular call succeeded.
+    ///
+    /// Chained behind any push already in flight so pushes execute in the order they were fired
+    /// (FIFO): each push is a real network round trip, so two pushes fired close together (e.g.
+    /// add a contact then immediately delete it) could otherwise complete out of order and leave
+    /// the wrong final state in KV until the next mutation or deploy. The chain is never awaited
+    /// by the caller — only by the next fired push.
     private func firePushAllowlist() {
         guard let configDirectory else { return }
-        Task { await pushAllowlist(configDirectory) }
+        let previous = pushTask
+        pushTask = Task { [pushAllowlist] in
+            await previous?.value
+            await pushAllowlist(configDirectory)
+        }
     }
 }

--- a/Sources/AnglesiteApp/ContactsModel.swift
+++ b/Sources/AnglesiteApp/ContactsModel.swift
@@ -36,9 +36,22 @@ final class ContactsModel {
     /// resurface on a later scan, which is fine since scans are always owner-initiated.
     private var dismissedSuggestionKeys: Set<String> = []
     private let contactsProvider: ContactsProviding
+    /// Contacts allowlist push (#1567): fire-and-forget after each successful mutation, never
+    /// awaited inline — `add`/`update`/`remove` must return as soon as the local `ContactStore`
+    /// write completes, not wait on a network round trip. Injectable so tests can observe calls
+    /// without touching the network (mirrors `contactsProvider`'s DI seam); production default
+    /// is the real Cloudflare push.
+    private let pushAllowlist: @Sendable (URL) async -> Void
+    private var configDirectory: URL?
 
-    init(contactsProvider: ContactsProviding = SystemContactsProvider()) {
+    init(
+        contactsProvider: ContactsProviding = SystemContactsProvider(),
+        pushAllowlist: @escaping @Sendable (URL) async -> Void = { dir in
+            await ContactsAllowlistSync.pushIfConfigured(configDirectory: dir)
+        }
+    ) {
         self.contactsProvider = contactsProvider
+        self.pushAllowlist = pushAllowlist
     }
 
     /// Records which site this pane reads. Called once per site open, like
@@ -53,6 +66,7 @@ final class ContactsModel {
     /// trigger a fresh load: `ContactsView`'s `.task` only calls `reload()` when idle.
     func configure(site: CurrentSite) {
         store = ContactStore(configDirectory: site.configDirectory)
+        configDirectory = site.configDirectory
         contacts = []
         loadState = .idle
         suggestions = []
@@ -85,6 +99,7 @@ final class ContactsModel {
             writeFailure = "\(error)"
         }
         await reload()
+        firePushAllowlist()
     }
 
     func update(_ contact: Contact) async {
@@ -96,6 +111,7 @@ final class ContactsModel {
             writeFailure = "\(error)"
         }
         await reload()
+        firePushAllowlist()
     }
 
     func remove(_ contact: Contact) async {
@@ -107,6 +123,7 @@ final class ContactsModel {
             writeFailure = "\(error)"
         }
         await reload()
+        firePushAllowlist()
     }
 
     /// Runs one on-demand Contacts.framework scan (Website ▸ Contacts… ▸ "Find in Contacts…").
@@ -156,5 +173,15 @@ final class ContactsModel {
 
     private func suggestionKey(_ suggestion: MatchSuggestion) -> String {
         "\(suggestion.candidateURL.absoluteString)|\(suggestion.systemContactName)"
+    }
+
+    /// Fires the allowlist push as a detached `Task` so `add`/`update`/`remove` return as soon as
+    /// the local write (and reload) finish — the push is best-effort and must never block a UI
+    /// action on a network round trip (#1567 design §3/§4). A failed local write still fires this:
+    /// `knownMeURLs()` is re-read fresh inside the push, so it always reflects whatever's actually
+    /// on disk regardless of whether this particular call succeeded.
+    private func firePushAllowlist() {
+        guard let configDirectory else { return }
+        Task { await pushAllowlist(configDirectory) }
     }
 }

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -1076,6 +1076,12 @@ final class DeployModel {
                         siteBase: url,
                         secretStore: self.keychain
                     )
+                },
+                pushContactsAllowlist: { [weak self] in
+                    guard let self else { return }
+                    await ContactsAllowlistSync.pushIfConfigured(
+                        configDirectory: configDirectory, secretStore: self.keychain
+                    )
                 }
             )
             currentMilestone = nil

--- a/Sources/AnglesiteCore/CloudflareAccountLookup.swift
+++ b/Sources/AnglesiteCore/CloudflareAccountLookup.swift
@@ -1,0 +1,28 @@
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Shared "resolve the token's first visible Cloudflare account id" lookup (#1567 review) — used
+/// by every `*Sync`/`*IfConfigured` orchestrator that needs an account id but has no
+/// separately-stored one to key off (unlike #587's `ProvisionedResources.inboxAccountID`). A
+/// personal Anglesite deployment has exactly one Cloudflare account per token, so "just take the
+/// first account" is always correct. Previously duplicated privately, byte-for-byte, in both
+/// `MicropubContentSync` and `ReceivedInteractionSync` — consolidated here so `ContactsAllowlistSync`
+/// doesn't add a third copy.
+enum CloudflareAccountLookup {
+    private struct CFAccount: Decodable, Sendable { let id: String }
+    private struct CFEnvelope: Decodable, Sendable { let success: Bool; let result: [CFAccount]? }
+
+    static func resolveAccountID(apiToken: String, baseURL: String, transport: CloudflareTransport) async -> String? {
+        guard let url = URL(string: "\(baseURL)/accounts?per_page=1") else { return nil }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        guard let (data, http) = try? await transport(request), (200..<300).contains(http.statusCode),
+              let envelope = try? JSONDecoder().decode(CFEnvelope.self, from: data), envelope.success
+        else { return nil }
+        return envelope.result?.first?.id
+    }
+}

--- a/Sources/AnglesiteCore/ContactsAllowlistKVClient.swift
+++ b/Sources/AnglesiteCore/ContactsAllowlistKVClient.swift
@@ -1,0 +1,54 @@
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Cloudflare Workers KV client for the #1567 contacts allowlist push. Writes the site's
+/// normalized me-URL set (`ContactStore.knownMeURLs()`) as a single JSON array under
+/// `contacts:allowlist` in the already-provisioned `SOCIAL_KV` namespace — the future
+/// authenticated-read gate (epic #963 slice 4) reads this key from the Worker side. Follows the
+/// same injectable-transport DI pattern as `InboxKVClient`/`HTTPCloudflareClient` — no Keychain
+/// coupling, token passed in at init.
+public struct ContactsAllowlistKVClient: Sendable {
+    private static let key = "contacts:allowlist"
+
+    private let baseURL: String
+    private let accountID: String
+    private let namespaceID: String
+    private let apiToken: String
+    private let transport: CloudflareTransport
+
+    public init(
+        accountID: String,
+        namespaceID: String,
+        apiToken: String,
+        baseURL: String = "https://api.cloudflare.com/client/v4",
+        transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
+    ) {
+        self.accountID = accountID
+        self.namespaceID = namespaceID
+        self.apiToken = apiToken
+        self.baseURL = baseURL
+        self.transport = transport
+    }
+
+    /// Replaces the whole `contacts:allowlist` value with `meURLs`, sorted for a deterministic
+    /// request body. Whole-set replace, not an incremental add/remove — the caller
+    /// (`ContactsAllowlistSync`) always supplies the complete current set, so this single call
+    /// doubles as both "push on change" and "reconcile."
+    public func putAllowlist(_ meURLs: Set<String>) async throws {
+        let body = try JSONEncoder().encode(meURLs.sorted())
+        let valueURLString = "\(baseURL)/accounts/\(accountID)/storage/kv/namespaces/\(namespaceID)/values/\(Self.key)"
+        guard let url = URL(string: valueURLString) else { throw CloudflareError.malformedResponse }
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+        let (_, http) = try await transport(request)
+        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
+        guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
+    }
+}

--- a/Sources/AnglesiteCore/ContactsAllowlistSync.swift
+++ b/Sources/AnglesiteCore/ContactsAllowlistSync.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Pushes the site's contact allowlist (`ContactStore.knownMeURLs()`) to the Worker's
+/// `SOCIAL_KV` store (#1567) — both on a contact add/remove and, as the consistency backstop, on
+/// every deploy. Both triggers call the same whole-set-replace `push`, so `Config/contacts.json`
+/// is always the authoritative source: there's no diffing, only an unconditional overwrite.
+public enum ContactsAllowlistSync {
+    /// Reads `store`'s current me-URL set and replaces `client`'s `contacts:allowlist` value with
+    /// it. Never throws — a failure (network, auth, provisioning) is logged and otherwise
+    /// invisible; the next successful call (the next contact change, or the next deploy) retries
+    /// with the current state, so a missed push self-heals rather than needing a retry queue.
+    public static func push(store: ContactStore, client: ContactsAllowlistKVClient) async {
+        do {
+            let meURLs = try await store.knownMeURLs()
+            try await client.putAllowlist(meURLs)
+        } catch {
+            await LogCenter.shared.append(
+                source: "ContactsAllowlistSync", stream: .stderr,
+                text: "Failed to push contacts allowlist to SOCIAL_KV: \(error). Will retry on the "
+                    + "next contact change or deploy.")
+        }
+    }
+
+    /// Reads the site's `SiteSettings` and Cloudflare API token from `secretStore`; no-ops (no
+    /// network call) unless `SOCIAL_KV` has been provisioned
+    /// (`provisionedWorkerResources.kvNamespaceID`) and a token is available — i.e. the site has
+    /// never been deployed yet. `configDirectory` is the package's `Config/` directory
+    /// (`AnglesitePackage.configURL`).
+    public static func pushIfConfigured(
+        configDirectory: URL,
+        secretStore: any SecretStore = PlatformSecretStore.make(),
+        baseURL: String = "https://api.cloudflare.com/client/v4",
+        transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
+    ) async {
+        guard let settings = try? SiteConfigStore.read(from: configDirectory),
+              let namespaceID = settings.provisionedWorkerResources?.kvNamespaceID, !namespaceID.isEmpty
+        else { return }
+        guard let token = try? await CloudflareAPICredentials.resolve(secretStore: secretStore), !token.isEmpty
+        else { return }
+        guard let accountID = await CloudflareAccountLookup.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
+        else { return }
+
+        let store = ContactStore(configDirectory: configDirectory)
+        let client = ContactsAllowlistKVClient(
+            accountID: accountID, namespaceID: namespaceID, apiToken: token, baseURL: baseURL, transport: transport)
+        await push(store: store, client: client)
+    }
+}

--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -467,11 +467,11 @@ public enum DeployCoordinator {
         /// frontmatter a backfill pass might otherwise read stale. Best-effort and never throws,
         /// like every other step here. Callers without ActivityPub provisioned pass a no-op.
         backfillActivityPubOutbox: () async -> Void = {},
-        /// Contacts allowlist push (#1567): overwrites the Worker's `SOCIAL_KV` `contacts:allowlist`
-        /// key with the site's current known me-URLs. Ordered last — unrelated to every other
-        /// pass here, and (unlike the others) it's a reconcile that only needs to run once per
-        /// deploy, not depend on anything the earlier passes produced. Best-effort and never
-        /// throws, like every other step here. Callers without contacts configured pass a no-op.
+        /// Contacts allowlist push (#1567): pushes the site's current known me-URLs to their
+        /// remote store. Ordered last — unrelated to every other pass here, and (unlike the
+        /// others) it's a reconcile that only needs to run once per deploy, not depend on
+        /// anything the earlier passes produced. Best-effort and never throws, like every other
+        /// step here. Callers without contacts configured pass a no-op.
         pushContactsAllowlist: () async -> Void = {}
     ) async {
         onMilestone(.deployWebmentions)

--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -466,7 +466,13 @@ public enum DeployCoordinator {
         /// outbox. Ordered last — after `syndicate()`, since POSSE write-back can change post
         /// frontmatter a backfill pass might otherwise read stale. Best-effort and never throws,
         /// like every other step here. Callers without ActivityPub provisioned pass a no-op.
-        backfillActivityPubOutbox: () async -> Void = {}
+        backfillActivityPubOutbox: () async -> Void = {},
+        /// Contacts allowlist push (#1567): overwrites the Worker's `SOCIAL_KV` `contacts:allowlist`
+        /// key with the site's current known me-URLs. Ordered last — unrelated to every other
+        /// pass here, and (unlike the others) it's a reconcile that only needs to run once per
+        /// deploy, not depend on anything the earlier passes produced. Best-effort and never
+        /// throws, like every other step here. Callers without contacts configured pass a no-op.
+        pushContactsAllowlist: () async -> Void = {}
     ) async {
         onMilestone(.deployWebmentions)
         await sendWebmentions()
@@ -480,5 +486,7 @@ public enum DeployCoordinator {
         await notifySubscribers()
         onMilestone(.deployBackfillingActivityPub)
         await backfillActivityPubOutbox()
+        onMilestone(.deployPushingContactsAllowlist)
+        await pushContactsAllowlist()
     }
 }

--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -426,18 +426,19 @@ public enum DeployCoordinator {
         try? await configStore.save(updated)
     }
 
-    /// Runs the five post-deploy passes — webmention-send, Standard.site record publish,
-    /// POSSE-syndication, WebSub publish-ping, and ActivityPub outbox backfill (`sendWebmentions`,
-    /// `publishStandardSite`, `syndicate`, `notifySubscribers`, and `backfillActivityPubOutbox`
-    /// below) — in the fixed order the deploy pipeline has always used: Astro's build (already
-    /// complete by the time this runs) regenerates the site's RSS/Atom/JSON feeds, so webmention
-    /// discovery is ordered after the deployed canonical pages exist, and each subsequent pass is
-    /// ordered after the ones before it (see each parameter's own doc comment for why).
-    /// `onMilestone` fires immediately before each pass so a UI caller can surface progress
+    /// Runs the seven post-deploy passes — webmention-send, Standard.site record publish,
+    /// blogroll graph-record publish, POSSE-syndication, WebSub publish-ping, ActivityPub outbox
+    /// backfill, and contacts-allowlist push (`sendWebmentions`, `publishStandardSite`,
+    /// `publishStandardSiteGraph`, `syndicate`, `notifySubscribers`, `backfillActivityPubOutbox`,
+    /// and `pushContactsAllowlist` below) — in the fixed order the deploy pipeline has always used:
+    /// Astro's build (already complete by the time this runs) regenerates the site's RSS/Atom/JSON
+    /// feeds, so webmention discovery is ordered after the deployed canonical pages exist, and each
+    /// subsequent pass is ordered after the ones before it (see each parameter's own doc comment for
+    /// why). `onMilestone` fires immediately before each pass so a UI caller can surface progress
     /// (`DeployModel` wires it to the Dock-tile progress bar, #526) — the milestone always fires even
     /// if the caller-supplied closure for that pass turns out to be a no-op (e.g. no pending
-    /// webmention targets). All five passes are awaited sequentially, never concurrently, matching
-    /// the historical behavior; none of the five closures is expected to throw (the real commands
+    /// webmention targets). All seven passes are awaited sequentially, never concurrently, matching
+    /// the historical behavior; none of the seven closures is expected to throw (the real commands
     /// they wrap are documented best-effort and never throw).
     public static func runPostDeploySequencing(
         onMilestone: (OperationProgress) -> Void,
@@ -463,11 +464,12 @@ public enum DeployCoordinator {
         /// it's best-effort and never throws. Callers without the hub provisioned pass a no-op.
         notifySubscribers: () async -> Void = {},
         /// ActivityPub outbox backfill (#926): syncs existing content into the site's actor's
-        /// outbox. Ordered last — after `syndicate()`, since POSSE write-back can change post
-        /// frontmatter a backfill pass might otherwise read stale. Best-effort and never throws,
-        /// like every other step here. Callers without ActivityPub provisioned pass a no-op.
+        /// outbox. Ordered after `syndicate()`, before the final contacts-allowlist push — since
+        /// POSSE write-back can change post frontmatter a backfill pass might otherwise read
+        /// stale. Best-effort and never throws, like every other step here. Callers without
+        /// ActivityPub provisioned pass a no-op.
         backfillActivityPubOutbox: () async -> Void = {},
-        /// Contacts allowlist push (#1567): pushes the site's current known me-URLs to their
+        /// Contacts allowlist push (#1567): pushes the site's current known me-URLs to the site's
         /// remote store. Ordered last — unrelated to every other pass here, and (unlike the
         /// others) it's a reconcile that only needs to run once per deploy, not depend on
         /// anything the earlier passes produced. Best-effort and never throws, like every other

--- a/Sources/AnglesiteCore/MicropubContentSync.swift
+++ b/Sources/AnglesiteCore/MicropubContentSync.swift
@@ -1,10 +1,5 @@
 // Sources/AnglesiteCore/MicropubContentSync.swift
 import Foundation
-// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
-// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
-#if canImport(FoundationNetworking)
-import FoundationNetworking
-#endif
 
 /// Orchestrates #912's "pull Micropub-created posts from D1 and turn each into a typed content
 /// file" step. This file holds the pure URL-parsing and mf2-to-field mapping logic; `pullAndCommit`

--- a/Sources/AnglesiteCore/MicropubContentSync.swift
+++ b/Sources/AnglesiteCore/MicropubContentSync.swift
@@ -285,27 +285,11 @@ public enum MicropubContentSync {
         else { return 0 }
         guard let token = try? await CloudflareAPICredentials.resolve(secretStore: secretStore), !token.isEmpty
         else { return 0 }
-        guard let accountID = await Self.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
+        guard let accountID = await CloudflareAccountLookup.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
         else { return 0 }
 
         let client = MicropubPostD1Client(
             accountID: accountID, databaseID: databaseID, apiToken: token, baseURL: baseURL, transport: transport)
         return await pullAndCommit(client: client, siteDirectory: siteDirectory, configDirectory: configDirectory)
-    }
-
-    private struct CFAccount: Decodable, Sendable { let id: String }
-    private struct CFEnvelope: Decodable, Sendable { let success: Bool; let result: [CFAccount]? }
-
-    /// Resolves the token's first visible Cloudflare account id — same resolution
-    /// `ReceivedInteractionSync` uses, since a personal Anglesite deployment has exactly one
-    /// Cloudflare account per token.
-    private static func resolveAccountID(apiToken: String, baseURL: String, transport: CloudflareTransport) async -> String? {
-        guard let url = URL(string: "\(baseURL)/accounts?per_page=1") else { return nil }
-        var request = URLRequest(url: url)
-        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
-        guard let (data, http) = try? await transport(request), (200..<300).contains(http.statusCode),
-              let envelope = try? JSONDecoder().decode(CFEnvelope.self, from: data), envelope.success
-        else { return nil }
-        return envelope.result?.first?.id
     }
 }

--- a/Sources/AnglesiteCore/OperationProgress.swift
+++ b/Sources/AnglesiteCore/OperationProgress.swift
@@ -78,8 +78,8 @@ public extension OperationProgress {
     static let deployBackfillingActivityPub = OperationProgress(
         kind: .deploy, phase: "activityPubBackfill", label: "Backfilling ActivityPub outbox…"
     )
-    /// Post-deploy: pushing the contact allowlist (me-URLs) to the Worker's `SOCIAL_KV` store
-    /// (#1567) — the future authenticated-read gate's data source.
+    /// Post-deploy: pushing the contact allowlist (me-URLs) to the future authenticated-read
+    /// gate's backing store (#1567).
     static let deployPushingContactsAllowlist = OperationProgress(
         kind: .deploy, phase: "contactsAllowlistPush", label: "Syncing contacts allowlist…"
     )

--- a/Sources/AnglesiteCore/OperationProgress.swift
+++ b/Sources/AnglesiteCore/OperationProgress.swift
@@ -78,6 +78,11 @@ public extension OperationProgress {
     static let deployBackfillingActivityPub = OperationProgress(
         kind: .deploy, phase: "activityPubBackfill", label: "Backfilling ActivityPub outbox…"
     )
+    /// Post-deploy: pushing the contact allowlist (me-URLs) to the Worker's `SOCIAL_KV` store
+    /// (#1567) — the future authenticated-read gate's data source.
+    static let deployPushingContactsAllowlist = OperationProgress(
+        kind: .deploy, phase: "contactsAllowlistPush", label: "Syncing contacts allowlist…"
+    )
 
     /// Backup: staging working-tree changes.
     static let backupStaging = OperationProgress(kind: .backup, phase: "staging", label: "Staging changes…")

--- a/Sources/AnglesiteCore/ReceivedInteractionSync.swift
+++ b/Sources/AnglesiteCore/ReceivedInteractionSync.swift
@@ -1,9 +1,4 @@
 import Foundation
-// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
-// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
-#if canImport(FoundationNetworking)
-import FoundationNetworking
-#endif
 
 /// Orchestrates #362's "pull the Worker's verified webmention inbox and snapshot it into the
 /// site's git working copy" step: query D1 (`WebmentionInboxD1Client`), reconcile + commit

--- a/Sources/AnglesiteCore/ReceivedInteractionSync.swift
+++ b/Sources/AnglesiteCore/ReceivedInteractionSync.swift
@@ -51,25 +51,6 @@ public enum ReceivedInteractionSync {
         return committedIDs.count
     }
 
-    private struct CFAccount: Decodable, Sendable { let id: String }
-    private struct CFEnvelope: Decodable, Sendable { let success: Bool; let result: [CFAccount]? }
-
-    /// Resolves the token's first visible Cloudflare account id — same "just take the first
-    /// account" resolution `HTTPCloudflareClient.workerScriptNames`/`CloudflareCapabilityProber`
-    /// use, since a personal Anglesite deployment has exactly one Cloudflare account per token, and
-    /// there is no separate stored account id for webmention/D1 to key off (unlike #587's
-    /// `ProvisionedResources.inboxAccountID`, since the D1 database itself is already identified
-    /// by `SiteSettings.provisionedWorkerResources.d1DatabaseID`).
-    private static func resolveAccountID(apiToken: String, baseURL: String, transport: CloudflareTransport) async -> String? {
-        guard let url = URL(string: "\(baseURL)/accounts?per_page=1") else { return nil }
-        var request = URLRequest(url: url)
-        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
-        guard let (data, http) = try? await transport(request), (200..<300).contains(http.statusCode),
-              let envelope = try? JSONDecoder().decode(CFEnvelope.self, from: data), envelope.success
-        else { return nil }
-        return envelope.result?.first?.id
-    }
-
     /// Reads the site's `SiteSettings` and the Cloudflare API token from `secretStore`; no-ops
     /// (returns 0, no network call) unless a D1 database has been provisioned
     /// (`provisionedWorkerResources.d1DatabaseID`, set once the webmention receive Worker has been
@@ -88,7 +69,7 @@ public enum ReceivedInteractionSync {
         else { return 0 }
         guard let token = try? await CloudflareAPICredentials.resolve(secretStore: secretStore), !token.isEmpty
         else { return 0 }
-        guard let accountID = await Self.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
+        guard let accountID = await CloudflareAccountLookup.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
         else { return 0 }
 
         let client = WebmentionInboxD1Client(

--- a/Tests/AnglesiteAppTests/ContactsModelTests.swift
+++ b/Tests/AnglesiteAppTests/ContactsModelTests.swift
@@ -143,6 +143,59 @@ struct ContactsModelTests {
         #expect(added.linkedActor == nil)
     }
 
+    @Test("add fires a fire-and-forget allowlist push without blocking or throwing")
+    func addTriggersAllowlistPush() async throws {
+        let recorder = PushRecorder()
+        let model = ContactsModel(
+            contactsProvider: FakeContactsProvider(result: .success([])),
+            pushAllowlist: { url in await recorder.record(url) })
+        let site = try Self.makeSite()
+        model.configure(site: site)
+        await model.reload()
+
+        await model.add(me: URL(string: "https://alice.example")!, displayName: "Alice")
+        await recorder.waitForCall()
+
+        #expect(await recorder.calls == [site.configDirectory])
+    }
+
+    @Test("update fires a fire-and-forget allowlist push")
+    func updateTriggersAllowlistPush() async throws {
+        let recorder = PushRecorder()
+        let model = ContactsModel(
+            contactsProvider: FakeContactsProvider(result: .success([])),
+            pushAllowlist: { url in await recorder.record(url) })
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+        await model.add(me: URL(string: "https://alice.example")!, displayName: "Alice")
+        await recorder.waitForCall()
+        var added = try #require(model.contacts.first)
+        added.displayName = "Alice Renamed"
+
+        await model.update(added)
+        await recorder.waitForCall(count: 2)
+
+        #expect(await recorder.calls.count == 2)
+    }
+
+    @Test("remove fires a fire-and-forget allowlist push")
+    func removeTriggersAllowlistPush() async throws {
+        let recorder = PushRecorder()
+        let model = ContactsModel(
+            contactsProvider: FakeContactsProvider(result: .success([])),
+            pushAllowlist: { url in await recorder.record(url) })
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+        await model.add(me: URL(string: "https://alice.example")!, displayName: "Alice")
+        await recorder.waitForCall()
+        let added = try #require(model.contacts.first)
+
+        await model.remove(added)
+        await recorder.waitForCall(count: 2)
+
+        #expect(await recorder.calls.count == 2)
+    }
+
     @Test("configure(site:) resets per-site state so a window replay never leaks another site's contacts (#966 review)")
     func configureResetsStateAcrossSites() async throws {
         let model = ContactsModel(contactsProvider: FakeContactsProvider(result: .success([])))
@@ -207,5 +260,28 @@ struct ContactsModelTests {
 
         await model.scanForMatches(candidateFollowerURLs: [bob])
         #expect(model.suggestions.isEmpty)
+    }
+}
+
+/// Records `pushAllowlist` invocations from a detached `Task`, and lets a test await the Nth
+/// call deterministically instead of racing an unstructured Task with a sleep.
+private actor PushRecorder {
+    private(set) var calls: [URL] = []
+    private var continuations: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    func record(_ url: URL) {
+        calls.append(url)
+        continuations.removeAll { count, continuation in
+            guard calls.count >= count else { return false }
+            continuation.resume()
+            return true
+        }
+    }
+
+    func waitForCall(count: Int = 1) async {
+        if calls.count >= count { return }
+        await withCheckedContinuation { continuation in
+            continuations.append((count, continuation))
+        }
     }
 }

--- a/Tests/AnglesiteAppTests/ContactsModelTests.swift
+++ b/Tests/AnglesiteAppTests/ContactsModelTests.swift
@@ -196,6 +196,30 @@ struct ContactsModelTests {
         #expect(await recorder.calls.count == 2)
     }
 
+    @Test("rapid pushes execute in FIFO order, not completion order (#1567 review)")
+    func pushesExecuteInFIFOOrder() async throws {
+        // The first push is deliberately slower than the second so that, absent chaining, the
+        // second (fast) push would start and finish before the first (slow) one completes —
+        // exactly the out-of-order-completion bug this test guards against.
+        let recorder = OrderedPushRecorder(delays: [.milliseconds(100), .zero])
+        let model = ContactsModel(
+            contactsProvider: FakeContactsProvider(result: .success([])),
+            pushAllowlist: { url in await recorder.push(url) })
+        let site = try Self.makeSite()
+        model.configure(site: site)
+        await model.reload()
+
+        // add() fires the first (slow) push; remove() fires the second (fast) push immediately
+        // after, before the first has had a chance to complete.
+        await model.add(me: URL(string: "https://alice.example")!, displayName: "Alice")
+        let added = try #require(model.contacts.first)
+        await model.remove(added)
+
+        await recorder.waitForEvents(count: 4)
+
+        #expect(await recorder.events == ["start-1", "end-1", "start-2", "end-2"])
+    }
+
     @Test("configure(site:) resets per-site state so a window replay never leaks another site's contacts (#966 review)")
     func configureResetsStateAcrossSites() async throws {
         let model = ContactsModel(contactsProvider: FakeContactsProvider(result: .success([])))
@@ -280,6 +304,51 @@ private actor PushRecorder {
 
     func waitForCall(count: Int = 1) async {
         if calls.count >= count { return }
+        await withCheckedContinuation { continuation in
+            continuations.append((count, continuation))
+        }
+    }
+}
+
+/// Records `pushAllowlist` invocations as `"start-N"`/`"end-N"` markers, where `N` is the order
+/// calls arrived in (not the order they finish) — lets a test prove pushes are chained FIFO
+/// rather than racing. Each call's simulated work duration is drawn from `delays` by arrival
+/// order, so an earlier call can be made deliberately slower than a later one: under FIFO
+/// chaining the events still come out strictly `start-1, end-1, start-2, end-2, ...` even though
+/// call 2 finishes its own work faster, because call 2 doesn't start until call 1's `Task`
+/// completes.
+private actor OrderedPushRecorder {
+    private(set) var events: [String] = []
+    private let delays: [Duration]
+    private var arrivalCount = 0
+    private var continuations: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    init(delays: [Duration]) {
+        self.delays = delays
+    }
+
+    func push(_ url: URL) async {
+        arrivalCount += 1
+        let index = arrivalCount
+        record("start-\(index)")
+        let delay = index - 1 < delays.count ? delays[index - 1] : .zero
+        if delay > .zero {
+            try? await Task.sleep(for: delay)
+        }
+        record("end-\(index)")
+    }
+
+    private func record(_ event: String) {
+        events.append(event)
+        continuations.removeAll { count, continuation in
+            guard events.count >= count else { return false }
+            continuation.resume()
+            return true
+        }
+    }
+
+    func waitForEvents(count: Int) async {
+        if events.count >= count { return }
         await withCheckedContinuation { continuation in
             continuations.append((count, continuation))
         }

--- a/Tests/AnglesiteCoreTests/CloudflareAccountLookupTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareAccountLookupTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct CloudflareAccountLookupTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://api.cloudflare.com/")!, statusCode: status,
+                         httpVersion: nil, headerFields: nil)!
+    }
+
+    @Test("resolves the first account id from a successful envelope")
+    func resolvesFirstAccountID() async {
+        let body = Data("""
+        {"success": true, "result": [{"id": "acct1"}, {"id": "acct2"}]}
+        """.utf8)
+        let accountID = await CloudflareAccountLookup.resolveAccountID(
+            apiToken: "token", baseURL: "https://api.cloudflare.com/client/v4",
+            transport: { _ in (body, Self.response(200)) })
+        #expect(accountID == "acct1")
+    }
+
+    @Test("returns nil on a non-2xx response")
+    func returnsNilOnHTTPError() async {
+        let accountID = await CloudflareAccountLookup.resolveAccountID(
+            apiToken: "token", baseURL: "https://api.cloudflare.com/client/v4",
+            transport: { _ in (Data(), Self.response(403)) })
+        #expect(accountID == nil)
+    }
+
+    @Test("returns nil when the envelope reports success: false")
+    func returnsNilOnUnsuccessfulEnvelope() async {
+        let body = Data("""
+        {"success": false, "result": null}
+        """.utf8)
+        let accountID = await CloudflareAccountLookup.resolveAccountID(
+            apiToken: "token", baseURL: "https://api.cloudflare.com/client/v4",
+            transport: { _ in (body, Self.response(200)) })
+        #expect(accountID == nil)
+    }
+
+    @Test("returns nil when the result list is empty")
+    func returnsNilOnEmptyResult() async {
+        let body = Data("""
+        {"success": true, "result": []}
+        """.utf8)
+        let accountID = await CloudflareAccountLookup.resolveAccountID(
+            apiToken: "token", baseURL: "https://api.cloudflare.com/client/v4",
+            transport: { _ in (body, Self.response(200)) })
+        #expect(accountID == nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/ContactsAllowlistKVClientTests.swift
+++ b/Tests/AnglesiteCoreTests/ContactsAllowlistKVClientTests.swift
@@ -1,0 +1,76 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct ContactsAllowlistKVClientTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://api.cloudflare.com/")!, statusCode: status,
+                         httpVersion: nil, headerFields: nil)!
+    }
+
+    @Test("putAllowlist PUTs a sorted JSON array to the contacts:allowlist key")
+    func putsSortedArray() async throws {
+        let captured = CapturedRequest()
+        let client = ContactsAllowlistKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { request in
+                await captured.set(request)
+                return (Data(), Self.response(200))
+            })
+
+        try await client.putAllowlist(["bob.example", "alice.example"])
+
+        let request = await captured.value
+        #expect(request?.httpMethod == "PUT")
+        #expect(request?.url?.path.hasSuffix("/values/contacts:allowlist") == true)
+        #expect(request?.value(forHTTPHeaderField: "Authorization") == "Bearer token")
+        let body = try #require(await captured.body)
+        let decoded = try JSONDecoder().decode([String].self, from: body)
+        #expect(decoded == ["alice.example", "bob.example"])
+    }
+
+    @Test("putAllowlist succeeds with an empty set (last contact removed)")
+    func putsEmptySet() async throws {
+        let captured = CapturedRequest()
+        let client = ContactsAllowlistKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { request in
+                await captured.set(request)
+                return (Data(), Self.response(200))
+            })
+
+        try await client.putAllowlist([])
+
+        let body = try #require(await captured.body)
+        let decoded = try JSONDecoder().decode([String].self, from: body)
+        #expect(decoded.isEmpty)
+    }
+
+    @Test("throws unauthorized on a 401/403 response")
+    func throwsUnauthorized() async {
+        let client = ContactsAllowlistKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "bad",
+            transport: { _ in (Data(), Self.response(403)) })
+        await #expect(throws: CloudflareError.unauthorized) {
+            try await client.putAllowlist(["alice.example"])
+        }
+    }
+
+    @Test("throws http(status:) on any other non-2xx response")
+    func throwsHTTPError() async {
+        let client = ContactsAllowlistKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { _ in (Data(), Self.response(500)) })
+        await #expect(throws: CloudflareError.http(status: 500)) {
+            try await client.putAllowlist(["alice.example"])
+        }
+    }
+}
+
+/// Actor wrapper so the `@Sendable` transport closure can hand a captured `URLRequest`/body back
+/// to the test body without a data race. Mirrors `InboxKVClientTests.CapturedRequest`.
+private actor CapturedRequest {
+    private(set) var value: URLRequest?
+    var body: Data? { value?.httpBody }
+    func set(_ request: URLRequest) { value = request }
+}

--- a/Tests/AnglesiteCoreTests/ContactsAllowlistSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/ContactsAllowlistSyncTests.swift
@@ -1,0 +1,143 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct ContactsAllowlistSyncTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://api.cloudflare.com/")!, statusCode: status,
+                         httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func makeConfigDir() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("contacts-allowlist-sync-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    @Test("push reads the store's known me-URLs and forwards them to the client")
+    func pushForwardsKnownMeURLs() async throws {
+        let configDir = Self.makeConfigDir()
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        let store = ContactStore(configDirectory: configDir)
+        try await store.add(Contact(me: URL(string: "https://alice.example")!, displayName: "Alice"))
+
+        let captured = CapturedURLs()
+        let client = ContactsAllowlistKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { request in
+                if let body = request.httpBody, let urls = try? JSONDecoder().decode([String].self, from: body) {
+                    await captured.set(urls)
+                }
+                return (Data(), Self.response(200))
+            })
+
+        await ContactsAllowlistSync.push(store: store, client: client)
+
+        #expect(await captured.value == ["alice.example"])
+    }
+
+    @Test("push logs and does not throw when the client fails")
+    func pushSwallowsClientFailure() async throws {
+        let configDir = Self.makeConfigDir()
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        let store = ContactStore(configDirectory: configDir)
+        let client = ContactsAllowlistKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { _ in (Data(), Self.response(500)) })
+
+        // Must not throw and must not hang — the whole point of `push` is that it's safe to call
+        // fire-and-forget from a UI action.
+        await ContactsAllowlistSync.push(store: store, client: client)
+    }
+
+    @Test("pushIfConfigured no-ops (no network call) when SOCIAL_KV has not been provisioned")
+    func noOpsWithoutKVNamespace() async {
+        let configDir = Self.makeConfigDir()
+        try? FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configDir) }
+
+        await ContactsAllowlistSync.pushIfConfigured(
+            configDirectory: configDir,
+            secretStore: FakeSecretStore(token: "unused"),
+            transport: { _ in
+                Issue.record("transport must not be called with no provisioned SOCIAL_KV namespace")
+                struct UnexpectedNetworkCall: Error {}
+                throw UnexpectedNetworkCall()
+            })
+    }
+
+    @Test("pushIfConfigured no-ops (no network call) when no Cloudflare token is available")
+    func noOpsWithoutToken() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimClear()
+        defer { cfToken.release() }
+        let configDir = Self.makeConfigDir()
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        try await SiteConfigStore(configDirectory: configDir).save(
+            SiteSettings(provisionedWorkerResources: .init(kvNamespaceID: "ns1")))
+
+        await ContactsAllowlistSync.pushIfConfigured(
+            configDirectory: configDir,
+            secretStore: FakeSecretStore(token: nil),
+            transport: { _ in
+                Issue.record("transport must not be called with no Cloudflare token")
+                struct UnexpectedNetworkCall: Error {}
+                throw UnexpectedNetworkCall()
+            })
+    }
+
+    @Test("pushIfConfigured resolves the account id and pushes the current allowlist")
+    func resolvesAccountAndPushes() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimClear()
+        defer { cfToken.release() }
+        let configDir = Self.makeConfigDir()
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        try await SiteConfigStore(configDirectory: configDir).save(
+            SiteSettings(provisionedWorkerResources: .init(kvNamespaceID: "ns1")))
+        let store = ContactStore(configDirectory: configDir)
+        try await store.add(Contact(me: URL(string: "https://alice.example")!, displayName: "Alice"))
+
+        let accountsBody = Data("""
+        {"success": true, "result": [{"id": "acct1"}]}
+        """.utf8)
+        let seenAuthorization = SeenHeader()
+        let capturedPUT = CapturedURLs()
+
+        await ContactsAllowlistSync.pushIfConfigured(
+            configDirectory: configDir,
+            secretStore: FakeSecretStore(token: "token"),
+            transport: { request in
+                await seenAuthorization.record(request.value(forHTTPHeaderField: "Authorization"))
+                if request.url!.path.hasSuffix("/accounts") { return (accountsBody, Self.response(200)) }
+                if request.url!.path.hasSuffix("/values/contacts:allowlist") {
+                    if let body = request.httpBody, let urls = try? JSONDecoder().decode([String].self, from: body) {
+                        await capturedPUT.set(urls)
+                    }
+                    return (Data(), Self.response(200))
+                }
+                return (Data(), Self.response(404))
+            })
+
+        #expect(await capturedPUT.value == ["alice.example"])
+        #expect(await seenAuthorization.value == "Bearer token")
+    }
+}
+
+private struct FakeSecretStore: SecretStore {
+    let token: String?
+    func read(account: String) throws -> String? { account == SecretAccounts.cloudflareToken ? token : nil }
+    func write(_ value: String, account: String) throws {}
+    func delete(account: String) throws {}
+}
+
+private actor CapturedURLs {
+    private(set) var value: [String]?
+    func set(_ urls: [String]) { value = urls }
+}
+
+private actor SeenHeader {
+    private(set) var value: String?
+    func record(_ value: String?) { self.value = value }
+}

--- a/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
@@ -651,6 +651,7 @@ struct DeployCoordinatorTests {
             "milestone:syndicating", "syndicate",
             "milestone:websubPing", "notify",
             "milestone:activityPubBackfill",
+            "milestone:contactsAllowlistPush",
         ])
     }
 
@@ -684,6 +685,7 @@ struct DeployCoordinatorTests {
             "milestone:syndicating", "syndicate",
             "milestone:websubPing", "notify",
             "milestone:activityPubBackfill",
+            "milestone:contactsAllowlistPush",
         ])
     }
 
@@ -702,6 +704,7 @@ struct DeployCoordinatorTests {
             "milestone:syndicating", "syndicate",
             "milestone:websubPing",
             "milestone:activityPubBackfill",
+            "milestone:contactsAllowlistPush",
         ])
     }
 
@@ -724,11 +727,47 @@ struct DeployCoordinatorTests {
             "milestone:syndicating", "syndicate",
             "milestone:websubPing", "notify",
             "milestone:activityPubBackfill", "backfill",
+            "milestone:contactsAllowlistPush",
         ])
     }
 
     @Test("backfillActivityPubOutbox defaults to a no-op, so existing call sites without it still compile and run")
     func postDeploySequencingDefaultsBackfillToNoOp() async {
+        let recorder = CallRecorder()
+        await DeployCoordinator.runPostDeploySequencing(
+            onMilestone: { _ in },
+            sendWebmentions: { recorder.record("send") },
+            syndicate: { recorder.record("syndicate") }
+        )
+        #expect(recorder.calls == ["send", "syndicate"])
+    }
+
+    @Test("pushContactsAllowlist runs last, after backfillActivityPubOutbox, with a milestone immediately before it")
+    func postDeploySequencingRunsContactsAllowlistPushLast() async {
+        let recorder = CallRecorder()
+        await DeployCoordinator.runPostDeploySequencing(
+            onMilestone: { progress in recorder.record("milestone:\(progress.phase)") },
+            sendWebmentions: { recorder.record("send") },
+            publishStandardSite: { recorder.record("standardsite") },
+            publishStandardSiteGraph: { recorder.record("standardsitegraph") },
+            syndicate: { recorder.record("syndicate") },
+            notifySubscribers: { recorder.record("notify") },
+            backfillActivityPubOutbox: { recorder.record("backfill") },
+            pushContactsAllowlist: { recorder.record("allowlist") }
+        )
+        #expect(recorder.calls == [
+            "milestone:webmentions", "send",
+            "milestone:standardSitePublishing", "standardsite",
+            "milestone:standardSiteGraphPublishing", "standardsitegraph",
+            "milestone:syndicating", "syndicate",
+            "milestone:websubPing", "notify",
+            "milestone:activityPubBackfill", "backfill",
+            "milestone:contactsAllowlistPush", "allowlist",
+        ])
+    }
+
+    @Test("pushContactsAllowlist defaults to a no-op, so existing call sites without it still compile and run")
+    func postDeploySequencingDefaultsContactsAllowlistPushToNoOp() async {
         let recorder = CallRecorder()
         await DeployCoordinator.runPostDeploySequencing(
             onMilestone: { _ in },

--- a/docs/superpowers/plans/2026-08-18-contacts-allowlist-push.md
+++ b/docs/superpowers/plans/2026-08-18-contacts-allowlist-push.md
@@ -24,8 +24,12 @@
 
 - **Create** `Sources/AnglesiteCore/ContactsAllowlistKVClient.swift` — the KV HTTP client (one method: `putAllowlist(_:)`).
 - **Create** `Tests/AnglesiteCoreTests/ContactsAllowlistKVClientTests.swift`
+- **Create** `Sources/AnglesiteCore/CloudflareAccountLookup.swift` — shared "resolve the token's first visible account id" helper, consolidating the three near-identical private copies this task would otherwise create a fourth of.
+- **Create** `Tests/AnglesiteCoreTests/CloudflareAccountLookupTests.swift`
 - **Create** `Sources/AnglesiteCore/ContactsAllowlistSync.swift` — the orchestrator (`push`, `pushIfConfigured`).
 - **Create** `Tests/AnglesiteCoreTests/ContactsAllowlistSyncTests.swift`
+- **Modify** `Sources/AnglesiteCore/MicropubContentSync.swift` — delegate to the shared `CloudflareAccountLookup` instead of its own private `resolveAccountID`.
+- **Modify** `Sources/AnglesiteCore/ReceivedInteractionSync.swift` — same delegation.
 - **Modify** `Sources/AnglesiteCore/OperationProgress.swift` — add the `deployPushingContactsAllowlist` milestone constant.
 - **Modify** `Sources/AnglesiteCore/DeployCoordinator.swift` — add a `pushContactsAllowlist` step to `runPostDeploySequencing`.
 - **Modify** `Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift` — update 4 existing expectations, add 1 new test.
@@ -206,17 +210,87 @@ git commit -m "feat(#1567): add ContactsAllowlistKVClient for SOCIAL_KV writes"
 
 ---
 
-### Task 2: `ContactsAllowlistSync`
+### Task 2: Shared `CloudflareAccountLookup` + `ContactsAllowlistSync`
+
+`ContactsAllowlistSync.pushIfConfigured` needs the same "resolve the token's
+first visible Cloudflare account id" lookup that `MicropubContentSync` and
+`ReceivedInteractionSync` each already implement as a byte-for-byte-identical
+private copy (`private struct CFAccount`/`CFEnvelope` +
+`private static func resolveAccountID(apiToken:baseURL:transport:)`). Adding
+a fourth private copy would triplicate — extract it once as
+`CloudflareAccountLookup` and have all three (plus the new one) delegate to
+it, deleting the two existing private copies in the same task.
 
 **Files:**
+- Create: `Sources/AnglesiteCore/CloudflareAccountLookup.swift`
+- Test: `Tests/AnglesiteCoreTests/CloudflareAccountLookupTests.swift`
 - Create: `Sources/AnglesiteCore/ContactsAllowlistSync.swift`
 - Test: `Tests/AnglesiteCoreTests/ContactsAllowlistSyncTests.swift`
+- Modify: `Sources/AnglesiteCore/MicropubContentSync.swift:288` (call site), `:296-310` (delete private duplicate)
+- Modify: `Sources/AnglesiteCore/ReceivedInteractionSync.swift:91` (call site), `:54-71` (delete private duplicate)
 
 **Interfaces:**
-- Consumes: `ContactStore` (`Sources/AnglesiteCore/ContactStore.swift:8`, `init(configDirectory:)`, `func knownMeURLs() throws -> Set<String>`); `ContactsAllowlistKVClient` from Task 1; `SiteConfigStore.read(from:fileManager:)` (`Sources/AnglesiteCore/SiteConfigStore.swift:211`); `SiteSettings.provisionedWorkerResources?.kvNamespaceID` (`Sources/AnglesiteCore/WorkerComposition.swift:108`); `CloudflareAPICredentials.resolve(secretStore:)` (`Sources/AnglesiteCore/CloudflareAPICredentials.swift:40`); `SecretStore`, `PlatformSecretStore.make()`; `LogCenter.shared.append(source:stream:text:)`.
-- Produces: `public enum ContactsAllowlistSync { static func push(store: ContactStore, client: ContactsAllowlistKVClient) async; static func pushIfConfigured(configDirectory: URL, secretStore: any SecretStore = PlatformSecretStore.make(), baseURL: String = ..., transport: @escaping CloudflareTransport = ...) async }` — consumed by Tasks 4 and 5.
+- Consumes: `ContactStore` (`Sources/AnglesiteCore/ContactStore.swift:8`, `init(configDirectory:)`, `func knownMeURLs() throws -> Set<String>`); `ContactsAllowlistKVClient` from Task 1; `SiteConfigStore.read(from:fileManager:)` (`Sources/AnglesiteCore/SiteConfigStore.swift:211`); `SiteSettings.provisionedWorkerResources?.kvNamespaceID` (`Sources/AnglesiteCore/WorkerComposition.swift:108`); `CloudflareAPICredentials.resolve(secretStore:)` (`Sources/AnglesiteCore/CloudflareAPICredentials.swift:40`); `SecretStore`, `PlatformSecretStore.make()`; `LogCenter.shared.append(source:stream:text:)`; `CloudflareTransport` (`Sources/AnglesiteCore/CloudflareReading.swift:78`).
+- Produces:
+  - `enum CloudflareAccountLookup { static func resolveAccountID(apiToken: String, baseURL: String, transport: CloudflareTransport) async -> String? }` (module-internal, no `public`) — consumed by `MicropubContentSync`, `ReceivedInteractionSync`, `ContactsAllowlistSync`, and by Task 5 only indirectly (through `ContactsAllowlistSync`).
+  - `public enum ContactsAllowlistSync { static func push(store: ContactStore, client: ContactsAllowlistKVClient) async; static func pushIfConfigured(configDirectory: URL, secretStore: any SecretStore = PlatformSecretStore.make(), baseURL: String = ..., transport: @escaping CloudflareTransport = ...) async }` — consumed by Tasks 4 and 5.
 
 - [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/CloudflareAccountLookupTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct CloudflareAccountLookupTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://api.cloudflare.com/")!, statusCode: status,
+                         httpVersion: nil, headerFields: nil)!
+    }
+
+    @Test("resolves the first account id from a successful envelope")
+    func resolvesFirstAccountID() async {
+        let body = Data("""
+        {"success": true, "result": [{"id": "acct1"}, {"id": "acct2"}]}
+        """.utf8)
+        let accountID = await CloudflareAccountLookup.resolveAccountID(
+            apiToken: "token", baseURL: "https://api.cloudflare.com/client/v4",
+            transport: { _ in (body, Self.response(200)) })
+        #expect(accountID == "acct1")
+    }
+
+    @Test("returns nil on a non-2xx response")
+    func returnsNilOnHTTPError() async {
+        let accountID = await CloudflareAccountLookup.resolveAccountID(
+            apiToken: "token", baseURL: "https://api.cloudflare.com/client/v4",
+            transport: { _ in (Data(), Self.response(403)) })
+        #expect(accountID == nil)
+    }
+
+    @Test("returns nil when the envelope reports success: false")
+    func returnsNilOnUnsuccessfulEnvelope() async {
+        let body = Data("""
+        {"success": false, "result": null}
+        """.utf8)
+        let accountID = await CloudflareAccountLookup.resolveAccountID(
+            apiToken: "token", baseURL: "https://api.cloudflare.com/client/v4",
+            transport: { _ in (body, Self.response(200)) })
+        #expect(accountID == nil)
+    }
+
+    @Test("returns nil when the result list is empty")
+    func returnsNilOnEmptyResult() async {
+        let body = Data("""
+        {"success": true, "result": []}
+        """.utf8)
+        let accountID = await CloudflareAccountLookup.resolveAccountID(
+            apiToken: "token", baseURL: "https://api.cloudflare.com/client/v4",
+            transport: { _ in (body, Self.response(200)) })
+        #expect(accountID == nil)
+    }
+}
+```
 
 ```swift
 // Tests/AnglesiteCoreTests/ContactsAllowlistSyncTests.swift
@@ -367,10 +441,82 @@ private actor SeenHeader {
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `swift test --package-path . --filter ContactsAllowlistSyncTests`
-Expected: FAIL to compile — `ContactsAllowlistSync` does not exist yet.
+Run: `swift test --package-path . --filter "CloudflareAccountLookupTests|ContactsAllowlistSyncTests"`
+Expected: FAIL to compile — neither `CloudflareAccountLookup` nor `ContactsAllowlistSync` exist yet.
 
 - [ ] **Step 3: Write the implementation**
+
+First, the shared helper:
+
+```swift
+// Sources/AnglesiteCore/CloudflareAccountLookup.swift
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Shared "resolve the token's first visible Cloudflare account id" lookup (#1567 review) — used
+/// by every `*Sync`/`*IfConfigured` orchestrator that needs an account id but has no
+/// separately-stored one to key off (unlike #587's `ProvisionedResources.inboxAccountID`). A
+/// personal Anglesite deployment has exactly one Cloudflare account per token, so "just take the
+/// first account" is always correct. Previously duplicated privately, byte-for-byte, in both
+/// `MicropubContentSync` and `ReceivedInteractionSync` — consolidated here so `ContactsAllowlistSync`
+/// doesn't add a third copy.
+enum CloudflareAccountLookup {
+    private struct CFAccount: Decodable, Sendable { let id: String }
+    private struct CFEnvelope: Decodable, Sendable { let success: Bool; let result: [CFAccount]? }
+
+    static func resolveAccountID(apiToken: String, baseURL: String, transport: CloudflareTransport) async -> String? {
+        guard let url = URL(string: "\(baseURL)/accounts?per_page=1") else { return nil }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        guard let (data, http) = try? await transport(request), (200..<300).contains(http.statusCode),
+              let envelope = try? JSONDecoder().decode(CFEnvelope.self, from: data), envelope.success
+        else { return nil }
+        return envelope.result?.first?.id
+    }
+}
+```
+
+Then update the two existing call sites to delegate to it instead of their own private copy.
+
+In `Sources/AnglesiteCore/MicropubContentSync.swift`, change line 288 from:
+
+```swift
+        guard let accountID = await Self.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
+```
+
+to:
+
+```swift
+        guard let accountID = await CloudflareAccountLookup.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
+```
+
+and delete lines 296-310 (the private `CFAccount`/`CFEnvelope` structs and `resolveAccountID` — everything between the end of `pullAndCommitIfConfigured` and the enum's closing `}`), so the file ends with:
+
+```swift
+        let client = MicropubPostD1Client(
+            accountID: accountID, databaseID: databaseID, apiToken: token, baseURL: baseURL, transport: transport)
+        return await pullAndCommit(client: client, siteDirectory: siteDirectory, configDirectory: configDirectory)
+    }
+}
+```
+
+In `Sources/AnglesiteCore/ReceivedInteractionSync.swift`, delete lines 54-71 (the private `CFAccount`/`CFEnvelope` structs and the doc-commented `resolveAccountID`, right after `pullAndCommit`'s closing `}` and before the `pullAndCommitIfConfigured` doc comment), and change what is currently line 91 from:
+
+```swift
+        guard let accountID = await Self.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
+```
+
+to:
+
+```swift
+        guard let accountID = await CloudflareAccountLookup.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
+```
+
+Then the new orchestrator:
 
 ```swift
 // Sources/AnglesiteCore/ContactsAllowlistSync.swift
@@ -413,7 +559,7 @@ public enum ContactsAllowlistSync {
         else { return }
         guard let token = try? await CloudflareAPICredentials.resolve(secretStore: secretStore), !token.isEmpty
         else { return }
-        guard let accountID = await Self.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
+        guard let accountID = await CloudflareAccountLookup.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
         else { return }
 
         let store = ContactStore(configDirectory: configDirectory)
@@ -421,35 +567,25 @@ public enum ContactsAllowlistSync {
             accountID: accountID, namespaceID: namespaceID, apiToken: token, baseURL: baseURL, transport: transport)
         await push(store: store, client: client)
     }
-
-    private struct CFAccount: Decodable, Sendable { let id: String }
-    private struct CFEnvelope: Decodable, Sendable { let success: Bool; let result: [CFAccount]? }
-
-    /// Resolves the token's first visible Cloudflare account id — same resolution
-    /// `MicropubContentSync`/`ReceivedInteractionSync` use, since a personal Anglesite deployment
-    /// has exactly one Cloudflare account per token.
-    private static func resolveAccountID(apiToken: String, baseURL: String, transport: CloudflareTransport) async -> String? {
-        guard let url = URL(string: "\(baseURL)/accounts?per_page=1") else { return nil }
-        var request = URLRequest(url: url)
-        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
-        guard let (data, http) = try? await transport(request), (200..<300).contains(http.statusCode),
-              let envelope = try? JSONDecoder().decode(CFEnvelope.self, from: data), envelope.success
-        else { return nil }
-        return envelope.result?.first?.id
-    }
 }
 ```
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `swift test --package-path . --filter ContactsAllowlistSyncTests`
-Expected: PASS (5 tests)
+Run: `swift test --package-path . --filter "CloudflareAccountLookupTests|ContactsAllowlistSyncTests|MicropubContentSyncTests|ReceivedInteractionSyncTests"`
+Expected: PASS — the 4 new `CloudflareAccountLookupTests`, the 5 `ContactsAllowlistSyncTests`, and (unchanged behavior after the refactor) the existing `MicropubContentSyncTests`/`ReceivedInteractionSyncTests` suites all still pass.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add Sources/AnglesiteCore/ContactsAllowlistSync.swift Tests/AnglesiteCoreTests/ContactsAllowlistSyncTests.swift
-git commit -m "feat(#1567): add ContactsAllowlistSync push orchestrator"
+git add Sources/AnglesiteCore/CloudflareAccountLookup.swift Tests/AnglesiteCoreTests/CloudflareAccountLookupTests.swift \
+        Sources/AnglesiteCore/ContactsAllowlistSync.swift Tests/AnglesiteCoreTests/ContactsAllowlistSyncTests.swift \
+        Sources/AnglesiteCore/MicropubContentSync.swift Sources/AnglesiteCore/ReceivedInteractionSync.swift
+git commit -m "feat(#1567): add ContactsAllowlistSync push orchestrator
+
+Extracts the account-id lookup MicropubContentSync/ReceivedInteractionSync
+each duplicated privately into a shared CloudflareAccountLookup, rather than
+adding a third copy for the new contacts allowlist push."
 ```
 
 ---

--- a/docs/superpowers/plans/2026-08-18-contacts-allowlist-push.md
+++ b/docs/superpowers/plans/2026-08-18-contacts-allowlist-push.md
@@ -752,8 +752,8 @@ Expected: FAIL — the 4 updated tests fail (actual arrays are missing `"milesto
 In `Sources/AnglesiteCore/OperationProgress.swift`, immediately after the `deployBackfillingActivityPub` constant (after line 80's closing `)`):
 
 ```swift
-    /// Post-deploy: pushing the contact allowlist (me-URLs) to the Worker's `SOCIAL_KV` store
-    /// (#1567) — the future authenticated-read gate's data source.
+    /// Post-deploy: pushing the contact allowlist (me-URLs) to the future authenticated-read
+    /// gate's backing store (#1567).
     static let deployPushingContactsAllowlist = OperationProgress(
         kind: .deploy, phase: "contactsAllowlistPush", label: "Syncing contacts allowlist…"
     )
@@ -770,11 +770,11 @@ In `Sources/AnglesiteCore/DeployCoordinator.swift`, change the `runPostDeploySeq
         syndicate: () async -> Void,
         notifySubscribers: () async -> Void = {},
         backfillActivityPubOutbox: () async -> Void = {},
-        /// Contacts allowlist push (#1567): overwrites the Worker's `SOCIAL_KV` `contacts:allowlist`
-        /// key with the site's current known me-URLs. Ordered last — unrelated to every other
-        /// pass here, and (unlike the others) it's a reconcile that only needs to run once per
-        /// deploy, not depend on anything the earlier passes produced. Best-effort and never
-        /// throws, like every other step here. Callers without contacts configured pass a no-op.
+        /// Contacts allowlist push (#1567): pushes the site's current known me-URLs to their
+        /// remote store. Ordered last — unrelated to every other pass here, and (unlike the
+        /// others) it's a reconcile that only needs to run once per deploy, not depend on
+        /// anything the earlier passes produced. Best-effort and never throws, like every other
+        /// step here. Callers without contacts configured pass a no-op.
         pushContactsAllowlist: () async -> Void = {}
     ) async {
         onMilestone(.deployWebmentions)

--- a/docs/superpowers/plans/2026-08-18-contacts-allowlist-push.md
+++ b/docs/superpowers/plans/2026-08-18-contacts-allowlist-push.md
@@ -1,0 +1,980 @@
+# Contacts Allowlist Push Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Push the site's contact allowlist (normalized me-URLs) to the Worker's `SOCIAL_KV` store whenever a contact is added/removed, and unconditionally re-push on every deploy as a consistency backstop.
+
+**Architecture:** A new `ContactsAllowlistKVClient` (Cloudflare KV HTTP client, injectable-transport DI, mirrors `InboxKVClient`) writes a single JSON-array key (`contacts:allowlist`) to the site's already-provisioned `SOCIAL_KV` namespace. A new `ContactsAllowlistSync` orchestrator (mirrors `InboxSubmissionSync`/`MicropubContentSync`'s `*IfConfigured` shape) reads `ContactStore.knownMeURLs()` and pushes the whole set through that client, resolving credentials/namespace id from `SiteConfigStore`/`SecretStore` the same way those sync types do. It's wired into `ContactsModel.add/update/remove` (fire-and-forget, non-blocking) and into `DeployCoordinator.runPostDeploySequencing` (a new best-effort post-deploy step, like the existing webmention/syndication/backfill passes).
+
+**Tech Stack:** Swift 6.4 / Swift Testing, `AnglesiteCore` (SwiftPM), `AnglesiteAppCore` (the `Sources/AnglesiteApp` SwiftPM target).
+
+## Global Constraints
+
+- Read `CONTRIBUTING.md` in this worktree before making any change — it is the source of truth for workflow, and this plan does not repeat it.
+- Conventional commits, subject line ≤72 characters, reference `#1567` in each commit subject.
+- Every push is best-effort: it must never throw out of a caller, never block a UI action, and never fail a deploy. Failures are logged via `LogCenter`, not surfaced as errors.
+- No new Cloudflare resources: reuse the already-provisioned `SOCIAL_KV` namespace (`ProvisionedResources.kvNamespaceID`). Do not touch `SocialWorkerProvisionCommand`, `WorkerComposition`'s provisioning logic, or any `worker/migrations/*.sql` file.
+- Do not modify `Resources/Template/worker/worker.ts` — reading/checking the allowlist is epic #963 slice 4, a separate issue.
+- `swift test --package-path .` must pass after every task. Because Task 4/5 touch `Sources/AnglesiteApp`, run the full suite locally on the Xcode 27 toolchain before considering the plan done (per `CONTRIBUTING.md` ▸ Testing — CI does not execute `AnglesiteAppTests` at all).
+- Follow `docs/testing-macos-app.md` for toolchain setup (`DEVELOPER_DIR`) if `swift test` fails with a stale/broken toolchain error.
+
+---
+
+## File Structure
+
+- **Create** `Sources/AnglesiteCore/ContactsAllowlistKVClient.swift` — the KV HTTP client (one method: `putAllowlist(_:)`).
+- **Create** `Tests/AnglesiteCoreTests/ContactsAllowlistKVClientTests.swift`
+- **Create** `Sources/AnglesiteCore/ContactsAllowlistSync.swift` — the orchestrator (`push`, `pushIfConfigured`).
+- **Create** `Tests/AnglesiteCoreTests/ContactsAllowlistSyncTests.swift`
+- **Modify** `Sources/AnglesiteCore/OperationProgress.swift` — add the `deployPushingContactsAllowlist` milestone constant.
+- **Modify** `Sources/AnglesiteCore/DeployCoordinator.swift` — add a `pushContactsAllowlist` step to `runPostDeploySequencing`.
+- **Modify** `Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift` — update 4 existing expectations, add 1 new test.
+- **Modify** `Sources/AnglesiteApp/ContactsModel.swift` — inject a `pushAllowlist` closure, call it after `add`/`update`/`remove`.
+- **Modify** `Tests/AnglesiteAppTests/ContactsModelTests.swift` — add push-is-attempted coverage.
+- **Modify** `Sources/AnglesiteApp/DeployModel.swift` — wire `ContactsAllowlistSync.pushIfConfigured` into the `runPostDeploySequencing` call site.
+
+---
+
+### Task 1: `ContactsAllowlistKVClient`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/ContactsAllowlistKVClient.swift`
+- Test: `Tests/AnglesiteCoreTests/ContactsAllowlistKVClientTests.swift`
+
+**Interfaces:**
+- Consumes: `CloudflareTransport` (`Sources/AnglesiteCore/CloudflareReading.swift:78`), `HTTPCloudflareClient.defaultTransport` (`Sources/AnglesiteCore/HTTPCloudflareClient.swift:181`), `CloudflareError` (`Sources/AnglesiteCore/CloudflareReading.swift:9`, cases `.unauthorized`, `.http(status:)`, `.malformedResponse`).
+- Produces: `public struct ContactsAllowlistKVClient: Sendable { init(accountID:namespaceID:apiToken:baseURL:transport:); func putAllowlist(_ meURLs: Set<String>) async throws }` — consumed by Task 2.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/ContactsAllowlistKVClientTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct ContactsAllowlistKVClientTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://api.cloudflare.com/")!, statusCode: status,
+                         httpVersion: nil, headerFields: nil)!
+    }
+
+    @Test("putAllowlist PUTs a sorted JSON array to the contacts:allowlist key")
+    func putsSortedArray() async throws {
+        let captured = CapturedRequest()
+        let client = ContactsAllowlistKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { request in
+                await captured.set(request)
+                return (Data(), Self.response(200))
+            })
+
+        try await client.putAllowlist(["bob.example", "alice.example"])
+
+        let request = await captured.value
+        #expect(request?.httpMethod == "PUT")
+        #expect(request?.url?.path.hasSuffix("/values/contacts:allowlist") == true)
+        #expect(request?.value(forHTTPHeaderField: "Authorization") == "Bearer token")
+        let body = try #require(await captured.body)
+        let decoded = try JSONDecoder().decode([String].self, from: body)
+        #expect(decoded == ["alice.example", "bob.example"])
+    }
+
+    @Test("putAllowlist succeeds with an empty set (last contact removed)")
+    func putsEmptySet() async throws {
+        let captured = CapturedRequest()
+        let client = ContactsAllowlistKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { request in
+                await captured.set(request)
+                return (Data(), Self.response(200))
+            })
+
+        try await client.putAllowlist([])
+
+        let body = try #require(await captured.body)
+        let decoded = try JSONDecoder().decode([String].self, from: body)
+        #expect(decoded.isEmpty)
+    }
+
+    @Test("throws unauthorized on a 401/403 response")
+    func throwsUnauthorized() async {
+        let client = ContactsAllowlistKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "bad",
+            transport: { _ in (Data(), Self.response(403)) })
+        await #expect(throws: CloudflareError.unauthorized) {
+            try await client.putAllowlist(["alice.example"])
+        }
+    }
+
+    @Test("throws http(status:) on any other non-2xx response")
+    func throwsHTTPError() async {
+        let client = ContactsAllowlistKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { _ in (Data(), Self.response(500)) })
+        await #expect(throws: CloudflareError.http(status: 500)) {
+            try await client.putAllowlist(["alice.example"])
+        }
+    }
+}
+
+/// Actor wrapper so the `@Sendable` transport closure can hand a captured `URLRequest`/body back
+/// to the test body without a data race. Mirrors `InboxKVClientTests.CapturedRequest`.
+private actor CapturedRequest {
+    private(set) var value: URLRequest?
+    var body: Data? { value?.httpBody }
+    func set(_ request: URLRequest) { value = request }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter ContactsAllowlistKVClientTests`
+Expected: FAIL to compile — `ContactsAllowlistKVClient` does not exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+```swift
+// Sources/AnglesiteCore/ContactsAllowlistKVClient.swift
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Cloudflare Workers KV client for the #1567 contacts allowlist push. Writes the site's
+/// normalized me-URL set (`ContactStore.knownMeURLs()`) as a single JSON array under
+/// `contacts:allowlist` in the already-provisioned `SOCIAL_KV` namespace — the future
+/// authenticated-read gate (epic #963 slice 4) reads this key from the Worker side. Follows the
+/// same injectable-transport DI pattern as `InboxKVClient`/`HTTPCloudflareClient` — no Keychain
+/// coupling, token passed in at init.
+public struct ContactsAllowlistKVClient: Sendable {
+    private static let key = "contacts:allowlist"
+
+    private let baseURL: String
+    private let accountID: String
+    private let namespaceID: String
+    private let apiToken: String
+    private let transport: CloudflareTransport
+
+    public init(
+        accountID: String,
+        namespaceID: String,
+        apiToken: String,
+        baseURL: String = "https://api.cloudflare.com/client/v4",
+        transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
+    ) {
+        self.accountID = accountID
+        self.namespaceID = namespaceID
+        self.apiToken = apiToken
+        self.baseURL = baseURL
+        self.transport = transport
+    }
+
+    /// Replaces the whole `contacts:allowlist` value with `meURLs`, sorted for a deterministic
+    /// request body. Whole-set replace, not an incremental add/remove — the caller
+    /// (`ContactsAllowlistSync`) always supplies the complete current set, so this single call
+    /// doubles as both "push on change" and "reconcile."
+    public func putAllowlist(_ meURLs: Set<String>) async throws {
+        let body = try JSONEncoder().encode(meURLs.sorted())
+        let valueURLString = "\(baseURL)/accounts/\(accountID)/storage/kv/namespaces/\(namespaceID)/values/\(Self.key)"
+        guard let url = URL(string: valueURLString) else { throw CloudflareError.malformedResponse }
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+        let (_, http) = try await transport(request)
+        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
+        guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter ContactsAllowlistKVClientTests`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContactsAllowlistKVClient.swift Tests/AnglesiteCoreTests/ContactsAllowlistKVClientTests.swift
+git commit -m "feat(#1567): add ContactsAllowlistKVClient for SOCIAL_KV writes"
+```
+
+---
+
+### Task 2: `ContactsAllowlistSync`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/ContactsAllowlistSync.swift`
+- Test: `Tests/AnglesiteCoreTests/ContactsAllowlistSyncTests.swift`
+
+**Interfaces:**
+- Consumes: `ContactStore` (`Sources/AnglesiteCore/ContactStore.swift:8`, `init(configDirectory:)`, `func knownMeURLs() throws -> Set<String>`); `ContactsAllowlistKVClient` from Task 1; `SiteConfigStore.read(from:fileManager:)` (`Sources/AnglesiteCore/SiteConfigStore.swift:211`); `SiteSettings.provisionedWorkerResources?.kvNamespaceID` (`Sources/AnglesiteCore/WorkerComposition.swift:108`); `CloudflareAPICredentials.resolve(secretStore:)` (`Sources/AnglesiteCore/CloudflareAPICredentials.swift:40`); `SecretStore`, `PlatformSecretStore.make()`; `LogCenter.shared.append(source:stream:text:)`.
+- Produces: `public enum ContactsAllowlistSync { static func push(store: ContactStore, client: ContactsAllowlistKVClient) async; static func pushIfConfigured(configDirectory: URL, secretStore: any SecretStore = PlatformSecretStore.make(), baseURL: String = ..., transport: @escaping CloudflareTransport = ...) async }` — consumed by Tasks 4 and 5.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/ContactsAllowlistSyncTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct ContactsAllowlistSyncTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://api.cloudflare.com/")!, statusCode: status,
+                         httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func makeConfigDir() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("contacts-allowlist-sync-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    @Test("push reads the store's known me-URLs and forwards them to the client")
+    func pushForwardsKnownMeURLs() async throws {
+        let configDir = Self.makeConfigDir()
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        let store = ContactStore(configDirectory: configDir)
+        try await store.add(Contact(me: URL(string: "https://alice.example")!, displayName: "Alice"))
+
+        let captured = CapturedURLs()
+        let client = ContactsAllowlistKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { request in
+                if let body = request.httpBody, let urls = try? JSONDecoder().decode([String].self, from: body) {
+                    await captured.set(urls)
+                }
+                return (Data(), Self.response(200))
+            })
+
+        await ContactsAllowlistSync.push(store: store, client: client)
+
+        #expect(await captured.value == ["alice.example"])
+    }
+
+    @Test("push logs and does not throw when the client fails")
+    func pushSwallowsClientFailure() async throws {
+        let configDir = Self.makeConfigDir()
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        let store = ContactStore(configDirectory: configDir)
+        let client = ContactsAllowlistKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { _ in (Data(), Self.response(500)) })
+
+        // Must not throw and must not hang — the whole point of `push` is that it's safe to call
+        // fire-and-forget from a UI action.
+        await ContactsAllowlistSync.push(store: store, client: client)
+    }
+
+    @Test("pushIfConfigured no-ops (no network call) when SOCIAL_KV has not been provisioned")
+    func noOpsWithoutKVNamespace() async {
+        let configDir = Self.makeConfigDir()
+        try? FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configDir) }
+
+        await ContactsAllowlistSync.pushIfConfigured(
+            configDirectory: configDir,
+            secretStore: FakeSecretStore(token: "unused"),
+            transport: { _ in
+                Issue.record("transport must not be called with no provisioned SOCIAL_KV namespace")
+                struct UnexpectedNetworkCall: Error {}
+                throw UnexpectedNetworkCall()
+            })
+    }
+
+    @Test("pushIfConfigured no-ops (no network call) when no Cloudflare token is available")
+    func noOpsWithoutToken() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimClear()
+        defer { cfToken.release() }
+        let configDir = Self.makeConfigDir()
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        try await SiteConfigStore(configDirectory: configDir).save(
+            SiteSettings(provisionedWorkerResources: .init(kvNamespaceID: "ns1")))
+
+        await ContactsAllowlistSync.pushIfConfigured(
+            configDirectory: configDir,
+            secretStore: FakeSecretStore(token: nil),
+            transport: { _ in
+                Issue.record("transport must not be called with no Cloudflare token")
+                struct UnexpectedNetworkCall: Error {}
+                throw UnexpectedNetworkCall()
+            })
+    }
+
+    @Test("pushIfConfigured resolves the account id and pushes the current allowlist")
+    func resolvesAccountAndPushes() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimClear()
+        defer { cfToken.release() }
+        let configDir = Self.makeConfigDir()
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        try await SiteConfigStore(configDirectory: configDir).save(
+            SiteSettings(provisionedWorkerResources: .init(kvNamespaceID: "ns1")))
+        let store = ContactStore(configDirectory: configDir)
+        try await store.add(Contact(me: URL(string: "https://alice.example")!, displayName: "Alice"))
+
+        let accountsBody = Data("""
+        {"success": true, "result": [{"id": "acct1"}]}
+        """.utf8)
+        let seenAuthorization = SeenHeader()
+        let capturedPUT = CapturedURLs()
+
+        await ContactsAllowlistSync.pushIfConfigured(
+            configDirectory: configDir,
+            secretStore: FakeSecretStore(token: "token"),
+            transport: { request in
+                await seenAuthorization.record(request.value(forHTTPHeaderField: "Authorization"))
+                if request.url!.path.hasSuffix("/accounts") { return (accountsBody, Self.response(200)) }
+                if request.url!.path.hasSuffix("/values/contacts:allowlist") {
+                    if let body = request.httpBody, let urls = try? JSONDecoder().decode([String].self, from: body) {
+                        await capturedPUT.set(urls)
+                    }
+                    return (Data(), Self.response(200))
+                }
+                return (Data(), Self.response(404))
+            })
+
+        #expect(await capturedPUT.value == ["alice.example"])
+        #expect(await seenAuthorization.value == "Bearer token")
+    }
+}
+
+private struct FakeSecretStore: SecretStore {
+    let token: String?
+    func read(account: String) throws -> String? { account == SecretAccounts.cloudflareToken ? token : nil }
+    func write(_ value: String, account: String) throws {}
+    func delete(account: String) throws {}
+}
+
+private actor CapturedURLs {
+    private(set) var value: [String]?
+    func set(_ urls: [String]) { value = urls }
+}
+
+private actor SeenHeader {
+    private(set) var value: String?
+    func record(_ value: String?) { self.value = value }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter ContactsAllowlistSyncTests`
+Expected: FAIL to compile — `ContactsAllowlistSync` does not exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+```swift
+// Sources/AnglesiteCore/ContactsAllowlistSync.swift
+import Foundation
+
+/// Pushes the site's contact allowlist (`ContactStore.knownMeURLs()`) to the Worker's
+/// `SOCIAL_KV` store (#1567) — both on a contact add/remove and, as the consistency backstop, on
+/// every deploy. Both triggers call the same whole-set-replace `push`, so `Config/contacts.json`
+/// is always the authoritative source: there's no diffing, only an unconditional overwrite.
+public enum ContactsAllowlistSync {
+    /// Reads `store`'s current me-URL set and replaces `client`'s `contacts:allowlist` value with
+    /// it. Never throws — a failure (network, auth, provisioning) is logged and otherwise
+    /// invisible; the next successful call (the next contact change, or the next deploy) retries
+    /// with the current state, so a missed push self-heals rather than needing a retry queue.
+    public static func push(store: ContactStore, client: ContactsAllowlistKVClient) async {
+        do {
+            let meURLs = try await store.knownMeURLs()
+            try await client.putAllowlist(meURLs)
+        } catch {
+            await LogCenter.shared.append(
+                source: "ContactsAllowlistSync", stream: .stderr,
+                text: "Failed to push contacts allowlist to SOCIAL_KV: \(error). Will retry on the "
+                    + "next contact change or deploy.")
+        }
+    }
+
+    /// Reads the site's `SiteSettings` and Cloudflare API token from `secretStore`; no-ops (no
+    /// network call) unless `SOCIAL_KV` has been provisioned
+    /// (`provisionedWorkerResources.kvNamespaceID`) and a token is available — i.e. the site has
+    /// never been deployed yet. `configDirectory` is the package's `Config/` directory
+    /// (`AnglesitePackage.configURL`).
+    public static func pushIfConfigured(
+        configDirectory: URL,
+        secretStore: any SecretStore = PlatformSecretStore.make(),
+        baseURL: String = "https://api.cloudflare.com/client/v4",
+        transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
+    ) async {
+        guard let settings = try? SiteConfigStore.read(from: configDirectory),
+              let namespaceID = settings.provisionedWorkerResources?.kvNamespaceID, !namespaceID.isEmpty
+        else { return }
+        guard let token = try? await CloudflareAPICredentials.resolve(secretStore: secretStore), !token.isEmpty
+        else { return }
+        guard let accountID = await Self.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
+        else { return }
+
+        let store = ContactStore(configDirectory: configDirectory)
+        let client = ContactsAllowlistKVClient(
+            accountID: accountID, namespaceID: namespaceID, apiToken: token, baseURL: baseURL, transport: transport)
+        await push(store: store, client: client)
+    }
+
+    private struct CFAccount: Decodable, Sendable { let id: String }
+    private struct CFEnvelope: Decodable, Sendable { let success: Bool; let result: [CFAccount]? }
+
+    /// Resolves the token's first visible Cloudflare account id — same resolution
+    /// `MicropubContentSync`/`ReceivedInteractionSync` use, since a personal Anglesite deployment
+    /// has exactly one Cloudflare account per token.
+    private static func resolveAccountID(apiToken: String, baseURL: String, transport: CloudflareTransport) async -> String? {
+        guard let url = URL(string: "\(baseURL)/accounts?per_page=1") else { return nil }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        guard let (data, http) = try? await transport(request), (200..<300).contains(http.statusCode),
+              let envelope = try? JSONDecoder().decode(CFEnvelope.self, from: data), envelope.success
+        else { return nil }
+        return envelope.result?.first?.id
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter ContactsAllowlistSyncTests`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContactsAllowlistSync.swift Tests/AnglesiteCoreTests/ContactsAllowlistSyncTests.swift
+git commit -m "feat(#1567): add ContactsAllowlistSync push orchestrator"
+```
+
+---
+
+### Task 3: `DeployCoordinator.runPostDeploySequencing` gets a `pushContactsAllowlist` step
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/OperationProgress.swift`
+- Modify: `Sources/AnglesiteCore/DeployCoordinator.swift:442-483` (`runPostDeploySequencing`)
+- Modify: `Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift:625-740`
+
+**Interfaces:**
+- Consumes: existing `OperationProgress` shape (`Sources/AnglesiteCore/OperationProgress.swift`).
+- Produces: `OperationProgress.deployPushingContactsAllowlist` constant; `DeployCoordinator.runPostDeploySequencing(..., pushContactsAllowlist: () async -> Void = {})` — consumed by Task 5.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift`, immediately after `postDeploySequencingRunsBackfillLast` (after line 728's closing `}`):
+
+```swift
+    @Test("pushContactsAllowlist runs last, after backfillActivityPubOutbox, with a milestone immediately before it")
+    func postDeploySequencingRunsContactsAllowlistPushLast() async {
+        let recorder = CallRecorder()
+        await DeployCoordinator.runPostDeploySequencing(
+            onMilestone: { progress in recorder.record("milestone:\(progress.phase)") },
+            sendWebmentions: { recorder.record("send") },
+            publishStandardSite: { recorder.record("standardsite") },
+            publishStandardSiteGraph: { recorder.record("standardsitegraph") },
+            syndicate: { recorder.record("syndicate") },
+            notifySubscribers: { recorder.record("notify") },
+            backfillActivityPubOutbox: { recorder.record("backfill") },
+            pushContactsAllowlist: { recorder.record("allowlist") }
+        )
+        #expect(recorder.calls == [
+            "milestone:webmentions", "send",
+            "milestone:standardSitePublishing", "standardsite",
+            "milestone:standardSiteGraphPublishing", "standardsitegraph",
+            "milestone:syndicating", "syndicate",
+            "milestone:websubPing", "notify",
+            "milestone:activityPubBackfill", "backfill",
+            "milestone:contactsAllowlistPush", "allowlist",
+        ])
+    }
+
+    @Test("pushContactsAllowlist defaults to a no-op, so existing call sites without it still compile and run")
+    func postDeploySequencingDefaultsContactsAllowlistPushToNoOp() async {
+        let recorder = CallRecorder()
+        await DeployCoordinator.runPostDeploySequencing(
+            onMilestone: { _ in },
+            sendWebmentions: { recorder.record("send") },
+            syndicate: { recorder.record("syndicate") }
+        )
+        #expect(recorder.calls == ["send", "syndicate"])
+    }
+```
+
+Then update the 4 existing tests whose expected `calls` arrays end at `"milestone:activityPubBackfill"` (with no push call, since `pushContactsAllowlist` isn't passed in any of them) to append `"milestone:contactsAllowlistPush"` as the new final element:
+
+In `postDeploySequencingRunsInOrder` (around line 647-654), change:
+```swift
+        #expect(recorder.calls == [
+            "milestone:webmentions", "send",
+            "milestone:standardSitePublishing", "standardsite",
+            "milestone:standardSiteGraphPublishing", "standardsitegraph",
+            "milestone:syndicating", "syndicate",
+            "milestone:websubPing", "notify",
+            "milestone:activityPubBackfill",
+        ])
+```
+to:
+```swift
+        #expect(recorder.calls == [
+            "milestone:webmentions", "send",
+            "milestone:standardSitePublishing", "standardsite",
+            "milestone:standardSiteGraphPublishing", "standardsitegraph",
+            "milestone:syndicating", "syndicate",
+            "milestone:websubPing", "notify",
+            "milestone:activityPubBackfill",
+            "milestone:contactsAllowlistPush",
+        ])
+```
+
+In `postDeploySequencingDefaultsStandardSitePassesToNoOp` (around line 680-687), change:
+```swift
+        #expect(recorder.calls == [
+            "milestone:webmentions", "send",
+            "milestone:standardSitePublishing",
+            "milestone:standardSiteGraphPublishing",
+            "milestone:syndicating", "syndicate",
+            "milestone:websubPing", "notify",
+            "milestone:activityPubBackfill",
+        ])
+```
+to:
+```swift
+        #expect(recorder.calls == [
+            "milestone:webmentions", "send",
+            "milestone:standardSitePublishing",
+            "milestone:standardSiteGraphPublishing",
+            "milestone:syndicating", "syndicate",
+            "milestone:websubPing", "notify",
+            "milestone:activityPubBackfill",
+            "milestone:contactsAllowlistPush",
+        ])
+```
+
+In `postDeploySequencingDefaultsNotifyToNoOp` (around line 698-705), change:
+```swift
+        #expect(recorder.calls == [
+            "milestone:webmentions", "send",
+            "milestone:standardSitePublishing",
+            "milestone:standardSiteGraphPublishing",
+            "milestone:syndicating", "syndicate",
+            "milestone:websubPing",
+            "milestone:activityPubBackfill",
+        ])
+```
+to:
+```swift
+        #expect(recorder.calls == [
+            "milestone:webmentions", "send",
+            "milestone:standardSitePublishing",
+            "milestone:standardSiteGraphPublishing",
+            "milestone:syndicating", "syndicate",
+            "milestone:websubPing",
+            "milestone:activityPubBackfill",
+            "milestone:contactsAllowlistPush",
+        ])
+```
+
+In `postDeploySequencingRunsBackfillLast` (around line 720-727), change:
+```swift
+        #expect(recorder.calls == [
+            "milestone:webmentions", "send",
+            "milestone:standardSitePublishing", "standardsite",
+            "milestone:standardSiteGraphPublishing", "standardsitegraph",
+            "milestone:syndicating", "syndicate",
+            "milestone:websubPing", "notify",
+            "milestone:activityPubBackfill", "backfill",
+        ])
+```
+to:
+```swift
+        #expect(recorder.calls == [
+            "milestone:webmentions", "send",
+            "milestone:standardSitePublishing", "standardsite",
+            "milestone:standardSiteGraphPublishing", "standardsitegraph",
+            "milestone:syndicating", "syndicate",
+            "milestone:websubPing", "notify",
+            "milestone:activityPubBackfill", "backfill",
+            "milestone:contactsAllowlistPush",
+        ])
+```
+
+(`postDeploySequencingRunsBothPassesRegardless` and `postDeploySequencingDefaultsBackfillToNoOp` use `onMilestone: { _ in }`, so their expectations don't include milestones or the (unpassed) push call — leave them unchanged.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter DeployCoordinatorTests`
+Expected: FAIL — the 4 updated tests fail (actual arrays are missing `"milestone:contactsAllowlistPush"`), and the 2 new tests fail to compile (`pushContactsAllowlist` parameter doesn't exist yet).
+
+- [ ] **Step 3: Write the implementation**
+
+In `Sources/AnglesiteCore/OperationProgress.swift`, immediately after the `deployBackfillingActivityPub` constant (after line 80's closing `)`):
+
+```swift
+    /// Post-deploy: pushing the contact allowlist (me-URLs) to the Worker's `SOCIAL_KV` store
+    /// (#1567) — the future authenticated-read gate's data source.
+    static let deployPushingContactsAllowlist = OperationProgress(
+        kind: .deploy, phase: "contactsAllowlistPush", label: "Syncing contacts allowlist…"
+    )
+```
+
+In `Sources/AnglesiteCore/DeployCoordinator.swift`, change the `runPostDeploySequencing` signature and body:
+
+```swift
+    public static func runPostDeploySequencing(
+        onMilestone: (OperationProgress) -> Void,
+        sendWebmentions: () async -> Void,
+        publishStandardSite: () async -> Void = {},
+        publishStandardSiteGraph: () async -> Void = {},
+        syndicate: () async -> Void,
+        notifySubscribers: () async -> Void = {},
+        backfillActivityPubOutbox: () async -> Void = {},
+        /// Contacts allowlist push (#1567): overwrites the Worker's `SOCIAL_KV` `contacts:allowlist`
+        /// key with the site's current known me-URLs. Ordered last — unrelated to every other
+        /// pass here, and (unlike the others) it's a reconcile that only needs to run once per
+        /// deploy, not depend on anything the earlier passes produced. Best-effort and never
+        /// throws, like every other step here. Callers without contacts configured pass a no-op.
+        pushContactsAllowlist: () async -> Void = {}
+    ) async {
+        onMilestone(.deployWebmentions)
+        await sendWebmentions()
+        onMilestone(.deployStandardSitePublishing)
+        await publishStandardSite()
+        onMilestone(.deployStandardSiteGraphPublishing)
+        await publishStandardSiteGraph()
+        onMilestone(.deploySyndicating)
+        await syndicate()
+        onMilestone(.deployNotifyingSubscribers)
+        await notifySubscribers()
+        onMilestone(.deployBackfillingActivityPub)
+        await backfillActivityPubOutbox()
+        onMilestone(.deployPushingContactsAllowlist)
+        await pushContactsAllowlist()
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter DeployCoordinatorTests`
+Expected: PASS (all `runPostDeploySequencing` tests, including the 2 new ones)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/OperationProgress.swift Sources/AnglesiteCore/DeployCoordinator.swift Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
+git commit -m "feat(#1567): add pushContactsAllowlist post-deploy step"
+```
+
+---
+
+### Task 4: Wire the push into `ContactsModel`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/ContactsModel.swift`
+- Modify: `Tests/AnglesiteAppTests/ContactsModelTests.swift`
+
+**Interfaces:**
+- Consumes: `ContactsAllowlistSync.pushIfConfigured(configDirectory:secretStore:baseURL:transport:)` from Task 2; `CurrentSite.configDirectory` (`Sources/AnglesiteApp/CurrentSite.swift:35`).
+- Produces: `ContactsModel.init(contactsProvider:pushAllowlist:)` — the `pushAllowlist` parameter is a new injectable seam, `@Sendable (URL) async -> Void`, defaulting to `ContactsAllowlistSync.pushIfConfigured`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteAppTests/ContactsModelTests.swift`, after `manualAddLeavesLinkedActorNil` (after line 144's closing `}`):
+
+```swift
+    @Test("add fires a fire-and-forget allowlist push without blocking or throwing")
+    func addTriggersAllowlistPush() async throws {
+        let recorder = PushRecorder()
+        let model = ContactsModel(
+            contactsProvider: FakeContactsProvider(result: .success([])),
+            pushAllowlist: { url in await recorder.record(url) })
+        let site = try Self.makeSite()
+        model.configure(site: site)
+        await model.reload()
+
+        await model.add(me: URL(string: "https://alice.example")!, displayName: "Alice")
+        await recorder.waitForCall()
+
+        #expect(await recorder.calls == [site.configDirectory])
+    }
+
+    @Test("update fires a fire-and-forget allowlist push")
+    func updateTriggersAllowlistPush() async throws {
+        let recorder = PushRecorder()
+        let model = ContactsModel(
+            contactsProvider: FakeContactsProvider(result: .success([])),
+            pushAllowlist: { url in await recorder.record(url) })
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+        await model.add(me: URL(string: "https://alice.example")!, displayName: "Alice")
+        await recorder.waitForCall()
+        var added = try #require(model.contacts.first)
+        added.displayName = "Alice Renamed"
+
+        await model.update(added)
+        await recorder.waitForCall(count: 2)
+
+        #expect(await recorder.calls.count == 2)
+    }
+
+    @Test("remove fires a fire-and-forget allowlist push")
+    func removeTriggersAllowlistPush() async throws {
+        let recorder = PushRecorder()
+        let model = ContactsModel(
+            contactsProvider: FakeContactsProvider(result: .success([])),
+            pushAllowlist: { url in await recorder.record(url) })
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+        await model.add(me: URL(string: "https://alice.example")!, displayName: "Alice")
+        await recorder.waitForCall()
+        let added = try #require(model.contacts.first)
+
+        await model.remove(added)
+        await recorder.waitForCall(count: 2)
+
+        #expect(await recorder.calls.count == 2)
+    }
+```
+
+Add this helper actor at the bottom of the file, alongside the existing `private struct FakeContactsProvider`:
+
+```swift
+/// Records `pushAllowlist` invocations from a detached `Task`, and lets a test await the Nth
+/// call deterministically instead of racing an unstructured Task with a sleep.
+private actor PushRecorder {
+    private(set) var calls: [URL] = []
+    private var continuations: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    func record(_ url: URL) {
+        calls.append(url)
+        continuations.removeAll { count, continuation in
+            guard calls.count >= count else { return false }
+            continuation.resume()
+            return true
+        }
+    }
+
+    func waitForCall(count: Int = 1) async {
+        if calls.count >= count { return }
+        await withCheckedContinuation { continuation in
+            continuations.append((count, continuation))
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter ContactsModelTests`
+Expected: FAIL to compile — `ContactsModel.init` has no `pushAllowlist` parameter yet.
+
+- [ ] **Step 3: Write the implementation**
+
+In `Sources/AnglesiteApp/ContactsModel.swift`, add a stored property and change `init` (near the top, after the existing `private let contactsProvider: ContactsProviding` on line 38):
+
+```swift
+    private let contactsProvider: ContactsProviding
+    /// Contacts allowlist push (#1567): fire-and-forget after each successful mutation, never
+    /// awaited inline — `add`/`update`/`remove` must return as soon as the local `ContactStore`
+    /// write completes, not wait on a network round trip. Injectable so tests can observe calls
+    /// without touching the network (mirrors `contactsProvider`'s DI seam); production default
+    /// is the real Cloudflare push.
+    private let pushAllowlist: @Sendable (URL) async -> Void
+    private var configDirectory: URL?
+
+    init(
+        contactsProvider: ContactsProviding = SystemContactsProvider(),
+        pushAllowlist: @escaping @Sendable (URL) async -> Void = { dir in
+            await ContactsAllowlistSync.pushIfConfigured(configDirectory: dir)
+        }
+    ) {
+        self.contactsProvider = contactsProvider
+        self.pushAllowlist = pushAllowlist
+    }
+```
+
+Update `configure(site:)` to record `configDirectory` (add one line inside the existing method body, right after `store = ContactStore(configDirectory: site.configDirectory)`):
+
+```swift
+    func configure(site: CurrentSite) {
+        store = ContactStore(configDirectory: site.configDirectory)
+        configDirectory = site.configDirectory
+        contacts = []
+        loadState = .idle
+        suggestions = []
+        scanFailure = nil
+        writeFailure = nil
+        dismissedSuggestionKeys = []
+    }
+```
+
+Add a private helper and call it from `add`/`update`/`remove` right after each successful (or failed — the push always fires; the allowlist is a set of me-URLs, not written-vs-not) write. Replace the three methods:
+
+```swift
+    func add(me: URL, displayName: String, linkedActor: URL? = nil) async {
+        guard let store else { return }
+        let contact = Contact(me: me, displayName: displayName, linkedActor: linkedActor)
+        do {
+            try await store.add(contact)
+            writeFailure = nil
+        } catch {
+            writeFailure = "\(error)"
+        }
+        await reload()
+        firePushAllowlist()
+    }
+
+    func update(_ contact: Contact) async {
+        guard let store else { return }
+        do {
+            try await store.update(contact)
+            writeFailure = nil
+        } catch {
+            writeFailure = "\(error)"
+        }
+        await reload()
+        firePushAllowlist()
+    }
+
+    func remove(_ contact: Contact) async {
+        guard let store else { return }
+        do {
+            try await store.remove(id: contact.id)
+            writeFailure = nil
+        } catch {
+            writeFailure = "\(error)"
+        }
+        await reload()
+        firePushAllowlist()
+    }
+```
+
+And add the helper near the bottom of the type, alongside `suggestionKey(_:)`:
+
+```swift
+    /// Fires the allowlist push as a detached `Task` so `add`/`update`/`remove` return as soon as
+    /// the local write (and reload) finish — the push is best-effort and must never block a UI
+    /// action on a network round trip (#1567 design §3/§4). A failed local write still fires this:
+    /// `knownMeURLs()` is re-read fresh inside the push, so it always reflects whatever's actually
+    /// on disk regardless of whether this particular call succeeded.
+    private func firePushAllowlist() {
+        guard let configDirectory else { return }
+        Task { await pushAllowlist(configDirectory) }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter ContactsModelTests`
+Expected: PASS (all existing tests plus the 3 new ones)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ContactsModel.swift Tests/AnglesiteAppTests/ContactsModelTests.swift
+git commit -m "feat(#1567): push contacts allowlist after add/update/remove"
+```
+
+---
+
+### Task 5: Wire the push into the deploy flow
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/DeployModel.swift:1033-1080` (the `DeployCoordinator.runPostDeploySequencing` call site inside `runDeploy`'s `.succeeded` case)
+
+**Interfaces:**
+- Consumes: `DeployCoordinator.runPostDeploySequencing(..., pushContactsAllowlist:)` from Task 3; `ContactsAllowlistSync.pushIfConfigured(configDirectory:secretStore:)` from Task 2; `self.keychain: any SecretStore` (`Sources/AnglesiteApp/DeployModel.swift:162`); `configDirectory: URL` (the `runDeploy` parameter, already in scope at this call site).
+- Produces: nothing new consumed elsewhere — this is the final integration point.
+
+This task has no dedicated new unit test: `runDeploy`'s other post-deploy closures (`onDomainAttach`, `onMarkdownForAgents`, the `runPostDeploySequencing` closures themselves) are not unit-tested at this integration depth either — `DeployModelTests.swift` doesn't exercise them, since a real test would require a fully scripted `DeployCommand`/`SocialWorkerProvisionCommand`/container stack. Correctness here is covered by Task 2's `ContactsAllowlistSyncTests` (the logic being wired) and Task 3's `DeployCoordinatorTests` (the sequencing being wired into) — this task is pure wiring, verified by a successful build and the full test suite still passing.
+
+- [ ] **Step 1: Add the closure**
+
+In `Sources/AnglesiteApp/DeployModel.swift`, inside the `runPostDeploySequencing` call (around line 1033), add a new `pushContactsAllowlist` argument after `backfillActivityPubOutbox`:
+
+```swift
+            await DeployCoordinator.runPostDeploySequencing(
+                onMilestone: { [weak self] progress in self?.emitPostDeployMilestone(progress, siteID: siteID) },
+                sendWebmentions: { [weak self] in
+                    guard let self else { return }
+                    await self.webmentionCommand.send(
+                        siteID: siteID, siteDirectory: siteDirectory, configDirectory: configDirectory, siteBase: url
+                    )
+                },
+                publishStandardSite: { [weak self] in
+                    guard let self else { return }
+                    await self.standardSitePublishCommand.publish(
+                        siteID: siteID, siteDirectory: siteDirectory, configDirectory: configDirectory
+                    )
+                },
+                publishStandardSiteGraph: { [weak self] in
+                    guard let self else { return }
+                    await self.standardSiteGraphPublishCommand.publish(
+                        siteID: siteID, siteDirectory: siteDirectory, configDirectory: configDirectory
+                    )
+                },
+                syndicate: { [weak self] in
+                    guard let self else { return }
+                    await self.posseCommand.syndicate(
+                        siteID: siteID, siteDirectory: siteDirectory, configDirectory: configDirectory, siteBase: url
+                    )
+                },
+                notifySubscribers: { [weak self] in
+                    guard let self, websubProvisioned else { return }
+                    _ = await self.websubPing.notify(
+                        siteURL: siteURL ?? url.absoluteString,
+                        source: "websub:\(siteID)"
+                    )
+                },
+                backfillActivityPubOutbox: { [weak self] in
+                    guard let self, activitypubProvisioned else { return }
+                    _ = await self.activityPubOutboxBackfill.backfill(
+                        siteID: siteID,
+                        siteDirectory: siteDirectory,
+                        configDirectory: configDirectory,
+                        siteBase: url,
+                        secretStore: self.keychain
+                    )
+                },
+                pushContactsAllowlist: { [weak self] in
+                    guard let self else { return }
+                    await ContactsAllowlistSync.pushIfConfigured(
+                        configDirectory: configDirectory, secretStore: self.keychain
+                    )
+                }
+            )
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED (run `xcodegen generate` first if the worktree's `.xcodeproj` predates this change — see `docs/testing-macos-app.md`)
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `swift test --package-path .`
+Expected: PASS — every existing suite plus the new tests from Tasks 1-4. Per `CONTRIBUTING.md`, since this touches `Sources/AnglesiteApp`, run this on the Xcode 27 toolchain locally (`DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path .` if the default toolchain resolves elsewhere — see `docs/testing-macos-app.md`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/DeployModel.swift
+git commit -m "feat(#1567): push contacts allowlist as a post-deploy step"
+```
+
+---
+
+## Done criteria
+
+- `ContactsAllowlistKVClient` and `ContactsAllowlistSync` exist in `AnglesiteCore` with passing tests (Tasks 1-2).
+- `DeployCoordinator.runPostDeploySequencing` runs the allowlist push last, behind a milestone, with existing callers unaffected by the new defaulted parameter (Task 3).
+- `ContactsModel.add`/`update`/`remove` each fire a non-blocking allowlist push (Task 4).
+- A successful deploy re-pushes the allowlist unconditionally as the reconcile backstop (Task 5).
+- `swift test --package-path .` passes in full, on the Xcode 27 toolchain.
+- No changes to `Resources/Template/worker/worker.ts`, `SocialWorkerProvisionCommand.swift`, `WorkerComposition.swift`'s provisioning logic, or any `worker/migrations/*.sql` file.

--- a/docs/superpowers/specs/2026-08-18-contacts-allowlist-push-design.md
+++ b/docs/superpowers/specs/2026-08-18-contacts-allowlist-push-design.md
@@ -1,0 +1,140 @@
+# Push contact allowlist (me URLs) to Worker store — design (#1567)
+
+**Status:** approved design, pre-implementation.
+**Issue:** [#1567](https://github.com/Anglesite/Anglesite/issues/1567), slice 3
+of epic #963. Related: #966 (`ContactStore`, shipped — supplies
+`knownMeURLs()`), decision record
+`docs/superpowers/specs/2026-08-18-audience-limited-posting-decisions.md` §2.3.
+
+## 1. Context and goal
+
+The Worker's future authenticated-read gate (epic #963 slice 4, a separate
+issue) needs to check an IndieAuth-authenticated `me` against the site's
+contact set. That set lives only on the owner's Mac, in
+`Config/contacts.json` via `ContactStore` (#966). `ContactStore.knownMeURLs()`
+already exists for exactly this purpose but is unused today.
+
+**Goal:** push the normalized me-URL set to the Worker's KV store whenever a
+contact is added or removed, with an unconditional re-push at deploy time as
+the consistency backstop (per the epic decision: "revocation takes effect on
+the next push"). This issue ships the data path only — the Worker-side read
+gate that consumes it is slice 4, out of scope here.
+
+## 2. Storage: `SOCIAL_KV`, single key, bare array
+
+The Worker's per-site `SOCIAL_KV` namespace is already provisioned (used
+today for consent rate-limiting in `worker.ts`) — no new KV namespace, D1
+table, or migration is needed. One fixed key:
+
+```
+contacts:allowlist
+```
+
+holding a bare JSON array of normalized me-URL strings, e.g.:
+
+```json
+["https://alice.example", "https://bob.example/blog"]
+```
+
+No wrapper object, no metadata (`updatedAt`, counts, etc.), no display names
+or `linkedActor`/`linkedFeed` data — only the URLs, matching the epic's
+minimal-footprint privacy framing (§2.3 of the decision record: salted
+hashing was considered and rejected as pointless, since me-URLs are already
+public).
+
+## 3. Push mechanism: whole-set replace, no diffing
+
+Both triggers below perform the *identical* operation: read
+`ContactStore.knownMeURLs()`, PUT the resulting array to `contacts:allowlist`.
+There is no GET-then-compare and no incremental per-URL add/remove call to
+KV — the local `Config/contacts.json` is always authoritative, so an
+unconditional whole-set PUT is simultaneously "push on change" and
+"reconcile."
+
+### New types (`AnglesiteCore`)
+
+- **`ContactsAllowlistKVClient`** — a small HTTP client for the Cloudflare KV
+  API, following the same injectable-transport DI pattern as
+  `InboxKVClient`/`HTTPCloudflareClient` (no Keychain coupling; the bearer
+  token and account/namespace identifiers are passed in at init, sourced the
+  same way other KV/D1 clients already get them). One method:
+
+  ```swift
+  public struct ContactsAllowlistKVClient: Sendable {
+      public func putAllowlist(_ meURLs: Set<String>) async throws
+  }
+  ```
+
+  Internally: a single `PUT
+  /accounts/{account_id}/storage/kv/namespaces/{namespace_id}/values/contacts:allowlist`
+  call with the sorted array (sorted for deterministic request bodies /
+  easier debugging) as the JSON body.
+
+- **`ContactsAllowlistPusher`** — orchestrator wiring `ContactStore` to the
+  KV client:
+
+  ```swift
+  public struct ContactsAllowlistPusher: Sendable {
+      public func push(store: ContactStore, client: ContactsAllowlistKVClient) async throws
+  }
+  ```
+
+  `push` calls `store.knownMeURLs()` then `client.putAllowlist(_:)`. No
+  caching, no batching — this is called at most a few times per session.
+
+### Call sites
+
+1. **`ContactsModel.add`/`update`/`remove`** (`AnglesiteApp`) — after the
+   local `ContactStore` mutation succeeds, fire off the push as a
+   best-effort background task. The UI action completes on the local write
+   alone; the push never blocks or gates it.
+2. **Deploy flow** — alongside where `DomainConfigAudit`/
+   `DomainConfigReconciler` already run in the deploy sequence, add an
+   unconditional `ContactsAllowlistPusher.push` call after a successful
+   `wrangler deploy`, gated on the site's `SOCIAL_KV` namespace ID being
+   present in `ProvisionedResources` (i.e., the site has been provisioned at
+   least once).
+
+## 4. Error handling
+
+Per the epic's "app applies backend machinery it's confident about without
+asking" posture, and because there's no ambiguity here (local state is
+always correct), failures are never surfaced as a decision for the owner:
+
+- A push failure during a contact add/remove is logged to the debug pane
+  (subprocess/network logging is sacred — never silently swallowed) and
+  otherwise invisible. The contact mutation itself already succeeded
+  locally.
+- If the site has never been deployed/provisioned (no `SOCIAL_KV` namespace
+  ID yet), the push is skipped — there's nothing to push to. The first
+  successful deploy provisions the namespace and its own reconcile push
+  catches the site up.
+- A reconcile push failure during deploy is logged but does not fail the
+  deploy — the site's actual content deploy is the primary concern; the
+  allowlist will retry on the next deploy or next contact mutation.
+
+## 5. Testing
+
+Swift Testing, mirroring `InboxKVClient`'s existing test shape (mock
+transport injected at init):
+
+- `ContactsAllowlistKVClientTests` — verifies the PUT request URL, method,
+  auth header, and JSON body shape (sorted bare array) for a given me-URL
+  set.
+- `ContactsAllowlistPusherTests` — verifies `push` reads
+  `knownMeURLs()` from a `ContactStore` fixture and forwards exactly that
+  set to the client.
+- `ContactsModel` tests — verify a push is attempted after each successful
+  add/update/remove, and that a failing push does not propagate as a UI-
+  visible error or block the mutation.
+
+## 6. Explicitly out of scope
+
+- The Worker (`worker.ts`) reading or checking `contacts:allowlist` at
+  all — that's epic #963 slice 4 (the IndieAuth read gate), a separate
+  issue.
+- Any new KV namespace, D1 table, or provisioning-script changes —
+  `SOCIAL_KV` already exists and is provisioned for every site.
+- A user-facing retry affordance or drift-confirmation UI (unlike
+  `DomainConfigDriftSheetView`) — the correct state here is never ambiguous,
+  so no owner decision is needed.

--- a/docs/superpowers/specs/2026-08-18-contacts-allowlist-push-design.md
+++ b/docs/superpowers/specs/2026-08-18-contacts-allowlist-push-design.md
@@ -30,10 +30,12 @@ table, or migration is needed. One fixed key:
 contacts:allowlist
 ```
 
-holding a bare JSON array of normalized me-URL strings, e.g.:
+holding a bare JSON array of `ContactStore.knownMeURLs()`'s output verbatim
+— `normalizedIdentityKey(for:)`'s scheme-less `host+path` strings
+(`Contact.swift:41`), not full URLs, e.g.:
 
 ```json
-["https://alice.example", "https://bob.example/blog"]
+["alice.example", "bob.example/blog"]
 ```
 
 No wrapper object, no metadata (`updatedAt`, counts, etc.), no display names


### PR DESCRIPTION
Closes #1567

## Summary

- Adds `ContactsAllowlistKVClient` (Cloudflare KV HTTP client) and `ContactsAllowlistSync` (orchestrator) in `AnglesiteCore` — whole-set-replace push of `ContactStore.knownMeURLs()` to the already-provisioned `SOCIAL_KV` namespace under a single `contacts:allowlist` key, feeding epic #963 slice 4's future authenticated-read gate.
- Wires the push into two triggers: a non-blocking, FIFO-ordered fire-and-forget push after every contact add/update/remove (`ContactsModel`), and an unconditional re-push on every successful deploy as a consistency backstop (`DeployCoordinator.runPostDeploySequencing` / `DeployModel`).
- Extracts a shared `CloudflareAccountLookup` helper, consolidating two pre-existing byte-for-byte-duplicated private implementations (`MicropubContentSync`, `ReceivedInteractionSync`) rather than adding a third copy.
- Design: `docs/superpowers/specs/2026-08-18-contacts-allowlist-push-design.md`. Plan: `docs/superpowers/plans/2026-08-18-contacts-allowlist-push.md`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite passing (4109 AnglesiteCoreTests, 600+ AnglesiteAppTests, plus the smaller SwiftPM targets), verified on the Xcode 27 toolchain.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [ ] Manual smoke: verify the `contacts:allowlist` KV write against a real Cloudflare namespace (`wrangler kv key get contacts:allowlist` after adding a contact) — the request shape is only exercised against stubbed transports in tests today.