### PR TITLE
docs(help): refresh Help Book to match current app functionality

### DIFF
--- a/Resources/Anglesite.help/Contents/Resources/en.lproj/index.html
+++ b/Resources/Anglesite.help/Contents/Resources/en.lproj/index.html
@@ -21,6 +21,7 @@
 		</ul>
 		<h2>Editing</h2>
 		<ul>
+			<li><a href="pages/direct-editing.html">Editing pages directly</a></li>
 			<li><a href="pages/editing-with-assistant.html">Editing with the assistant</a></li>
 			<li><a href="pages/images.html">Adding and optimizing images</a></li>
 			<li><a href="pages/undo.html">Undoing edits</a></li>
@@ -29,11 +30,14 @@
 		<ul>
 			<li><a href="pages/health-and-readiness.html">Health and deploy readiness</a></li>
 			<li><a href="pages/deploying.html">Deploying your site</a></li>
+			<li><a href="pages/website-settings.html">Website settings</a></li>
+			<li><a href="pages/agent-readiness.html">Agent readiness</a></li>
 			<li><a href="pages/accounts.html">Accounts and setup</a></li>
 		</ul>
 		<h2>Reference</h2>
 		<ul>
 			<li><a href="pages/settings.html">Settings</a></li>
+			<li><a href="pages/device-pairing.html">iPhone/iPad pairing</a></li>
 			<li><a href="pages/updates.html">Updating Anglesite</a></li>
 			<li><a href="pages/debug-pane.html">Debug pane and logs</a></li>
 			<li><a href="pages/keyboard-shortcuts.html">Keyboard shortcuts</a></li>

--- a/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/accounts.html
+++ b/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/accounts.html
@@ -13,11 +13,12 @@
 	<p class="lead">Connect your GitHub and Cloudflare accounts so Anglesite can back up and publish your site.</p>
 
 	<h2>GitHub</h2>
