### PR TITLE
docs(#963): note relation to Private Webmention in spec

### DIFF
--- a/docs/superpowers/specs/2026-08-18-audience-limited-posting-decisions.md
+++ b/docs/superpowers/specs/2026-08-18-audience-limited-posting-decisions.md
@@ -29,6 +29,15 @@ issue):
   content, so this ships as a **documented extension with honest framing**,
   outside the site's W3C-conformance claim.
 
+  > **Relation to [Private Webmention](https://indieweb.org/Private-Webmention):**
+  > this restricted tier covers the same goal as that wiki draft — content
+  > visible only to specific people — but doesn't implement it. Private
+  > Webmention has essentially no interoperable ecosystem to conform to; the
+  > `contacts`-tier + `bto` design here (§2.4) achieves the same outcome
+  > through mechanisms Anglesite already has real interop with (IndieAuth,
+  > ActivityPub federation), which is why it was built this way instead of
+  > against that spec.
+
 The remaining six decisions were settled 2026-08-18 and are recorded below.
 
 ## 2. Decisions

--- a/docs/superpowers/specs/2026-08-18-audience-limited-posting-decisions.md
+++ b/docs/superpowers/specs/2026-08-18-audience-limited-posting-decisions.md
@@ -33,7 +33,7 @@ issue):
   > this restricted tier covers the same goal as that wiki draft — content
   > visible only to specific people — but doesn't implement it. Private
   > Webmention has essentially no interoperable ecosystem to conform to; the
-  > `contacts`-tier + `bto` design here (§2.4) achieves the same outcome
+  > `contacts`-tier + `bto` design here (§2.2, §2.4) achieves the same outcome
   > through mechanisms Anglesite already has real interop with (IndieAuth,
   > ActivityPub federation), which is why it was built this way instead of
   > against that spec.


### PR DESCRIPTION
## Summary

- Adds a short footnote to the audience-limited posting decision record explaining why the restricted-content tier doesn't implement the IndieWeb [Private Webmention](https://indieweb.org/Private-Webmention) draft, for anyone comparing Anglesite's IndieWeb coverage against that spec.
- Docs-only; no code changes.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] Docs-only change — no build/test impact.