-	<p>Your site's <code>Source</code> folder is an ordinary Git repository, so you can add a GitHub remote with the <code>gh</code> command-line tool or <code>git remote</code> in Terminal. Once the repository has an origin configured, Anglesite uses it to back up and publish your site.</p>
-	<p>To let Anglesite push to GitHub, add a GitHub personal access token in <strong>Settings ▸ Advanced</strong>. Create a fine-grained token with <em>Contents: Read and write</em> access for your site's repository at <code>github.com/settings/tokens</code>.</p>
+	<p>Your site's <code>Source</code> folder is an ordinary Git repository. Anglesite pushes to GitHub itself using a personal access token — add one in <strong>Settings ▸ Advanced ▸ Credentials</strong>, or when a publish or backup prompts you for one.</p>
+	<p>Create a fine-grained token at <code>github.com/settings/tokens</code> scoped to <strong>All repositories</strong> with: <em>Contents: Read and write</em>, <em>Administration: Read and write</em> (needed to create a new repository the first time you publish), <em>Repository security advisories: Read</em>, and <em>Dependabot alerts: Read</em> (the last two let Anglesite show a site's open security reports).</p>
 
 	<h2>Cloudflare</h2>
-	<p>When Anglesite needs to deploy to Cloudflare, it will prompt you to provide a Cloudflare API token. You can create one in your Cloudflare dashboard.</p>
+	<p>The easiest way to connect Cloudflare is to sign in from a Deploy sheet — Anglesite stores the credential and refreshes it automatically, and every Cloudflare-backed feature (deploy, domains, analytics, and more) uses it first.</p>
+	<p>If you'd rather not sign in, you can instead paste a Cloudflare API token in <strong>Settings ▸ Advanced ▸ Credentials</strong>; it's only used when no sign-in is connected.</p>
 
 	<h2>Stored securely</h2>
 	<p>Your credentials are stored in the macOS Keychain — not in any file inside your site folder.</p>
@@ -25,6 +26,7 @@
 	<p class="related">
 		<strong>See also:</strong>
 		<a href="deploying.html">Deploying your site</a>
+		<a href="agent-readiness.html">Agent readiness</a>
 		<a href="settings.html">Settings</a>
 		<a href="../index.html">Help home</a>
 	</p>

--- a/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/agent-readiness.html
+++ b/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/agent-readiness.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="robots" content="anchor">
+	<meta name="description" content="How Anglesite's Agent Readiness check scores how well your published site works with AI crawlers and agents.">
+	<title>Agent readiness — Anglesite Help</title>
+	<link rel="stylesheet" href="../shrd/help.css">
+</head>
+<body>
+	<h1>Agent readiness</h1>
+	<p class="lead">Agent Readiness checks how well your published site works with AI crawlers and agents — separate from the deploy-readiness dot, which checks whether your site is safe to publish.</p>
+
+	<h2>Running a check</h2>
+	<p>Choose <strong>Website ▸ Agent Readiness…</strong>. Your site needs to already be published, since the check scans the live, deployed site rather than your local files.</p>
+
+	<figure>
+		<!-- alt: The Agent Readiness sheet showing a scan result -->
+		<div class="screenshot-placeholder">Screenshot: The Agent Readiness sheet.</div>
+		<figcaption>The Agent Readiness sheet.</figcaption>
+	</figure>
+
+	<h2>What it checks</h2>
+	<p>The scan groups its checks into four categories — Discoverability, Content, Bot Access Control, and Capabilities — covering things like whether you have a <code>robots.txt</code> and sitemap, whether your pages offer content in forms AI agents can read, and whether you allow or block AI crawlers on purpose rather than by accident. It reports an overall tier (for example, "Bot-Aware") alongside how many checks passed.</p>
+	<p>Some checks describe capabilities Anglesite doesn't offer yet; those show as failing with an explanation rather than being hidden, so you know what's not available versus what's misconfigured.</p>
+
+	<h2>Requirements</h2>
+	<p>Running a scan calls a Cloudflare API, so it needs a Cloudflare account connected — see <a href="accounts.html">Accounts and setup</a>.</p>
+
+	<p class="related">
+		<strong>See also:</strong>
+		<a href="health-and-readiness.html">Health and deploy readiness</a>
+		<a href="deploying.html">Deploying your site</a>
+		<a href="accounts.html">Accounts and setup</a>
+		<a href="../index.html">Help home</a>
+	</p>
+</body>
+</html>

--- a/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/deploying.html
+++ b/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/deploying.html
@@ -13,7 +13,7 @@
 	<p class="lead">When your site is ready to share with the world, deploy it from the site window with a single action.</p>
 
 	<h2>Open the Deploy drawer</h2>
-	<p>Use the Deploy drawer in the site window to publish your site. Before anything is sent live, Anglesite runs its standard pre-deploy checks automatically.</p>
+	<p>Choose <strong>Website ▸ Publish…</strong> (<kbd>⇧⌘P</kbd>) to open the Deploy drawer and publish your site. Before anything is sent live, Anglesite runs its standard pre-deploy checks automatically.</p>
 
 	<figure>
 		<!-- alt: The Deploy drawer open in the Anglesite site window -->
@@ -31,6 +31,7 @@
 		<strong>See also:</strong>
 		<a href="accounts.html">Accounts and setup</a>
 		<a href="health-and-readiness.html">Health and deploy readiness</a>
+		<a href="agent-readiness.html">Agent readiness</a>
 		<a href="../index.html">Help home</a>
 	</p>
 </body>

--- a/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/device-pairing.html
+++ b/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/device-pairing.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="robots" content="anchor">
+	<meta name="description" content="How to pair a companion iPhone or iPad with Anglesite on your Mac.">
+	<title>iPhone/iPad pairing — Anglesite Help</title>
+	<link rel="stylesheet" href="../shrd/help.css">
+</head>
+<body>
+	<h1>iPhone/iPad pairing</h1>
+	<p class="lead">Settings ▸ iPhone/iPad pairs a companion Anglesite app on your phone or tablet with this Mac.</p>
+
+	<h2>Pairing a device</h2>
+	<p>Open <strong>Settings ▸ iPhone/iPad</strong> to see a QR code carrying this Mac's device ID and public key. Scan it from the Anglesite app on your iPhone or iPad to pair it. Paired devices are listed below the code, each with a <strong>Revoke</strong> button to remove it.</p>
+
+	<figure>
+		<!-- alt: The iPhone/iPad Settings pane showing a pairing QR code -->
+		<div class="screenshot-placeholder">Screenshot: The iPhone/iPad pairing pane.</div>
+		<figcaption>The iPhone/iPad pairing pane.</figcaption>
+	</figure>
+
+	<p>This is early: device pairing is part of Anglesite's cross-device "Anywhere" runtime, which is still under active development. Nothing leaves your iCloud account as part of pairing.</p>
+
+	<p class="related">
+		<strong>See also:</strong>
+		<a href="settings.html">Settings</a>
+		<a href="../index.html">Help home</a>
+	</p>
+</body>
+</html>

--- a/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/direct-editing.html
+++ b/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/direct-editing.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="robots" content="anchor">
+	<meta name="description" content="How to browse and edit your site directly using the Navigator, the Format and Page menus, and the Inspector.">
+	<title>Editing pages directly — Anglesite Help</title>
+	<link rel="stylesheet" href="../shrd/help.css">
+</head>
+<body>
+	<h1>Editing pages directly</h1>
+	<p class="lead">Alongside asking the assistant, you can browse and change your site's structure and content by hand using the Navigator sidebar, the Format and Page menus, and the Inspector.</p>
+
+	<h2>The Navigator</h2>
+	<p>Every site window has a Navigator sidebar listing your site's pages, posts, and folders. Click an item to jump to it:</p>
+	<ul>
+		<li><strong>Pages and posts</strong> render — selecting one shows the finished page in the live preview, not raw markup.</li>
+		<li><strong>The Website row</strong> opens <a href="website-settings.html">Website settings</a>.</li>
+	</ul>
+	<p>Components, stylesheets, and other supporting files aren't listed in the Navigator directly today — reach them from a <strong>Search Site…</strong> result (<kbd>⇧⌘F</kbd>) or from the <a href="#graph">Graph pane</a> instead.</p>
+
+	<figure>
+		<!-- alt: The Navigator sidebar listing a site's pages and posts, with the live preview showing the selected page -->
+		<div class="screenshot-placeholder">Screenshot: The Navigator sidebar next to the live preview.</div>
+		<figcaption>The Navigator sidebar next to the live preview.</figcaption>
+	</figure>
+
+	<h2>Preview, Editor, and Graph panes</h2>
+	<p>A site window has three main panes, switched with <strong>View ▸ Preview</strong> (<kbd>⌘1</kbd>), <strong>Editor</strong> (<kbd>⌘2</kbd>), and <strong>Graph</strong> (<kbd>⌘3</kbd>). Opening a file that isn't rendered as a page — a component, a stylesheet, or a plain text file — switches to the Editor pane automatically, using a plain text editor, a markdown editor, or the component editor (outline plus canvas) depending on the file.</p>
+
+	<h2 id="graph">The Graph pane</h2>
+	<p>The Graph pane visualizes your Astro project's structure: pages, layouts, components, content collections and their entries, images and other assets, and stylesheets, connected by import, "uses layout," "references asset," and "contains" relationships. It's useful for finding a component or style file to open in the Editor, or for understanding what depends on what before you change something shared.</p>
+
+	<h2>The Format and Page menus</h2>
+	<p>With a markdown or visual editor focused, <strong>Format ▸ Font</strong> applies <strong>Strong</strong> (<kbd>⌘B</kbd>), <strong>Emphasis</strong> (<kbd>⌘I</kbd>), Strikethrough, and inline Code; <strong>Format ▸ Heading</strong> sets Heading 1–6 (<kbd>⌥⌘1</kbd>–<kbd>⌥⌘6</kbd>); and <strong>Format ▸ Add Link…</strong> (<kbd>⌘K</kbd>) links the selection. These commands are disabled when a plain text file or the site preview itself has focus — they only act on an editor that understands rich formatting.</p>
+	<p>The <strong>Page</strong> menu creates new content: <strong>New Page…</strong> (<kbd>⌘N</kbd>) opens a sheet where you give it a title, adjust its URL if you want something other than the auto-generated slug, and pick a template. <strong>New Post…</strong> and <strong>New Link Post…</strong> (<kbd>⇧⌘L</kbd>, also in the File menu) create posts. <strong>Page ▸ Collections ▸ New Collection…</strong> sets up a new content collection.</p>
+
+	<figure>
+		<!-- alt: The New Page sheet with Title, URL, and Template fields -->
+		<div class="screenshot-placeholder">Screenshot: The New Page sheet.</div>
+		<figcaption>The New Page sheet.</figcaption>
+	</figure>
+
+	<h2>The Inspector</h2>
+	<p>Toggle the Inspector with <strong>View ▸ Inspector ▸ Show Inspector</strong> (<kbd>⌥⌘I</kbd>). Its Metadata tab shows details for whatever's selected — a page's title and description, a component's metadata, or a collection's type and entries. Its Style tab needs an element selected on the canvas first.</p>
+
+	<h2>Duplicate, Publish, and Unpublish</h2>
+	<p>With something selected in the Navigator, <strong>Edit ▸ Duplicate</strong> (<kbd>⌘D</kbd>) copies it. <strong>Edit ▸ Publish</strong> and <strong>Unpublish</strong> toggle whether the selected page or post is published — this is separate from deploying your whole site; see <a href="deploying.html">Deploying your site</a>.</p>
+
+	<p class="related">
+		<strong>See also:</strong>
+		<a href="editing-with-assistant.html">Editing with the assistant</a>
+		<a href="live-preview.html">Live preview</a>
+		<a href="website-settings.html">Website settings</a>
+		<a href="../index.html">Help home</a>
+	</p>
+</body>
+</html>

--- a/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/editing-with-assistant.html
+++ b/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/editing-with-assistant.html
@@ -10,10 +10,11 @@
 </head>
 <body>
 	<h1>Editing with the assistant</h1>
-	<p class="lead">Ask Anglesite to change anything on your site using plain language — no code required.</p>
+	<p class="lead">Alongside <a href="direct-editing.html">editing pages directly</a>, you can ask Anglesite to change your site using plain language — no code required.</p>
 
 	<h2>The chat panel</h2>
-	<p>The right side of every site window has a chat panel. Type what you want to change and the assistant takes care of the rest. You can ask for anything from a wording tweak to a layout change, and Anglesite will figure out which files to edit.</p>
+	<p>Show or hide the chat panel with <strong>View ▸ Show Chat</strong> (<kbd>⌃⌘K</kbd>) — it's a side panel, hidden until you open it. Type what you want to change and the assistant takes care of the rest. You can ask for anything from a wording tweak to a layout change, and Anglesite will figure out which files to edit.</p>
+	<p>By default the assistant runs entirely on-device using Apple Intelligence. In <strong>Settings ▸ Agents</strong> you can instead point it at a custom LLM endpoint or a connected agent — see <a href="settings.html">Settings</a>.</p>
 
 	<figure>
 		<!-- alt: The Anglesite site window with the chat panel open on the right, showing a message asking the assistant to edit a page -->
@@ -29,6 +30,7 @@
 
 	<p class="related">
 		<strong>See also:</strong>
+		<a href="direct-editing.html">Editing pages directly</a>
 		<a href="images.html">Adding and optimizing images</a>
 		<a href="undo.html">Undoing edits</a>
 		<a href="../index.html">Help home</a>

--- a/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/keyboard-shortcuts.html
+++ b/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/keyboard-shortcuts.html
@@ -12,6 +12,7 @@
 	<h1>Keyboard shortcuts</h1>
 	<p class="lead">Quick-reference shortcuts for common actions in Anglesite.</p>
 
+	<h2>General</h2>
 	<ul>
 		<li><kbd>⌘`</kbd> — cycle between open site windows</li>
 		<li><kbd>⌥⌘D</kbd> — show the Debug pane</li>
@@ -19,8 +20,56 @@
 		<li><kbd>⌘?</kbd> — open Anglesite Help</li>
 	</ul>
 
+	<h2>File</h2>
+	<ul>
+		<li><kbd>⇧⌘N</kbd> — New Site…</li>
+		<li><kbd>⇧⌘L</kbd> — New Link Post…</li>
+		<li><kbd>⌘O</kbd> — Open Site…</li>
+		<li><kbd>⌘S</kbd> — Save</li>
+		<li><kbd>⌘P</kbd> — Print…</li>
+	</ul>
+
+	<h2>Edit</h2>
+	<ul>
+		<li><kbd>⌘D</kbd> — Duplicate the selected item</li>
+		<li><kbd>⌘F</kbd> — Find…</li>
+		<li><kbd>⌘G</kbd> / <kbd>⇧⌘G</kbd> — Find Next / Find Previous</li>
+		<li><kbd>⌥⌘F</kbd> — Find &amp; Replace…</li>
+		<li><kbd>⇧⌘F</kbd> — Search Site…</li>
+	</ul>
+
+	<h2>Format (with a markdown or visual editor focused)</h2>
+	<ul>
+		<li><kbd>⌘B</kbd> / <kbd>⌘I</kbd> — Strong / Emphasis</li>
+		<li><kbd>⌥⌘1</kbd>–<kbd>⌥⌘6</kbd> — Heading 1–6</li>
+		<li><kbd>⌘K</kbd> — Add Link…</li>
+	</ul>
+
+	<h2>Page</h2>
+	<ul>
+		<li><kbd>⌘N</kbd> — New Page…</li>
+	</ul>
+
+	<h2>View</h2>
+	<ul>
+		<li><kbd>⌘1</kbd> / <kbd>⌘2</kbd> / <kbd>⌘3</kbd> — Preview / Editor / Graph pane</li>
+		<li><kbd>⌃⌘K</kbd> — Show/Hide Chat</li>
+		<li><kbd>⌥⌘I</kbd> — Show/Hide Inspector</li>
+		<li><kbd>⌘R</kbd> — Reload Preview</li>
+		<li><kbd>⌃⌘←</kbd> / <kbd>⌃⌘→</kbd> — Back / Forward in preview history</li>
+		<li><kbd>⌘0</kbd> / <kbd>⌘+</kbd> / <kbd>⌘−</kbd> — Actual Size / Zoom In / Zoom Out</li>
+	</ul>
+
+	<h2>Website</h2>
+	<ul>
+		<li><kbd>⇧⌘,</kbd> — Website Settings…</li>
+		<li><kbd>⇧⌘P</kbd> — Publish…</li>
+		<li><kbd>⌥⌘R</kbd> — Restart Dev Server</li>
+	</ul>
+
 	<p class="related">
 		<strong>See also:</strong>
+		<a href="direct-editing.html">Editing pages directly</a>
 		<a href="debug-pane.html">Debug pane and logs</a>
 		<a href="what-is-anglesite.html">What is Anglesite?</a>
 		<a href="../index.html">Help home</a>

--- a/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/live-preview.html
+++ b/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/live-preview.html
@@ -13,7 +13,8 @@
 	<p class="lead">Each site window shows your site running live so you can see exactly what you're building.</p>
 
 	<h2>A live view of your site</h2>
-	<p>The left side of every site window is a live preview of your running site. It looks and behaves just like your site does in a browser — including navigation between pages.</p>
+	<p>The main pane of every site window is a live preview of your running site. It looks and behaves just like your site does in a browser — including navigation between pages.</p>
+	<p>Preview is one of three main panes, switched with <strong>View ▸ Preview / Editor / Graph</strong> (<kbd>⌘1</kbd>, <kbd>⌘2</kbd>, <kbd>⌘3</kbd>). Selecting a page or post in the Navigator sidebar always brings you back to Preview, since pages render rather than open as text — see <a href="direct-editing.html">Editing pages directly</a>.</p>
 
 	<figure>
 		<!-- alt: A live preview of a website displayed in the left panel of the Anglesite site window -->
@@ -29,6 +30,7 @@
 
 	<p class="related">
 		<strong>See also:</strong>
+		<a href="direct-editing.html">Editing pages directly</a>
 		<a href="editing-with-assistant.html">Editing with the assistant</a>
 		<a href="health-and-readiness.html">Health and deploy readiness</a>
 		<a href="../index.html">Help home</a>

--- a/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/settings.html
+++ b/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/settings.html
@@ -4,13 +4,13 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="robots" content="anchor">
-	<meta name="description" content="How to open Anglesite Settings and what you can manage there.">
+	<meta name="description" content="How to open Anglesite Settings and what each of its five tabs manages: General, Siri AI, Agents, iPhone/iPad, and Advanced.">
 	<title>Settings — Anglesite Help</title>
 	<link rel="stylesheet" href="../shrd/help.css">
 </head>
 <body>
 	<h1>Settings</h1>
-	<p class="lead">Settings is where you manage general preferences and review the status of your connected accounts.</p>
+	<p class="lead">Settings has five tabs: General, Siri AI, Agents, iPhone/iPad, and Advanced.</p>
 
 	<h2>Opening Settings</h2>
 	<ol>
@@ -23,11 +23,26 @@
 		<figcaption>Anglesite Settings.</figcaption>
 	</figure>
 
-	<p>From Settings you can manage your general preferences and see which accounts are connected. For details on connecting accounts, see <a href="accounts.html">Accounts and setup</a>.</p>
+	<h2>General</h2>
+	<p>Everyday toggles: auto-generating alt text for dropped images and description suggestions for new pages (both on-device, require Apple Intelligence), completion notifications for background operations, a dial-up sound effect while things load, and VoiceOver announcements for streaming chat and deploy progress.</p>
+
+	<h2>Siri AI</h2>
+	<p>A read-only checklist of whether this Mac can run Anglesite's Siri-driven workflows — macOS version, Apple Foundation Models availability, and App Intents/Shortcuts registration — with a Re-check button. Per-site Siri readiness has its own check under <strong>Website ▸ Siri AI Readiness…</strong>.</p>
+
+	<h2>Agents</h2>
+	<p>Chooses what powers the assistant chat panel: on-device Apple Intelligence (the default), a custom endpoint for any OpenAI-compatible chat API (hosted or self-hosted), or an agent you've connected over the Agent Client Protocol. Add, edit, or remove ACP agent connections here too. See <a href="editing-with-assistant.html">Editing with the assistant</a>.</p>
+
+	<h2>iPhone/iPad</h2>
+	<p>Pairs a companion iPhone or iPad with this Mac. See <a href="device-pairing.html">iPhone/iPad pairing</a>.</p>
+
+	<h2>Advanced</h2>
+	<p>Where to store new site packages, your GitHub and Cloudflare credentials (see <a href="accounts.html">Accounts and setup</a>), and Diagnostics — including the <strong>Show Debug Pane menu item</strong> toggle (see <a href="debug-pane.html">Debug pane and logs</a>).</p>
 
 	<p class="related">
 		<strong>See also:</strong>
 		<a href="accounts.html">Accounts and setup</a>
+		<a href="editing-with-assistant.html">Editing with the assistant</a>
+		<a href="device-pairing.html">iPhone/iPad pairing</a>
 		<a href="updates.html">Updating Anglesite</a>
 		<a href="../index.html">Help home</a>
 	</p>

--- a/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/sites.html
+++ b/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/sites.html
@@ -28,11 +28,13 @@
 	<p>Every site has its own window. To switch between open sites, use the <strong>Window</strong> menu or press <kbd>⌘`</kbd> to cycle through open windows.</p>
 
 	<h2>Creating a new site</h2>
-	<p>To create a new site, choose <strong>File ▸ New ▸ Site</strong>. Once set up, the site appears in the Sites window and you can open it from there.</p>
+	<p>To create a new site, choose <strong>File ▸ New Site…</strong> (<kbd>⇧⌘N</kbd>). This opens a short setup wizard; once it finishes, the new site appears in the Sites window and opens in its own window. You can also start one from the Sites window's <strong>Add Site ▸ Create new site…</strong> menu, or from Anglesite's Dock menu.</p>
+	<p>Already have a site's files somewhere else on disk? Use <strong>Add Site ▸ Import existing site…</strong> in the Sites window to bring it in without losing its history.</p>
 
 	<p class="related">
 		<strong>See also:</strong>
 		<a href="live-preview.html">Live preview</a>
+		<a href="direct-editing.html">Editing pages directly</a>
 		<a href="editing-with-assistant.html">Editing with the assistant</a>
 		<a href="../index.html">Help home</a>
 	</p>

--- a/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/troubleshooting.html
+++ b/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/troubleshooting.html
@@ -24,10 +24,17 @@
 	<h2>Where are my files?</h2>
 	<p>Your site is an ordinary folder on your Mac. You can open it in Finder at any time and work with the files directly in any app you like — Anglesite doesn't lock you in.</p>
 
+	<h2>Format menu commands are greyed out</h2>
+	<p>Format commands only act on a markdown or visual editor. They're disabled while the live preview, a plain text file, or nothing in particular has focus. See <a href="direct-editing.html">Editing pages directly</a>.</p>
+
+	<h2>I can't find a component or style file in the Navigator</h2>
+	<p>The Navigator currently lists pages, posts, and folders — not components or stylesheets. Use <strong>Search Site…</strong> (<kbd>⇧⌘F</kbd>) or the Graph pane (<kbd>⌘3</kbd>) to find and open one.</p>
+
 	<p class="related">
 		<strong>See also:</strong>
 		<a href="debug-pane.html">Debug pane and logs</a>
 		<a href="health-and-readiness.html">Health and deploy readiness</a>
+		<a href="direct-editing.html">Editing pages directly</a>
 		<a href="../index.html">Help home</a>
 	</p>
 </body>

--- a/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/website-settings.html
+++ b/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/website-settings.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="robots" content="anchor">
+	<meta name="description" content="What you can configure in Website Settings: site identity, analytics, redirects, licensing, email security, security reports, social accounts, and Workers.">
+	<title>Website settings — Anglesite Help</title>
+	<link rel="stylesheet" href="../shrd/help.css">
+</head>
+<body>
+	<h1>Website settings</h1>
+	<p class="lead">Website settings hold the site-wide configuration for your site — separate from the app's own Settings window.</p>
+
+	<h2>Opening Website settings</h2>
+	<p>Choose <strong>Website ▸ Website Settings…</strong> (<kbd>⇧⌘,</kbd>), or click the Website row at the top of the Navigator sidebar.</p>
+
+	<figure>
+		<!-- alt: The Website Settings sheet showing its row of tabs -->
+		<div class="screenshot-placeholder">Screenshot: Website Settings.</div>
+		<figcaption>Website Settings.</figcaption>
+	</figure>
+
+	<h2>What's in each tab</h2>
+	<ul>
+		<li><strong>Website</strong> — your site's title, language, and icons.</li>
+		<li><strong>Analytics</strong> — analytics provider setup and UTM codes.</li>
+		<li><strong>Redirects</strong> — URL redirects for your site.</li>
+		<li><strong>Licensing</strong> — the license your content is published under.</li>
+		<li><strong>Email Security</strong> — MTA-STS email security policy.</li>
+		<li><strong>Security Reports</strong> — where security researchers can report issues with your site.</li>
+		<li><strong>Social</strong> — linked social accounts, such as Bluesky.</li>
+		<li><strong>Workers</strong> — Cloudflare Worker configuration for your site.</li>
+	</ul>
+
+	<p class="related">
+		<strong>See also:</strong>
+		<a href="direct-editing.html">Editing pages directly</a>
+		<a href="deploying.html">Deploying your site</a>
+		<a href="accounts.html">Accounts and setup</a>
+		<a href="../index.html">Help home</a>
+	</p>
+</body>
+</html>

--- a/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/what-is-anglesite.html
+++ b/Resources/Anglesite.help/Contents/Resources/en.lproj/pages/what-is-anglesite.html
@@ -10,10 +10,10 @@
 </head>
 <body>
 	<h1>What is Anglesite?</h1>
-	<p class="lead">Anglesite is a native macOS app that gives your website a home — where you can preview it live, edit with an assistant, check it's ready, and deploy it.</p>
+	<p class="lead">Anglesite is a native macOS app that gives your website a home — where you can preview it live, edit it directly or with an assistant, check it's ready, and deploy it.</p>
 
 	<h2>A native home for your website</h2>
-	<p>Anglesite hosts the Anglesite site toolkit. Each site is a folder of files — a self-contained static website — that lives on your Mac. Open the app, pick a site, and you're looking at a live preview alongside a chat window where the assistant helps you make changes.</p>
+	<p>Anglesite hosts the Anglesite site toolkit. Each site is a folder of files — a self-contained static website — that lives on your Mac. Open the app, pick a site, and you're looking at a live preview with a Navigator sidebar for jumping between pages, and an optional chat panel where an assistant can help you make changes.</p>
 
 	<figure>
 		<!-- alt: The Anglesite site window with a live website preview on the left and an assistant chat panel on the right -->
@@ -27,7 +27,8 @@
 	<h2>What you can do here</h2>
 	<ul>
 		<li><strong>Preview your site live</strong> — see it running in the app exactly as visitors will see it.</li>
-		<li><strong>Edit with the assistant</strong> — describe what you want and Anglesite makes the changes.</li>
+		<li><strong>Edit pages directly</strong> — use the Navigator, Format and Page menus, and Inspector to change content and structure yourself.</li>
+		<li><strong>Edit with the assistant</strong> — describe what you want in chat and let it make the changes.</li>
 		<li><strong>Check readiness</strong> — Anglesite surfaces any issues before you publish.</li>
 		<li><strong>Deploy</strong> — send your site live when it's ready.</li>
 	</ul>
@@ -36,6 +37,7 @@
 		<strong>See also:</strong>
 		<a href="sites.html">Open and create sites</a>
 		<a href="live-preview.html">Live preview</a>
+		<a href="direct-editing.html">Editing pages directly</a>
 		<a href="../index.html">Help home</a>
 	</p>
 </body>


### PR DESCRIPTION
<!-- No issue closed by this PR — it's prep work for #619, not a resolution of it. -->

## Summary

- Fact-checked every Help Book page against `Sources/AnglesiteApp`/`Sources/AnglesiteCore` and fixed three stale claims: the New Site menu path, Cloudflare's account flow (OAuth sign-in first, manual token as fallback), and an incomplete keyboard-shortcuts list.
- Added coverage for what's shipped since the book was authored: direct editing (Navigator, Editor/Graph panes, Format/Page menus, Inspector), Website Settings, Agent Readiness, and the Agents/Siri AI/iPhone-iPad Settings tabs.
- Reframed assistant editing as a complementary mode alongside direct editing rather than the only editing path.
- Related to #619 (real screenshots + book icon) — this pass gets the copy accurate first so screenshots aren't captured against stale text.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `scripts/check-help-links.sh` — `OK: all help links resolve.`
- [x] `scripts/build-help-index.sh` — index rebuilds cleanly over all 19 pages.
- [x] Manual smoke: opened the landing page and several new/edited pages in a browser to confirm layout, `<kbd>` shortcuts, and links render correctly.
- [ ] `swift test --package-path .` / `xcodebuild ... build` — not run; this change touches only `Resources/Anglesite.help/` (no Swift sources, no `Resources/Template/`), so it isn't expected to affect either suite.