### PR TITLE
docs(#1597): Vouch protocol design spec + implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-08-20-vouch-trust-list.md
+++ b/docs/superpowers/plans/2026-08-20-vouch-trust-list.md
@@ -1,0 +1,1303 @@
+# Vouch trust-list fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the Vouch verification shipped in [davidwkeith/workers#505](https://github.com/davidwkeith/workers/pull/505) — it checks the wrong domain (target instead of source) and has no trust list, making the "Vouched" signal trivially forgeable — and give it a real trust list sourced from the site's existing blogroll.
+
+**Architecture:** Sidecar fix (new commit/PR on top of the already-merged #505): `verifyVouch` gains a required `isTrustedDomain` predicate, checked *before* any fetch, and matches the fetched vouch page against the **source's** hostname instead of the target's. `WebmentionConfig` gains an optional `isTrustedVouchDomain`, threaded through the queue consumer. App side: the trust list is the site's existing blogroll content collection, synced to the same `SOCIAL_KV` namespace `#1567` already provisions (new key `vouch:trusted-domains`) via a new Swift pair mirroring `ContactsAllowlistSync`/`ContactsAllowlistKVClient`, read at Worker request time by a new `worker/vouch-trust.ts` mirroring `reader-identity.ts`.
+
+**Tech Stack:** TypeScript (Cloudflare Workers, vitest + `@cloudflare/vitest-pool-workers`) for the sidecar package; Swift 6.4 (`AnglesiteCore`, Swift Testing) for the app; the same `worker/*.ts` TypeScript for the Worker-side read.
+
+Full design: [`docs/superpowers/specs/2026-08-20-vouch-webmention-design.md`](../specs/2026-08-20-vouch-webmention-design.md) — see "Bug found in review, and its fix."
+
+## Global Constraints
+
+- Sidecar repo (`davidwkeith/workers`): Node.js >= 22, pnpm 10 (`corepack enable`). Before any PR: `pnpm lint && pnpm format:check && pnpm typecheck && pnpm build && pnpm test` must pass.
+- Sidecar: every behavior change needs a colocated test in the package's `src/*.test.ts`.
+- **Do not manually bump `packages/webmention/package.json`'s version.** Confirmed the hard way on #505's review: version bumps come only from a dedicated `pnpm changeset version` release run per `RELEASING.md`, never hand-edited alongside feature work. Add a changeset only.
+- **Do not put a GitHub closing keyword (`Closes #1597`) in the sidecar PR** — #1597 is an Anglesite issue; reference it as plain text (`part of Anglesite/Anglesite#1597`) instead.
+- App repo (this one): macOS 27+ / Xcode 27+ (Swift 6.4). Run `swift test --package-path .` before opening the PR.
+- App repo: `npm test` inside `Resources/Template/` (or the narrower `npm run test:scripts`) covers `worker/*.test.ts`.
+- Conventional commits, subject <= 72 characters.
+- Both repos: additive-only. No existing field, column, or exported signature changes shape without a caller-visible reason — `verifyVouch`'s signature *does* change here (a new required parameter), which is the one deliberate exception in this plan, since the function is not yet used by any released version (only the just-merged, not-yet-published #505).
+
+---
+
+## Sidecar: `@dwk/webmention` (davidwkeith/workers)
+
+Base this work on `origin/main`, which now includes #505's merge commit (`461ef4e`). Do not build on the old `feat/vouch-webmention` branch — it's merged and its worktree (if still present at `.claude/worktrees/vouch-1597`) is stale; remove it if it still exists before starting (`git worktree remove` from the main checkout, after confirming it's not mid-use by another process).
+
+### Task 1: Rewrite `verifyVouch` — trust list first, source-domain match, full logging
+
+**Files:**
+- Create worktree: `<davidwkeith/workers checkout>/.claude/worktrees/vouch-trust-fix/` on a new branch `fix/vouch-trust-list` based on `origin/main`
+- Modify: `packages/webmention/src/verify.ts`
+- Test: `packages/webmention/src/verify.test.ts`
+
+**Interfaces:**
+- Produces: `verifyVouch(vouchUrl: string, source: string, isTrustedDomain: (hostname: string) => boolean | Promise<boolean>, options?: VerifyOptions): Promise<VouchResult>`. `VouchResult` is unchanged (`{ readonly verified: boolean }`).
+
+- [ ] **Step 1: Create the worktree**
+
+```bash
+cd <davidwkeith/workers checkout>
+git fetch origin main
+git worktree add .claude/worktrees/vouch-trust-fix -b fix/vouch-trust-list origin/main
+cd .claude/worktrees/vouch-trust-fix
+pnpm install
+pnpm build
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+In `packages/webmention/src/verify.test.ts`, find the existing `describe("verifyVouch", ...)` block (it currently calls `verifyVouch(vouchUrl, target, { fetch: fetchImpl })` with a 3rd positional `options` argument and no trust predicate). Replace the whole block with:
+
+```ts
+describe("verifyVouch", () => {
+  const vouchUrl = "https://vouches.example/for-me";
+  const alwaysTrusted = () => true;
+  const neverTrusted = () => false;
+
+  it("is verified true when the vouch domain is trusted and the page links to the source's host", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(`<a href="${source}">I trust this site</a>`, {
+          headers: { "content-type": "text/html" },
+        }),
+    );
+    expect(
+      await verifyVouch(vouchUrl, source, alwaysTrusted, { fetch: fetchImpl }),
+    ).toEqual({ verified: true });
+  });
+
+  it("is verified true for a link to a different path under the source's host", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('<a href="https://blog.example/somewhere-else">x</a>', {
+          headers: { "content-type": "text/html" },
+        }),
+    );
+    expect(
+      await verifyVouch(vouchUrl, source, alwaysTrusted, { fetch: fetchImpl }),
+    ).toEqual({ verified: true });
+  });
+
+  it("is verified false when the vouch domain is not trusted, and never fetches", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("must not be called");
+    });
+    expect(
+      await verifyVouch(vouchUrl, source, neverTrusted, { fetch: fetchImpl }),
+    ).toEqual({ verified: false });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("is verified false when a trusted vouch page links elsewhere", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('<a href="https://elsewhere.example/">x</a>', {
+          headers: { "content-type": "text/html" },
+        }),
+    );
+    expect(
+      await verifyVouch(vouchUrl, source, alwaysTrusted, { fetch: fetchImpl }),
+    ).toEqual({ verified: false });
+  });
+
+  it("is verified false for a 404 vouch page", async () => {
+    const fetchImpl = vi.fn(async () => new Response("gone", { status: 404 }));
+    expect(
+      await verifyVouch(vouchUrl, source, alwaysTrusted, { fetch: fetchImpl }),
+    ).toEqual({ verified: false });
+  });
+
+  it("is verified false when the fetch throws", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network");
+    });
+    expect(
+      await verifyVouch(vouchUrl, source, alwaysTrusted, { fetch: fetchImpl }),
+    ).toEqual({ verified: false });
+  });
+
+  it("is verified false for a non-HTML vouch page", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ref: source }), {
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    expect(
+      await verifyVouch(vouchUrl, source, alwaysTrusted, { fetch: fetchImpl }),
+    ).toEqual({ verified: false });
+  });
+
+  it("is verified false when isTrustedDomain itself throws", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("must not be called");
+    });
+    const throwing = () => {
+      throw new Error("KV read failed");
+    };
+    expect(
+      await verifyVouch(vouchUrl, source, throwing, { fetch: fetchImpl }),
+    ).toEqual({ verified: false });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+```
+
+Note this test file already declares `const source = "https://blog.example/post";` and
+`const target = "https://example.com/article";` near the top (shared across the file's other
+`describe` blocks) — reuse the existing `source` constant, don't redeclare it.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pnpm test --project @dwk/webmention -- -t "verifyVouch"`
+Expected: FAIL to compile — `verifyVouch` doesn't accept a 3rd `isTrustedDomain` argument yet (existing call sites pass an options object as the 3rd argument).
+
+- [ ] **Step 4: Implement**
+
+Replace the entire `verifyVouch` function in `packages/webmention/src/verify.ts` (it's the last
+thing in the file, right after `verifySource`) with:
+
+```ts
+/** Outcome of fetching and checking a Vouch URL. */
+export interface VouchResult {
+  /** Whether the vouch domain was trusted and its page links to the source's hostname. */
+  readonly verified: boolean;
+}
+
+/**
+ * Check whether `vouchUrl` establishes a Vouch trust chain (indieweb.org/Vouch) for `source`:
+ * the vouch URL's own domain must be one the receiver already trusts (`isTrustedDomain`), *and*
+ * the vouch page — once fetched — must link anywhere under the **source's** hostname (not the
+ * target's; per the spec, "the vouch ... contains a hyperlink to the domain used in source").
+ *
+ * The trust check runs first, before any network access: an untrusted vouch domain returns
+ * `{ verified: false }` immediately, with no fetch at all — this also bounds the fetch
+ * amplification an attacker-named vouch URL could otherwise cause (every verified mention would
+ * otherwise trigger a second outbound fetch to a URL the sender picked). Only a trusted domain's
+ * page is fetched, through the same SSRF-safe {@link safeFetch} wrapper {@link verifySource}
+ * uses. Matching is **hostname** equality via {@link extractLinks}, not {@link sourceLinksTo}'s
+ * exact-URL match — any link on the vouch page pointing anywhere under the source's host counts.
+ * Only HTML vouch pages are scanned. `isTrustedDomain` throwing, a fetch failure, non-2xx status,
+ * non-HTML response, or oversized/unreadable body all yield `{ verified: false }`; this function
+ * never throws.
+ */
+export async function verifyVouch(
+  vouchUrl: string,
+  source: string,
+  isTrustedDomain: (hostname: string) => boolean | Promise<boolean>,
+  options?: VerifyOptions,
+): Promise<VouchResult> {
+  const doFetch: FetchLike =
+    options?.fetch ?? ((input, init) => fetch(input, init));
+  const logger = options?.logger ?? noopLogger;
+  const metrics = options?.metrics ?? noopMetrics;
+
+  const record = (
+    verified: boolean,
+    reason:
+      | "untrusted-domain"
+      | "trust-check-failed"
+      | "invalid-vouch-url"
+      | "invalid-source"
+      | "fetch-failed"
+      | "not-ok"
+      | "not-html"
+      | "body-unreadable"
+      | "ok",
+  ): VouchResult => {
+    const fields = {
+      vouchHost: hostFromUrl(vouchUrl),
+      sourceHost: hostFromUrl(source),
+      verified,
+      reason,
+    };
+    logger.info(WebmentionLogEvent.VouchVerified, fields);
+    metrics.count(WebmentionLogEvent.VouchVerified, fields);
+    return { verified };
+  };
+
+  let vouchHost: string;
+  try {
+    vouchHost = new URL(vouchUrl).hostname.toLowerCase();
+  } catch {
+    return record(false, "invalid-vouch-url");
+  }
+
+  let sourceHost: string;
+  try {
+    sourceHost = new URL(source).hostname.toLowerCase();
+  } catch {
+    return record(false, "invalid-source");
+  }
+
+  let trusted: boolean;
+  try {
+    trusted = await isTrustedDomain(vouchHost);
+  } catch {
+    return record(false, "trust-check-failed");
+  }
+  if (!trusted) {
+    return record(false, "untrusted-domain");
+  }
+
+  let response: Response;
+  let base: string;
+  try {
+    const result = await safeFetch(
+      doFetch,
+      vouchUrl,
+      { method: "GET", headers: { accept: "text/html, */*" } },
+      {
+        logger,
+        metrics,
+        logEvent: WebmentionLogEvent.SsrfBlocked,
+        allowedHosts: options?.fetchAllowedHosts,
+      },
+    );
+    response = result.response;
+    base = result.url;
+  } catch {
+    return record(false, "fetch-failed");
+  }
+
+  if (!response.ok) {
+    return record(false, "not-ok");
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!isHtmlContentType(contentType)) {
+    return record(false, "not-html");
+  }
+
+  const body = await readBodyCapped(response);
+  if (body === null) {
+    return record(false, "body-unreadable");
+  }
+
+  const links = await extractLinks(body, base);
+  const verified = links.some((link) => {
+    try {
+      return new URL(link).hostname.toLowerCase() === sourceHost;
+    } catch {
+      return false;
+    }
+  });
+
+  return record(verified, "ok");
+}
+```
+
+In `packages/webmention/src/log.ts`, update the `VouchVerified` doc comment (it currently says
+`Fields: verified`):
+
+```ts
+  /** Vouch verification finished (every exit path). Fields: `verified`, `reason`. */
+  VouchVerified: "webmention.vouch.verified",
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm test --project @dwk/webmention -- -t "verifyVouch"`
+Expected: PASS
+
+- [ ] **Step 6: Run the full package gate and commit**
+
+```bash
+pnpm --filter @dwk/webmention typecheck
+pnpm --filter @dwk/webmention build
+pnpm test --project @dwk/webmention
+git add packages/webmention/src/verify.ts packages/webmention/src/verify.test.ts packages/webmention/src/log.ts
+git commit -m "fix(webmention): vouch trust list, match source not target"
+```
+
+**Note:** `pnpm --filter @dwk/webmention typecheck`/`build` will fail after this step until Task 2 updates the one call site in `index.ts` — that's expected; Task 2 fixes it. If you want a green gate at every commit, do Task 1's and Task 2's implementation steps together before running the gate the first time; either way, land them as two separate commits per the steps above (they have independent test coverage and review value).
+
+---
+
+### Task 2: `WebmentionConfig.isTrustedVouchDomain` + queue consumer wiring
+
+**Files:**
+- Modify: `packages/webmention/src/index.ts`
+- Test: `packages/webmention/src/index.test.ts`
+
+**Interfaces:**
+- Consumes: `verifyVouch(vouchUrl, source, isTrustedDomain, options?)` (Task 1).
+- Produces: `WebmentionConfig.isTrustedVouchDomain?: (hostname: string) => boolean | Promise<boolean>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/webmention/src/index.test.ts`, inside `describe("createWebmentionQueueConsumer", ...)`, the existing vouch tests build their `fetchImpl` branching on the vouch URL vs. the source URL and assert on `stored?.vouch`. Add `isTrustedVouchDomain: () => true` to `config` in the two tests that expect a vouch outcome, and add three new tests:
+
+```ts
+  it("does not verify vouch when isTrustedVouchDomain is not configured (defaults to always-untrusted)", async () => {
+    const inbox = new MemoryInbox();
+    const fetchedUrls: string[] = [];
+    const fetchImpl: FetchLike = vi.fn(async (input) => {
+      fetchedUrls.push(String(input));
+      return new Response('<a href="https://example.com/article">x</a>', {
+        headers: { "content-type": "text/html" },
+      });
+    });
+    const consumer = createWebmentionQueueConsumer({
+      ...config,
+      inbox,
+      fetch: fetchImpl,
+      // isTrustedVouchDomain intentionally omitted
+    });
+    const { batch } = batchOf([
+      {
+        source: "https://other.example/p",
+        target: "https://example.com/article",
+        vouch: "https://vouches.example/for-me",
+      },
+    ]);
+    await consumer(batch, {} as WebmentionEnv, ctx);
+
+    const [stored] = await inbox.list();
+    expect(stored?.vouch).toEqual({
+      url: "https://vouches.example/for-me",
+      verified: false,
+    });
+    // The vouch URL itself must never be fetched when it's untrusted (Task 1's contract) —
+    // only the source URL should appear.
+    expect(fetchedUrls).toEqual(["https://other.example/p"]);
+  });
+
+  it("verifies vouch against the source's domain, not the target's", async () => {
+    const inbox = new MemoryInbox();
+    const fetchImpl: FetchLike = vi.fn(async (input) => {
+      const url = String(input);
+      if (url === "https://vouches.example/for-me") {
+        // Links to the SOURCE, not the target — this must verify true only because
+        // isTrustedVouchDomain is configured and the match is against source.
+        return new Response(
+          '<a href="https://other.example/p">I trust this sender</a>',
+          { headers: { "content-type": "text/html" } },
+        );
+      }
+      return new Response('<a href="https://example.com/article">x</a>', {
+        headers: { "content-type": "text/html" },
+      });
+    });
+    const consumer = createWebmentionQueueConsumer({
+      ...config,
+      inbox,
+      fetch: fetchImpl,
+      isTrustedVouchDomain: () => true,
+    });
+    const { batch } = batchOf([
+      {
+        source: "https://other.example/p",
+        target: "https://example.com/article",
+        vouch: "https://vouches.example/for-me",
+      },
+    ]);
+    await consumer(batch, {} as WebmentionEnv, ctx);
+
+    const [stored] = await inbox.list();
+    expect(stored?.vouch).toEqual({
+      url: "https://vouches.example/for-me",
+      verified: true,
+    });
+  });
+
+  it("passes the vouch URL's hostname to isTrustedVouchDomain", async () => {
+    const inbox = new MemoryInbox();
+    const seenHostnames: string[] = [];
+    const fetchImpl: FetchLike = vi.fn(
+      async () =>
+        new Response('<a href="https://other.example/p">x</a>', {
+          headers: { "content-type": "text/html" },
+        }),
+    );
+    const consumer = createWebmentionQueueConsumer({
+      ...config,
+      inbox,
+      fetch: fetchImpl,
+      isTrustedVouchDomain: (hostname) => {
+        seenHostnames.push(hostname);
+        return true;
+      },
+    });
+    const { batch } = batchOf([
+      {
+        source: "https://other.example/p",
+        target: "https://example.com/article",
+        vouch: "https://vouches.example/for-me",
+      },
+    ]);
+    await consumer(batch, {} as WebmentionEnv, ctx);
+
+    expect(seenHostnames).toEqual(["vouches.example"]);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm test --project @dwk/webmention -- -t "vouch"`
+Expected: FAIL — `createWebmentionQueueConsumer` still calls `verifyVouch(vouch, target, {...})`
+(2-arg-plus-options, matching Task 1's old signature), which no longer typechecks against Task
+1's 4-parameter `verifyVouch`. Confirm the compile error names `isTrustedDomain` as a missing
+argument.
+
+- [ ] **Step 3: Implement**
+
+In `packages/webmention/src/index.ts`, add to `WebmentionConfig` (after `fetchAllowedHosts`):
+
+```ts
+  /**
+   * Whether a vouch URL's own hostname is one this receiver already trusts (indieweb.org/Vouch)
+   * — checked before any vouch page is fetched. Omitted entirely means "nothing is trusted yet"
+   * (every vouch verifies false, but the mention itself is unaffected — vouch is only ever a
+   * bonus signal on top of source→target verification, never a gate on it), not "everything is
+   * trusted." See {@link verifyVouch} in `verify.ts`.
+   */
+  readonly isTrustedVouchDomain?: (
+    hostname: string,
+  ) => boolean | Promise<boolean>;
+```
+
+In `createWebmentionQueueConsumer`, change the `vouchOutcome` computation (inside the
+`if (result.links) { ... }` block) from:
+
+```ts
+          const vouchOutcome =
+            vouch !== undefined
+              ? {
+                  url: vouch,
+                  verified: (
+                    await verifyVouch(vouch, target, {
+                      fetch: config.fetch,
+                      logger,
+                      metrics,
+                      fetchAllowedHosts: config.fetchAllowedHosts,
+                    })
+                  ).verified,
+                }
+              : undefined;
+```
+
+to:
+
+```ts
+          const vouchOutcome =
+            vouch !== undefined
+              ? {
+                  url: vouch,
+                  verified: (
+                    await verifyVouch(
+                      vouch,
+                      source,
+                      config.isTrustedVouchDomain ?? (() => false),
+                      {
+                        fetch: config.fetch,
+                        logger,
+                        metrics,
+                        fetchAllowedHosts: config.fetchAllowedHosts,
+                      },
+                    )
+                  ).verified,
+                }
+              : undefined;
+```
+
+(Only the `target` → `source` argument and the new third `isTrustedDomain` argument change —
+everything else in this block is untouched.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm test --project @dwk/webmention -- -t "vouch"`
+Expected: PASS
+
+- [ ] **Step 5: Run the full package gate and commit**
+
+```bash
+pnpm --filter @dwk/webmention typecheck
+pnpm --filter @dwk/webmention build
+pnpm test --project @dwk/webmention
+git add packages/webmention/src/index.ts packages/webmention/src/index.test.ts
+git commit -m "fix(webmention): thread isTrustedVouchDomain through the queue consumer"
+```
+
+---
+
+### Task 3: Changeset, full repo gate, PR
+
+**Files:**
+- Create: `.changeset/webmention-vouch-trust-list.md`
+
+- [ ] **Step 1: Add the changeset**
+
+```bash
+cat > .changeset/webmention-vouch-trust-list.md <<'EOF'
+---
+"@dwk/webmention": patch
+---
+
+Fix Vouch verification (indieweb.org/Vouch), shipped in the prior `minor` release with two
+bugs: it matched the vouch page against the **target's** domain instead of the **source's**,
+and had no trust list at all — meaning `vouch=<the source URL itself>` verified unconditionally
+once `verifySource` had already proven that link exists. `verifyVouch` now takes a required
+`isTrustedDomain` predicate, checked before any fetch (an untrusted vouch domain returns
+`verified: false` with no network access at all, closing a fetch-amplification side issue too),
+and matches the fetched page against the source's hostname. `WebmentionConfig` gains an
+optional `isTrustedVouchDomain`; omitted, every vouch verifies false rather than defaulting to
+trusted. `VouchVerified` now logs on every exit path (`reason` field), not only the one that
+reaches the link check. Part of Anglesite/Anglesite#1597.
+EOF
+```
+
+(`patch`, not `minor` — this corrects the previous release's behavior rather than adding new
+surface, even though `verifyVouch`'s exported signature does change; the package is still
+prerelease (`1.0.0-beta.N`), where changeset semver bumps are advisory ordering rather than a
+stability promise to external consumers.)
+
+- [ ] **Step 2: Run the full repo gate**
+
+```bash
+pnpm lint && pnpm format:check && pnpm typecheck && pnpm build && pnpm test
+```
+
+Expected: all green. Fix any failure before proceeding — do not skip a failing check.
+
+- [ ] **Step 3: Commit, push, open the PR**
+
+```bash
+git add .changeset/webmention-vouch-trust-list.md
+git commit -m "fix(webmention): add changeset for vouch trust-list fix"
+git push -u origin fix/vouch-trust-list
+```
+
+Confirm with the user before running `gh pr create` (pushing/opening a PR needs explicit
+confirmation per the standing safety rules). Once confirmed, open the PR against
+`davidwkeith/workers` main, referencing the bug found in review of
+[Anglesite/Anglesite#1604](https://github.com/Anglesite/Anglesite/pull/1604) and linking back
+to [#505](https://github.com/davidwkeith/workers/pull/505) as the PR this corrects. Body
+includes `part of Anglesite/Anglesite#1597` — no closing keyword.
+
+**Do not proceed to Task 4 until this PR has merged and a tagged `@dwk/webmention` release
+containing both #505 and this fix is published to npm** — the Anglesite-side plan
+(`docs/superpowers/plans/2026-08-20-vouch-webmention.md`, Task 6) bumps the dependency on that
+exact published version. Tasks 4–6 below (the Anglesite-side blogroll-trust-list pieces) have
+no dependency on this sidecar release, though, and can proceed in parallel if useful — only the
+*original* plan's Task 6 (which reads `vouch_url`/`vouch_verified` from D1) is gated on it.
+
+---
+
+## App side (Anglesite/Anglesite)
+
+### Task 4: `BlogrollTrustKVClient.swift`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/BlogrollTrustKVClient.swift`
+- Test: `Tests/AnglesiteCoreTests/BlogrollTrustKVClientTests.swift`
+
+**Interfaces:**
+- Produces: `BlogrollTrustKVClient.putTrustedDomains(_ domains: Set<String>) async throws`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/BlogrollTrustKVClientTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct BlogrollTrustKVClientTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://api.cloudflare.com/")!, statusCode: status,
+                         httpVersion: nil, headerFields: nil)!
+    }
+
+    @Test("putTrustedDomains PUTs a sorted JSON array to the vouch:trusted-domains key")
+    func putsSortedArray() async throws {
+        let captured = CapturedRequest()
+        let client = BlogrollTrustKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { request in
+                await captured.set(request)
+                return (Data(), Self.response(200))
+            })
+
+        try await client.putTrustedDomains(["bob.example", "alice.example"])
+
+        let request = await captured.value
+        #expect(request?.httpMethod == "PUT")
+        #expect(request?.url?.path.hasSuffix("/values/vouch:trusted-domains") == true)
+        #expect(request?.value(forHTTPHeaderField: "Authorization") == "Bearer token")
+        let body = try #require(await captured.body)
+        let decoded = try JSONDecoder().decode([String].self, from: body)
+        #expect(decoded == ["alice.example", "bob.example"])
+    }
+
+    @Test("putTrustedDomains succeeds with an empty set (empty blogroll)")
+    func putsEmptySet() async throws {
+        let captured = CapturedRequest()
+        let client = BlogrollTrustKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { request in
+                await captured.set(request)
+                return (Data(), Self.response(200))
+            })
+
+        try await client.putTrustedDomains([])
+
+        let body = try #require(await captured.body)
+        let decoded = try JSONDecoder().decode([String].self, from: body)
+        #expect(decoded.isEmpty)
+    }
+
+    @Test("throws unauthorized on a 401/403 response")
+    func throwsUnauthorized() async {
+        let client = BlogrollTrustKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "bad",
+            transport: { _ in (Data(), Self.response(403)) })
+        await #expect(throws: CloudflareError.unauthorized) {
+            try await client.putTrustedDomains(["alice.example"])
+        }
+    }
+
+    @Test("throws http(status:) on any other non-2xx response")
+    func throwsHTTPError() async {
+        let client = BlogrollTrustKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { _ in (Data(), Self.response(500)) })
+        await #expect(throws: CloudflareError.http(status: 500)) {
+            try await client.putTrustedDomains(["alice.example"])
+        }
+    }
+}
+
+private actor CapturedRequest {
+    private(set) var value: URLRequest?
+    var body: Data? { value?.httpBody }
+    func set(_ request: URLRequest) { value = request }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter BlogrollTrustKVClientTests`
+Expected: FAIL to compile — `BlogrollTrustKVClient` doesn't exist yet.
+
+- [ ] **Step 3: Implement**
+
+Create `Sources/AnglesiteCore/BlogrollTrustKVClient.swift` — a straight copy of
+`ContactsAllowlistKVClient.swift` with the type renamed and the key changed:
+
+```swift
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Cloudflare Workers KV client for the Vouch trust-list push (#1597). Writes the site's
+/// blogroll domains (`BlogrollTrustSync`) as a single JSON array under `vouch:trusted-domains`
+/// in the already-provisioned `SOCIAL_KV` namespace — `worker/vouch-trust.ts` reads this key
+/// from the Worker side to gate Vouch verification. Follows the same injectable-transport DI
+/// pattern as `ContactsAllowlistKVClient`/`InboxKVClient` — no Keychain coupling, token passed
+/// in at init.
+public struct BlogrollTrustKVClient: Sendable {
+    private static let key = "vouch:trusted-domains"
+
+    private let baseURL: String
+    private let accountID: String
+    private let namespaceID: String
+    private let apiToken: String
+    private let transport: CloudflareTransport
+
+    public init(
+        accountID: String,
+        namespaceID: String,
+        apiToken: String,
+        baseURL: String = "https://api.cloudflare.com/client/v4",
+        transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
+    ) {
+        self.accountID = accountID
+        self.namespaceID = namespaceID
+        self.apiToken = apiToken
+        self.baseURL = baseURL
+        self.transport = transport
+    }
+
+    /// Replaces the whole `vouch:trusted-domains` value with `domains`, sorted for a
+    /// deterministic request body. Whole-set replace, not an incremental add/remove — the
+    /// caller (`BlogrollTrustSync`) always supplies the complete current blogroll domain set, so
+    /// this single call doubles as both "push on change" and "reconcile."
+    public func putTrustedDomains(_ domains: Set<String>) async throws {
+        let body = try JSONEncoder().encode(domains.sorted())
+        let valueURLString = "\(baseURL)/accounts/\(accountID)/storage/kv/namespaces/\(namespaceID)/values/\(Self.key)"
+        guard let url = URL(string: valueURLString) else { throw CloudflareError.malformedResponse }
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+        let (_, http) = try await transport(request)
+        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
+        guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter BlogrollTrustKVClientTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/BlogrollTrustKVClient.swift Tests/AnglesiteCoreTests/BlogrollTrustKVClientTests.swift
+git commit -m "feat(#1597): add BlogrollTrustKVClient"
+```
+
+---
+
+### Task 5: `BlogrollTrustSync.swift` + wire into deploy
+
+**Files:**
+- Create: `Sources/AnglesiteCore/BlogrollTrustSync.swift`
+- Test: `Tests/AnglesiteCoreTests/BlogrollTrustSyncTests.swift`
+- Modify: `Sources/AnglesiteCore/OperationProgress.swift`
+- Modify: `Sources/AnglesiteCore/DeployCoordinator.swift`
+- Modify: `Sources/AnglesiteApp/DeployModel.swift`
+
+**Interfaces:**
+- Consumes: `BlogrollTrustKVClient.putTrustedDomains(_:)` (Task 4); `BlogrollPlan.build(projectRoot:) -> BlogrollPlan.Plan` (already exists — `Sources/AnglesiteCore/BlogrollPlan.swift`; each `Plan.entries[].url: URL`).
+- Produces: `BlogrollTrustSync.push(entries: [BlogrollPlan.Entry], client: BlogrollTrustKVClient) async`; `BlogrollTrustSync.pushIfConfigured(siteDirectory: URL, configDirectory: URL, secretStore:, baseURL:, transport:) async`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/BlogrollTrustSyncTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct BlogrollTrustSyncTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://api.cloudflare.com/")!, statusCode: status,
+                         httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func makeSiteDirectory() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("blogroll-trust-sync-\(UUID().uuidString)", isDirectory: true)
+        let blogrollDir = dir.appendingPathComponent("src/content/blogroll", isDirectory: true)
+        try FileManager.default.createDirectory(at: blogrollDir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private static func writeEntry(name: String, url: String, in siteDirectory: URL) throws {
+        let content = """
+        ---
+        name: \(name)
+        url: \(url)
+        addedDate: 2026-08-01
+        ---
+        """
+        let file = siteDirectory.appendingPathComponent("src/content/blogroll/\(name).md")
+        try content.write(to: file, atomically: true, encoding: .utf8)
+    }
+
+    @Test("push extracts hostnames from blogroll entries and forwards them to the client")
+    func pushForwardsHostnames() async throws {
+        let siteDirectory = try Self.makeSiteDirectory()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        try Self.writeEntry(name: "alice", url: "https://alice.example/", in: siteDirectory)
+        try Self.writeEntry(name: "bob", url: "https://bob.example/blog", in: siteDirectory)
+        let plan = BlogrollPlan.build(projectRoot: siteDirectory)
+
+        let captured = CapturedURLs()
+        let client = BlogrollTrustKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { request in
+                if let body = request.httpBody, let domains = try? JSONDecoder().decode([String].self, from: body) {
+                    await captured.set(domains)
+                }
+                return (Data(), Self.response(200))
+            })
+
+        await BlogrollTrustSync.push(entries: plan.entries, client: client)
+
+        #expect(await captured.value == ["alice.example", "bob.example"])
+    }
+
+    @Test("push dedupes multiple entries on the same host")
+    func pushDedupesHosts() async throws {
+        let siteDirectory = try Self.makeSiteDirectory()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        try Self.writeEntry(name: "alice-posts", url: "https://alice.example/posts", in: siteDirectory)
+        try Self.writeEntry(name: "alice-notes", url: "https://alice.example/notes", in: siteDirectory)
+        let plan = BlogrollPlan.build(projectRoot: siteDirectory)
+
+        let captured = CapturedURLs()
+        let client = BlogrollTrustKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { request in
+                if let body = request.httpBody, let domains = try? JSONDecoder().decode([String].self, from: body) {
+                    await captured.set(domains)
+                }
+                return (Data(), Self.response(200))
+            })
+
+        await BlogrollTrustSync.push(entries: plan.entries, client: client)
+
+        #expect(await captured.value == ["alice.example"])
+    }
+
+    @Test("push sends an empty array for an empty blogroll, not a no-op")
+    func pushSendsEmptyArray() async throws {
+        let siteDirectory = try Self.makeSiteDirectory()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let plan = BlogrollPlan.build(projectRoot: siteDirectory)
+        #expect(plan.entries.isEmpty)
+
+        let captured = CapturedURLs()
+        let client = BlogrollTrustKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { request in
+                if let body = request.httpBody, let domains = try? JSONDecoder().decode([String].self, from: body) {
+                    await captured.set(domains)
+                }
+                return (Data(), Self.response(200))
+            })
+
+        await BlogrollTrustSync.push(entries: plan.entries, client: client)
+
+        #expect(await captured.value == [])
+    }
+
+    @Test("push logs and does not throw when the client fails")
+    func pushSwallowsClientFailure() async throws {
+        let siteDirectory = try Self.makeSiteDirectory()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        try Self.writeEntry(name: "alice", url: "https://alice.example/", in: siteDirectory)
+        let plan = BlogrollPlan.build(projectRoot: siteDirectory)
+        let client = BlogrollTrustKVClient(
+            accountID: "acct1", namespaceID: "ns1", apiToken: "token",
+            transport: { _ in (Data(), Self.response(500)) })
+
+        await BlogrollTrustSync.push(entries: plan.entries, client: client)
+    }
+
+    @Test("pushIfConfigured no-ops (no network call) when SOCIAL_KV has not been provisioned")
+    func noOpsWithoutKVNamespace() async throws {
+        let siteDirectory = try Self.makeSiteDirectory()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let configDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("blogroll-trust-sync-config-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configDir) }
+
+        await BlogrollTrustSync.pushIfConfigured(
+            siteDirectory: siteDirectory,
+            configDirectory: configDir,
+            secretStore: FakeSecretStore(token: "unused"),
+            transport: { _ in
+                Issue.record("transport must not be called with no provisioned SOCIAL_KV namespace")
+                struct UnexpectedNetworkCall: Error {}
+                throw UnexpectedNetworkCall()
+            })
+    }
+
+    @Test("pushIfConfigured resolves the account id and pushes the current blogroll domains")
+    func resolvesAccountAndPushes() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimClear()
+        defer { cfToken.release() }
+        let siteDirectory = try Self.makeSiteDirectory()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        try Self.writeEntry(name: "alice", url: "https://alice.example/", in: siteDirectory)
+        let configDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("blogroll-trust-sync-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        try await SiteConfigStore(configDirectory: configDir).save(
+            SiteSettings(provisionedWorkerResources: .init(kvNamespaceID: "ns1")))
+
+        let accountsBody = Data("""
+        {"success": true, "result": [{"id": "acct1"}]}
+        """.utf8)
+        let capturedPUT = CapturedURLs()
+
+        await BlogrollTrustSync.pushIfConfigured(
+            siteDirectory: siteDirectory,
+            configDirectory: configDir,
+            secretStore: FakeSecretStore(token: "token"),
+            transport: { request in
+                if request.url!.path.hasSuffix("/accounts") { return (accountsBody, Self.response(200)) }
+                if request.url!.path.hasSuffix("/values/vouch:trusted-domains") {
+                    if let body = request.httpBody, let domains = try? JSONDecoder().decode([String].self, from: body) {
+                        await capturedPUT.set(domains)
+                    }
+                    return (Data(), Self.response(200))
+                }
+                return (Data(), Self.response(404))
+            })
+
+        #expect(await capturedPUT.value == ["alice.example"])
+    }
+}
+
+private struct FakeSecretStore: SecretStore {
+    let token: String?
+    func read(account: String) throws -> String? { account == SecretAccounts.cloudflareToken ? token : nil }
+    func write(_ value: String, account: String) throws {}
+    func delete(account: String) throws {}
+}
+
+private actor CapturedURLs {
+    private(set) var value: [String]?
+    func set(_ urls: [String]) { value = urls }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter BlogrollTrustSyncTests`
+Expected: FAIL to compile — `BlogrollTrustSync` doesn't exist yet.
+
+- [ ] **Step 3: Implement**
+
+Create `Sources/AnglesiteCore/BlogrollTrustSync.swift`:
+
+```swift
+import Foundation
+
+/// Pushes the site's blogroll domains (`BlogrollPlan.build(projectRoot:)`) to the Worker's
+/// `SOCIAL_KV` store under `vouch:trusted-domains` (#1597) — the Vouch trust list. Deploy-time
+/// only (unlike `ContactsAllowlistSync`, no immediate-on-edit trigger): the list doesn't need
+/// real-time freshness, and this avoids hooking every blogroll-editing code path. Both the
+/// deploy trigger and this whole-set-replace `push` make `src/content/blogroll/` the always-
+/// authoritative source: there's no diffing, only an unconditional overwrite, so a missed push
+/// self-heals on the next deploy.
+public enum BlogrollTrustSync {
+    /// Extracts each entry's hostname, deduplicates, and replaces `client`'s
+    /// `vouch:trusted-domains` value with the result. An empty blogroll still pushes an empty
+    /// array — never skipped — so removing every entry actually clears the trust list rather
+    /// than leaving a stale one in place. Never throws — a failure (network, auth,
+    /// provisioning) is logged and otherwise invisible; the next deploy retries with the
+    /// current state.
+    public static func push(entries: [BlogrollPlan.Entry], client: BlogrollTrustKVClient) async {
+        do {
+            let domains = Set(entries.compactMap { $0.url.host })
+            try await client.putTrustedDomains(domains)
+        } catch {
+            await LogCenter.shared.append(
+                source: "BlogrollTrustSync", stream: .stderr,
+                text: "Failed to push blogroll trust list to SOCIAL_KV: \(error). Will retry on "
+                    + "the next deploy.")
+        }
+    }
+
+    /// Reads the site's `SiteSettings` and Cloudflare API token from `secretStore`; no-ops (no
+    /// network call) unless `SOCIAL_KV` has been provisioned
+    /// (`provisionedWorkerResources.kvNamespaceID`) and a token is available. `siteDirectory` is
+    /// the package's `Source/` directory (`AnglesitePackage.sourceURL`) — `BlogrollPlan` reads
+    /// blogroll entries from there; `configDirectory` is the sibling `Config/` directory.
+    public static func pushIfConfigured(
+        siteDirectory: URL,
+        configDirectory: URL,
+        secretStore: any SecretStore = PlatformSecretStore.make(),
+        baseURL: String = "https://api.cloudflare.com/client/v4",
+        transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
+    ) async {
+        guard let settings = try? SiteConfigStore.read(from: configDirectory),
+              let namespaceID = settings.provisionedWorkerResources?.kvNamespaceID, !namespaceID.isEmpty
+        else { return }
+        guard let token = try? await CloudflareAPICredentials.resolve(secretStore: secretStore), !token.isEmpty
+        else { return }
+        guard let accountID = await CloudflareAccountLookup.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
+        else { return }
+
+        let plan = BlogrollPlan.build(projectRoot: siteDirectory)
+        let client = BlogrollTrustKVClient(
+            accountID: accountID, namespaceID: namespaceID, apiToken: token, baseURL: baseURL, transport: transport)
+        await push(entries: plan.entries, client: client)
+    }
+}
+```
+
+Check the exact signature `SiteConfigStore.read(from:)` uses in `ContactsAllowlistSync.swift`
+(`try? SiteConfigStore.read(from: configDirectory)`) before assuming it — if `SiteConfigStore`
+in this codebase actually only exposes an instance `load()` (as used elsewhere in
+`DeployModel.swift`: `SiteConfigStore(configDirectory: configDirectory).load()`), match
+whichever form `ContactsAllowlistSync.swift` itself uses verbatim, since this type is a direct
+copy of that file's pattern.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter BlogrollTrustSyncTests`
+Expected: PASS
+
+- [ ] **Step 5: Wire into the deploy pipeline**
+
+In `Sources/AnglesiteCore/OperationProgress.swift`, add a new milestone right after
+`deployPushingContactsAllowlist`:
+
+```swift
+    /// Post-deploy: pushing the blogroll's domains to the Vouch trust list's backing store
+    /// (#1597).
+    static let deployPushingVouchTrustList = OperationProgress(
+        kind: .deploy, phase: "vouchTrustListPush", label: "Syncing Vouch trust list…"
+    )
+```
+
+In `Sources/AnglesiteCore/DeployCoordinator.swift`, `runPostDeploySequencing` gains an eighth
+pass. Update the doc comment's "seven post-deploy passes" to "eight," add
+`pushVouchTrustList` after `pushContactsAllowlist`, and call it:
+
+```swift
+        pushContactsAllowlist: () async -> Void = {},
+        /// Vouch trust-list push (#1597): pushes the site's current blogroll domains to the
+        /// site's remote store. Ordered last, alongside contacts-allowlist push — unrelated to
+        /// every other pass here, and (like contacts) a reconcile that only needs to run once
+        /// per deploy. Best-effort and never throws, like every other step here. Callers
+        /// without a blogroll/SOCIAL_KV configured pass a no-op.
+        pushVouchTrustList: () async -> Void = {}
+    ) async {
+        onMilestone(.deployWebmentions)
+        await sendWebmentions()
+        onMilestone(.deployStandardSitePublishing)
+        await publishStandardSite()
+        onMilestone(.deployStandardSiteGraphPublishing)
+        await publishStandardSiteGraph()
+        onMilestone(.deploySyndicating)
+        await syndicate()
+        onMilestone(.deployNotifyingSubscribers)
+        await notifySubscribers()
+        onMilestone(.deployBackfillingActivityPub)
+        await backfillActivityPubOutbox()
+        onMilestone(.deployPushingContactsAllowlist)
+        await pushContactsAllowlist()
+        onMilestone(.deployPushingVouchTrustList)
+        await pushVouchTrustList()
+    }
+}
+```
+
+In `Sources/AnglesiteApp/DeployModel.swift`, find the call site that passes
+`pushContactsAllowlist:` (search for `ContactsAllowlistSync.pushIfConfigured`) and add a sibling
+parameter right after it:
+
+```swift
+                pushContactsAllowlist: { [weak self] in
+                    guard let self else { return }
+                    await ContactsAllowlistSync.pushIfConfigured(
+                        configDirectory: configDirectory, secretStore: self.keychain
+                    )
+                },
+                pushVouchTrustList: { [weak self] in
+                    guard let self else { return }
+                    await BlogrollTrustSync.pushIfConfigured(
+                        siteDirectory: siteDirectory, configDirectory: configDirectory, secretStore: self.keychain
+                    )
+                }
+```
+
+(`siteDirectory` is already in scope at this call site — it's used a few lines earlier for
+`backfillActivityPubOutbox`'s `siteDirectory: siteDirectory` argument.)
+
+- [ ] **Step 6: Run the full Swift suite and commit**
+
+```bash
+swift test --package-path .
+git add Sources/AnglesiteCore/BlogrollTrustSync.swift Tests/AnglesiteCoreTests/BlogrollTrustSyncTests.swift \
+  Sources/AnglesiteCore/OperationProgress.swift Sources/AnglesiteCore/DeployCoordinator.swift \
+  Sources/AnglesiteApp/DeployModel.swift
+git commit -m "feat(#1597): sync blogroll domains to the Vouch trust list on deploy"
+```
+
+---
+
+### Task 6: `worker/vouch-trust.ts` + wire into `worker.ts`
+
+**Files:**
+- Create: `Resources/Template/worker/vouch-trust.ts`
+- Test: `Resources/Template/worker/vouch-trust.test.ts`
+- Modify: `Resources/Template/worker/worker.ts`
+
+**Interfaces:**
+- Produces: `isTrustedVouchDomain(env: VouchTrustEnv, hostname: string): Promise<boolean>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Resources/Template/worker/vouch-trust.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { isTrustedVouchDomain } from "./vouch-trust.ts";
+
+describe("isTrustedVouchDomain", () => {
+  it("is true when the hostname is in the pushed trust list", async () => {
+    const env = { SOCIAL_KV: { get: async () => JSON.stringify(["alice.example", "bob.example"]) } };
+    expect(await isTrustedVouchDomain(env, "alice.example")).toBe(true);
+  });
+
+  it("is false when the hostname is not in the list", async () => {
+    const env = { SOCIAL_KV: { get: async () => JSON.stringify(["alice.example"]) } };
+    expect(await isTrustedVouchDomain(env, "carol.example")).toBe(false);
+  });
+
+  it("is false when SOCIAL_KV is not bound", async () => {
+    const env = {};
+    expect(await isTrustedVouchDomain(env, "alice.example")).toBe(false);
+  });
+
+  it("is false when the key is missing", async () => {
+    const env = { SOCIAL_KV: { get: async () => null } };
+    expect(await isTrustedVouchDomain(env, "alice.example")).toBe(false);
+  });
+
+  it("is false, not thrown, when the stored value is malformed JSON", async () => {
+    const env = { SOCIAL_KV: { get: async () => "not json" } };
+    expect(await isTrustedVouchDomain(env, "alice.example")).toBe(false);
+  });
+
+  it("is false when the stored value is valid JSON but not a string array", async () => {
+    const env = { SOCIAL_KV: { get: async () => JSON.stringify({ not: "an array" }) } };
+    expect(await isTrustedVouchDomain(env, "alice.example")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd Resources/Template && npx vitest run worker/vouch-trust.test.ts --config vitest.config.ts`
+Expected: FAIL — `./vouch-trust.ts` doesn't exist yet.
+
+- [ ] **Step 3: Implement**
+
+Create `Resources/Template/worker/vouch-trust.ts`:
+
+```ts
+/**
+ * Vouch trust-list membership (#1597), reading the `vouch:trusted-domains` key
+ * `BlogrollTrustSync` pushes to `SOCIAL_KV` from the site's blogroll.
+ *
+ * @see docs/superpowers/specs/2026-08-20-vouch-webmention-design.md
+ */
+
+const TRUST_LIST_KEY = "vouch:trusted-domains";
+
+/** Minimal KV read surface this module needs (mirrors `reader-identity.ts`'s `ReaderIdentityEnv`). */
+export interface VouchTrustEnv {
+  readonly SOCIAL_KV?: { get(key: string): Promise<string | null> };
+}
+
+/**
+ * Parses the bare JSON array of hostname strings `BlogrollTrustSync` pushes to
+ * `vouch:trusted-domains`. Returns an empty set for a missing binding, missing key, or
+ * malformed JSON — never throws, so a KV outage or an unexpected value degrades to "nothing is
+ * trusted yet" rather than crashing the queue consumer.
+ */
+async function readTrustedDomains(env: VouchTrustEnv): Promise<ReadonlySet<string>> {
+  if (!env.SOCIAL_KV) return new Set();
+  const raw = await env.SOCIAL_KV.get(TRUST_LIST_KEY);
+  if (raw === null) return new Set();
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((value): value is string => typeof value === "string"));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Whether `hostname` (already lowercased by `verifyVouch`) is in the pushed Vouch trust list.
+ */
+export async function isTrustedVouchDomain(env: VouchTrustEnv, hostname: string): Promise<boolean> {
+  const trusted = await readTrustedDomains(env);
+  return trusted.has(hostname);
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd Resources/Template && npx vitest run worker/vouch-trust.test.ts --config vitest.config.ts`
+Expected: PASS
+
+- [ ] **Step 5: Wire into `worker.ts`**
+
+In `Resources/Template/worker/worker.ts`, add the import near the other `worker/*.ts` imports
+(alongside `reader-identity.ts`'s import):
+
+```ts
+import { isTrustedVouchDomain } from "./vouch-trust.ts";
+```
+
+In `handleWebmentionQueue` (currently ~line 958), add `isTrustedVouchDomain` to the
+`createWebmentionQueueConsumer` config:
+
+```ts
+function handleWebmentionQueue(
+  batch: MessageBatch<WebmentionJob>,
+  env: WorkerEnv,
+  ctx: ExecutionContext,
+): Promise<void> {
+  if (!env.WEBMENTION_QUEUE || !env.WEBMENTION_INBOX || !env.SITE_URL) {
+    return Promise.resolve();
+  }
+  const consumer = createWebmentionQueueConsumer({
+    baseUrl: env.SITE_URL,
+    inbox: createD1Inbox(env.WEBMENTION_INBOX),
+    isTrustedVouchDomain: (hostname) => isTrustedVouchDomain(env, hostname),
+  });
+  const webmentionEnv: WebmentionEnv = {
+    WEBMENTION_QUEUE: env.WEBMENTION_QUEUE,
+    WEBMENTION_INBOX: env.WEBMENTION_INBOX,
+  };
+  return consumer(batch, webmentionEnv, ctx);
+}
+```
+
+(Only the new `isTrustedVouchDomain` line is added — everything else in this function is
+unchanged. `env` is already in scope here, so the closure can read the real per-request
+`SOCIAL_KV` binding.) This requires the `@dwk/webmention` dependency bump from the *other* plan
+(`docs/superpowers/plans/2026-08-20-vouch-webmention.md`, Task 6, Step 1) to have landed first —
+`WebmentionConfig.isTrustedVouchDomain` doesn't exist in the currently-pinned `1.0.0-beta.1`.
+If that bump hasn't happened yet, do it as part of this step (same one-line `package.json`
+change) rather than waiting — Task 6 there will find it already done.
+
+- [ ] **Step 6: Run the full template test suite and commit**
+
+```bash
+cd Resources/Template
+npm run test:scripts
+npm run test:worker
+cd ../..
+git add Resources/Template/worker/vouch-trust.ts Resources/Template/worker/vouch-trust.test.ts \
+  Resources/Template/worker/worker.ts Resources/Template/package.json
+git commit -m "feat(#1597): wire the Vouch trust list into the webmention queue consumer"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** the design spec's "Bug found in review, and its fix" section maps
+  entirely to Tasks 1–2 (algorithm) and 4–6 (trust-list plumbing); Task 3 covers the release
+  mechanics note ("its own changeset, its own review"). The "Non-goals" list (no dedicated
+  vouch-trust UI, reuses blogroll as-is) has no task, correctly — it's an explicit absence.
+- **Placeholder scan:** no TBD/TODO. Task 5's implementation step flags one genuine uncertainty
+  (whether `SiteConfigStore.read(from:)` vs. an instance `.load()` is this codebase's actual
+  call shape) rather than guessing — resolved by copying whatever `ContactsAllowlistSync.swift`
+  itself does, since that file is being mirrored verbatim and is the ground truth.
+- **Type consistency:** `verifyVouch(vouchUrl, source, isTrustedDomain, options?)` (Task 1) →
+  called by the queue consumer as `verifyVouch(vouch, source, config.isTrustedVouchDomain ??
+  (() => false), {...})` (Task 2) → `WebmentionConfig.isTrustedVouchDomain` (Task 2) → supplied
+  by `worker.ts` as `(hostname) => isTrustedVouchDomain(env, hostname)` (Task 6) → reading
+  `SOCIAL_KV` key `vouch:trusted-domains` (Task 6) ← written by `BlogrollTrustKVClient
+  .putTrustedDomains` (Task 4) ← called by `BlogrollTrustSync.push` (Task 5) reading
+  `BlogrollPlan.Entry.url.host`. Names and the trust-list key string (`vouch:trusted-domains`)
+  match at every hop.

--- a/docs/superpowers/plans/2026-08-20-vouch-webmention-plan.md
+++ b/docs/superpowers/plans/2026-08-20-vouch-webmention-plan.md
@@ -1,0 +1,1567 @@
+# Vouch protocol for webmention spam mitigation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add IndieWeb [Vouch](https://indieweb.org/Vouch) support to inbound Webmentions — an optional sender-supplied URL that, when it also links to the target's domain, is recorded as a trust signal and rendered on the received interaction.
+
+**Architecture:** The fetch/verify pipeline lives in `@dwk/webmention` (sidecar repo `davidwkeith/workers`); Anglesite only composes it. Vouch verification is added to that package the same way RSVP support was: an optional field on the queue job → a new `verifyVouch` check (twin of `verifySource`) → an additive D1 column → surfaced in `VerifiedMention`. Anglesite then threads the new field through its D1 reader, Swift model, Zod schema, and Astro render — no new moderation queue, no change to the existing hard verification gate.
+
+**Tech Stack:** TypeScript (Cloudflare Workers, vitest + `@cloudflare/vitest-pool-workers`) for the sidecar package; Swift 6.4 (`AnglesiteCore`, Swift Testing) + Astro/Zod (`node:test`) for the app.
+
+Full design: [`docs/superpowers/specs/2026-08-20-vouch-webmention-design.md`](../specs/2026-08-20-vouch-webmention-design.md).
+
+## Global Constraints
+
+- Sidecar repo (`davidwkeith/workers`): Node.js >= 22, pnpm 10 (`corepack enable`). Before any PR: `pnpm lint && pnpm format:check && pnpm typecheck && pnpm build && pnpm test` must pass (CONTRIBUTING.md ▸ "Development workflow").
+- Sidecar: every behavior change needs a colocated test in the package's `src/*.test.ts` (CONTRIBUTING.md).
+- Sidecar: read `packages/webmention/spec/packages/webmention.md`-adjacent doc comments before changing behavior; keep doc comments accurate, don't add a separate spec file.
+- App repo (this one): macOS 27+ / Xcode 27+ (Swift 6.4). Run `swift test --package-path .` before opening the PR (`AnglesiteCoreTests` covers everything touched here).
+- App repo: `npm test` inside `Resources/Template/` (or the narrower `npm run test:scripts`) covers `src/lib/*.test.ts`.
+- Conventional commits, subject <= 72 characters.
+- **Do not put a GitHub closing keyword (`Closes #1597`) in the sidecar PR** — #1597 is an Anglesite issue; a cross-repo closing keyword would close it before the app-side half ships. Reference it as plain text (`part of Anglesite/Anglesite#1597`) instead. Reserve `Closes #1597` for the final Anglesite PR (Task 10).
+- Both repos: additive-only. No existing field, column, or exported signature changes shape — only new optional ones are added, matching every other field in this pipeline (`rsvp`, the mf2-enrichment columns).
+
+---
+
+## Sidecar: `@dwk/webmention` (davidwkeith/workers)
+
+Do this work in a worktree off `origin/main` (the local `main` branch is behind `origin/main`, and the checked-out branch `codex/issue-327-phase-3` is unrelated feature work — do not build on either).
+
+### Task 1: `WebmentionJob.vouch` + receive-handler parsing
+
+**Files:**
+- Create worktree: `/Users/dwk/Developer/github.com/davidwkeith/workers/.claude/worktrees/vouch-1597/` on a new branch `feat/vouch-webmention` based on `origin/main`
+- Modify: `packages/webmention/src/index.ts` (`WebmentionJob` interface, `createWebmention`)
+- Test: `packages/webmention/src/index.test.ts`
+
+**Interfaces:**
+- Produces: `WebmentionJob.vouch?: string` (raw form value, already validated as a syntactically valid `http(s)` URL — or absent).
+
+- [ ] **Step 1: Create the worktree**
+
+```bash
+cd /Users/dwk/Developer/github.com/davidwkeith/workers
+git fetch origin main
+git worktree add .claude/worktrees/vouch-1597 -b feat/vouch-webmention origin/main
+cd .claude/worktrees/vouch-1597
+pnpm install
+pnpm build
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+In `packages/webmention/src/index.test.ts`, change the `formPost` helper to accept an optional third argument, and add two new `it` blocks inside `describe("createWebmention", ...)`:
+
+```ts
+function formPost(source?: string, target?: string, vouch?: string): Request {
+  const body = new URLSearchParams();
+  if (source !== undefined) body.set("source", source);
+  if (target !== undefined) body.set("target", target);
+  if (vouch !== undefined) body.set("vouch", vouch);
+  return new Request("https://example.com/webmention", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+}
+```
+
+```ts
+  it("includes a syntactically valid vouch URL in the enqueued job", async () => {
+    const handler = createWebmention(config);
+    const { env, sent } = envWithQueue();
+    const response = await handler(
+      formPost(
+        "https://other.example/p",
+        "https://example.com/article",
+        "https://vouches.example/for-me",
+      ),
+      env,
+      ctx,
+    );
+    expect(response.status).toBe(202);
+    expect(sent).toEqual([
+      {
+        source: "https://other.example/p",
+        target: "https://example.com/article",
+        vouch: "https://vouches.example/for-me",
+      },
+    ]);
+  });
+
+  it("drops a malformed vouch URL instead of rejecting the mention", async () => {
+    const handler = createWebmention(config);
+    const { env, sent } = envWithQueue();
+    const response = await handler(
+      formPost(
+        "https://other.example/p",
+        "https://example.com/article",
+        "not-a-url",
+      ),
+      env,
+      ctx,
+    );
+    expect(response.status).toBe(202);
+    expect(sent).toEqual([
+      {
+        source: "https://other.example/p",
+        target: "https://example.com/article",
+      },
+    ]);
+  });
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pnpm test --project @dwk/webmention -- -t "vouch"`
+Expected: FAIL — `sent[0]` has no `vouch` key yet (the job is still just `{ source, target }`).
+
+- [ ] **Step 4: Implement**
+
+In `packages/webmention/src/index.ts`, add `vouch` to `WebmentionJob`:
+
+```ts
+/** A queued verification job: confirm that `source` links to `target`. */
+export interface WebmentionJob {
+  readonly source: string;
+  readonly target: string;
+  /**
+   * The sender's Vouch URL (indieweb.org/Vouch), when supplied and
+   * syntactically a valid `http(s)` URL. Verified asynchronously alongside
+   * `source`/`target` — see {@link verifyVouch} in `verify.ts`.
+   */
+  readonly vouch?: string;
+}
+```
+
+Add a small parsing helper right after `formValue`:
+
+```ts
+/**
+ * Extract and validate the optional `vouch` form field. A missing or
+ * syntactically invalid value returns `undefined` rather than an error —
+ * Vouch is a supplementary trust signal (indieweb.org/Vouch), not a required
+ * one, so a malformed vouch parameter must never turn into a whole-mention
+ * rejection.
+ */
+function validVouchUrl(value: string | File | null): string | undefined {
+  const raw = formValue(value);
+  if (raw === null || raw === "") {
+    return undefined;
+  }
+  try {
+    const url = new URL(raw);
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.toString()
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+```
+
+Then in `createWebmention`, read it and thread it into the enqueue call:
+
+```ts
+    const vouch = validVouchUrl(form.get("vouch"));
+
+    await env.WEBMENTION_QUEUE.send({
+      source: result.source,
+      target: result.target,
+      ...(vouch !== undefined ? { vouch } : {}),
+    });
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm test --project @dwk/webmention -- -t "vouch"`
+Expected: PASS
+
+- [ ] **Step 6: Run the full package gate and commit**
+
+```bash
+pnpm --filter @dwk/webmention typecheck
+pnpm --filter @dwk/webmention build
+pnpm test --project @dwk/webmention
+git add packages/webmention/src/index.ts packages/webmention/src/index.test.ts
+git commit -m "feat(webmention): accept an optional vouch URL on receive"
+```
+
+---
+
+### Task 2: `VerifiedMention.vouch` + D1 inbox columns
+
+**Files:**
+- Modify: `packages/webmention/src/inbox.ts`
+- Test: `packages/webmention/src/inbox.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `VerifiedMention.vouch?: { readonly url: string; readonly verified: boolean }`; `InboxStore.store()`/`list()` round-trip it via new `vouch_url TEXT` / `vouch_verified INTEGER` columns.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/webmention/src/inbox.test.ts` (inside `describe("createD1Inbox", ...)`):
+
+```ts
+  it("persists and lists a vouch outcome", async () => {
+    const inbox = createD1Inbox(db, { table: "wm_vouch" });
+    await inbox.store({
+      source: "https://a.example/vouch",
+      target: "https://example.com/x",
+      verifiedAt: 1,
+      vouch: { url: "https://trusted.example/", verified: true },
+    });
+    const all = await inbox.list();
+    expect(all[0]?.vouch).toEqual({
+      url: "https://trusted.example/",
+      verified: true,
+    });
+  });
+
+  it("distinguishes a failed vouch attempt from no vouch at all", async () => {
+    const inbox = createD1Inbox(db, { table: "wm_vouch_failed" });
+    await inbox.store({
+      source: "https://a.example/vouch",
+      target: "https://example.com/x",
+      verifiedAt: 1,
+      vouch: { url: "https://untrusted.example/", verified: false },
+    });
+    const all = await inbox.list();
+    expect(all[0]?.vouch).toEqual({
+      url: "https://untrusted.example/",
+      verified: false,
+    });
+  });
+
+  it("omits vouch on a mention stored without one", async () => {
+    const inbox = createD1Inbox(db, { table: "wm_no_vouch" });
+    await inbox.store({
+      source: "https://a.example/p",
+      target: "https://example.com/x",
+      verifiedAt: 1,
+    });
+    const all = await inbox.list();
+    expect(all[0]?.vouch).toBeUndefined();
+  });
+
+  it("migrates a pre-vouch table additively", async () => {
+    // A table created by a @dwk/webmention version before vouch support
+    // existed — has every enrichment column except vouch_url/vouch_verified.
+    await db
+      .prepare(
+        "CREATE TABLE wm_pre_vouch (source TEXT NOT NULL, target TEXT NOT NULL, " +
+          "verified_at INTEGER NOT NULL, rsvp TEXT, id TEXT, interaction_type TEXT, " +
+          "author_name TEXT, author_url TEXT, author_photo TEXT, content TEXT, " +
+          "published_at INTEGER, PRIMARY KEY (source, target))",
+      )
+      .run();
+    await db
+      .prepare(
+        "INSERT INTO wm_pre_vouch (source, target, verified_at, id) VALUES (?1, ?2, ?3, ?4)",
+      )
+      .bind(
+        "https://old.example/p",
+        "https://example.com/x",
+        7,
+        mentionId("https://old.example/p", "https://example.com/x"),
+      )
+      .run();
+
+    const inbox = createD1Inbox(db, { table: "wm_pre_vouch" });
+    const preExisting = (await inbox.list())[0];
+    expect(preExisting?.vouch).toBeUndefined();
+
+    await inbox.store({
+      source: "https://new.example/vouched",
+      target: "https://example.com/x",
+      verifiedAt: 8,
+      vouch: { url: "https://trusted.example/", verified: true },
+    });
+    const vouched = (await inbox.list()).find(
+      (m) => m.source === "https://new.example/vouched",
+    );
+    expect(vouched?.vouch).toEqual({
+      url: "https://trusted.example/",
+      verified: true,
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm test --project @dwk/webmention -- -t "vouch"`
+Expected: FAIL — `vouch` is not a recognized field on `VerifiedMention`/not persisted.
+
+- [ ] **Step 3: Implement**
+
+In `packages/webmention/src/inbox.ts`:
+
+Add to `ADDED_COLUMNS` (after the existing `published_at` entry):
+
+```ts
+const ADDED_COLUMNS: ReadonlyArray<readonly [name: string, type: string]> = [
+  ["rsvp", "TEXT"],
+  ["id", "TEXT"],
+  ["interaction_type", "TEXT"],
+  ["author_name", "TEXT"],
+  ["author_url", "TEXT"],
+  ["author_photo", "TEXT"],
+  ["content", "TEXT"],
+  ["published_at", "INTEGER"],
+  ["vouch_url", "TEXT"],
+  ["vouch_verified", "INTEGER"],
+];
+```
+
+Add to `VerifiedMention`:
+
+```ts
+  /**
+   * The sender's Vouch URL (indieweb.org/Vouch) and whether it was confirmed
+   * to link to the target's domain; omitted when no vouch was sent. A vouch
+   * that was sent but did NOT check out is still recorded (`verified: false`)
+   * — distinct from no vouch at all, since a failed vouch attempt is a
+   * stronger spam signal than silence.
+   */
+  readonly vouch?: { readonly url: string; readonly verified: boolean };
+```
+
+Add to `MentionRow`:
+
+```ts
+  readonly vouch_url: string | null;
+  readonly vouch_verified: number | null;
+```
+
+In `store()`, extend the `INSERT`:
+
+```ts
+    async store(mention) {
+      await ensureSchema();
+      await db
+        .prepare(
+          `INSERT INTO ${table} (source, target, verified_at, rsvp, id, ` +
+            `interaction_type, author_name, author_url, author_photo, ` +
+            `content, published_at, vouch_url, vouch_verified) ` +
+            `VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13) ` +
+            `ON CONFLICT (source, target) ` +
+            `DO UPDATE SET verified_at = excluded.verified_at, ` +
+            `rsvp = excluded.rsvp, ` +
+            `id = excluded.id, ` +
+            `interaction_type = excluded.interaction_type, ` +
+            `author_name = excluded.author_name, ` +
+            `author_url = excluded.author_url, ` +
+            `author_photo = excluded.author_photo, ` +
+            `content = excluded.content, ` +
+            `published_at = excluded.published_at, ` +
+            `vouch_url = excluded.vouch_url, ` +
+            `vouch_verified = excluded.vouch_verified`,
+        )
+        .bind(
+          mention.source,
+          mention.target,
+          mention.verifiedAt,
+          mention.rsvp ?? null,
+          mentionId(mention.source, mention.target),
+          mention.interactionType ?? "mention",
+          mention.author?.name ?? null,
+          mention.author?.url ?? null,
+          mention.author?.photo ?? null,
+          mention.content ?? null,
+          mention.publishedAt ?? mention.verifiedAt,
+          mention.vouch?.url ?? null,
+          mention.vouch !== undefined ? (mention.vouch.verified ? 1 : 0) : null,
+        )
+        .run();
+    },
+```
+
+In `list()`, extend the selected columns and the row mapping:
+
+```ts
+      const columns =
+        `id, source, target, verified_at, rsvp, interaction_type, ` +
+        `author_name, author_url, author_photo, content, published_at, ` +
+        `vouch_url, vouch_verified`;
+```
+
+```ts
+        const vouch =
+          row.vouch_url !== null && row.vouch_verified !== null
+            ? { url: row.vouch_url, verified: row.vouch_verified !== 0 }
+            : undefined;
+        return {
+          id: row.id ?? mentionId(row.source, row.target),
+          source: row.source,
+          target: row.target,
+          verifiedAt: row.verified_at,
+          interactionType:
+            row.interaction_type !== null &&
+            isInteractionType(row.interaction_type)
+              ? row.interaction_type
+              : "mention",
+          ...(author !== undefined ? { author } : {}),
+          ...(row.content !== null ? { content: row.content } : {}),
+          publishedAt: row.published_at ?? row.verified_at,
+          ...(row.rsvp !== null && isRsvpValue(row.rsvp)
+            ? { rsvp: row.rsvp }
+            : {}),
+          ...(vouch !== undefined ? { vouch } : {}),
+        };
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm test --project @dwk/webmention -- -t "vouch"`
+Expected: PASS
+
+- [ ] **Step 5: Run the full package gate and commit**
+
+```bash
+pnpm --filter @dwk/webmention typecheck
+pnpm --filter @dwk/webmention build
+pnpm test --project @dwk/webmention
+git add packages/webmention/src/inbox.ts packages/webmention/src/inbox.test.ts
+git commit -m "feat(webmention): store vouch outcome on the inbox record"
+```
+
+---
+
+### Task 3: `verifyVouch` + `VouchVerified` log event
+
+**Files:**
+- Modify: `packages/webmention/src/verify.ts`
+- Modify: `packages/webmention/src/log.ts`
+- Modify: `packages/webmention/src/index.ts` (export block only)
+- Test: `packages/webmention/src/verify.test.ts`
+
+**Interfaces:**
+- Consumes: `safeFetch`, `readBodyCapped`, `FetchLike` (`@dwk/safe-fetch`); `isHtmlContentType` (`./html.js`); `extractLinks` (already local to `verify.ts`); `hostFromUrl`, `noopLogger`, `noopMetrics` (`@dwk/log`).
+- Produces: `verifyVouch(vouchUrl: string, target: string, options?: VerifyOptions): Promise<VouchResult>` where `VouchResult = { readonly verified: boolean }`. Never throws.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/webmention/src/verify.test.ts` (new top-level `describe`, after the existing `describe("verifySource", ...)` block):
+
+```ts
+describe("verifyVouch", () => {
+  const vouchUrl = "https://vouches.example/for-me";
+
+  it("is verified true when the vouch page links to the target's host", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(`<a href="${target}">I trust this site</a>`, {
+          headers: { "content-type": "text/html" },
+        }),
+    );
+    expect(
+      await verifyVouch(vouchUrl, target, { fetch: fetchImpl }),
+    ).toEqual({ verified: true });
+  });
+
+  it("is verified true for a link to a different path under the target's host", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('<a href="https://example.com/somewhere-else">x</a>', {
+          headers: { "content-type": "text/html" },
+        }),
+    );
+    expect(
+      await verifyVouch(vouchUrl, target, { fetch: fetchImpl }),
+    ).toEqual({ verified: true });
+  });
+
+  it("is verified false when the vouch page links elsewhere", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('<a href="https://elsewhere.example/">x</a>', {
+          headers: { "content-type": "text/html" },
+        }),
+    );
+    expect(
+      await verifyVouch(vouchUrl, target, { fetch: fetchImpl }),
+    ).toEqual({ verified: false });
+  });
+
+  it("is verified false for a 404 vouch page", async () => {
+    const fetchImpl = vi.fn(async () => new Response("gone", { status: 404 }));
+    expect(
+      await verifyVouch(vouchUrl, target, { fetch: fetchImpl }),
+    ).toEqual({ verified: false });
+  });
+
+  it("is verified false when the fetch throws", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network");
+    });
+    expect(
+      await verifyVouch(vouchUrl, target, { fetch: fetchImpl }),
+    ).toEqual({ verified: false });
+  });
+
+  it("is verified false for a non-HTML vouch page", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ref: target }), {
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    expect(
+      await verifyVouch(vouchUrl, target, { fetch: fetchImpl }),
+    ).toEqual({ verified: false });
+  });
+});
+```
+
+And update the import line at the top of the file:
+
+```ts
+import { extractLinks, sourceLinksTo, verifySource, verifyVouch } from "./verify.js";
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm test --project @dwk/webmention -- -t "verifyVouch"`
+Expected: FAIL — `verifyVouch` is not exported.
+
+- [ ] **Step 3: Implement**
+
+In `packages/webmention/src/log.ts`, add a new event (after `VerifyFetchFailed`):
+
+```ts
+  /** Vouch verification finished. Fields: `verified`. */
+  VouchVerified: "webmention.vouch.verified",
+```
+
+In `packages/webmention/src/verify.ts`, add after `verifySource`:
+
+```ts
+/** Outcome of fetching and checking a Vouch URL. */
+export interface VouchResult {
+  /** Whether the vouch page links anywhere under the target's hostname. */
+  readonly verified: boolean;
+}
+
+/**
+ * Fetch `vouchUrl` and check whether it links anywhere under `target`'s
+ * hostname — the Vouch protocol's trust signal (indieweb.org/Vouch): a page
+ * already known to (or trusted by) the sender is fetched and confirmed to
+ * link back to the target's domain, raising confidence the mention isn't
+ * spam.
+ *
+ * Uses the same SSRF-safe {@link safeFetch} wrapper as {@link verifySource}.
+ * Unlike {@link sourceLinksTo}'s exact-URL match, this checks **hostname**
+ * equality — any link on the vouch page pointing anywhere under the target's
+ * host counts, per the "domain of the target" wording of the spec. Only HTML
+ * vouch pages are scanned (this is a hyperlink check, not the multi-format
+ * exact-match Webmention verification itself needs). Any fetch failure,
+ * non-2xx status, non-HTML response, or oversized/unreadable body yields
+ * `{ verified: false }`; this function never throws.
+ */
+export async function verifyVouch(
+  vouchUrl: string,
+  target: string,
+  options?: VerifyOptions,
+): Promise<VouchResult> {
+  const doFetch: FetchLike =
+    options?.fetch ?? ((input, init) => fetch(input, init));
+  const logger = options?.logger ?? noopLogger;
+  const metrics = options?.metrics ?? noopMetrics;
+
+  let targetHost: string;
+  try {
+    targetHost = new URL(target).hostname.toLowerCase();
+  } catch {
+    return { verified: false };
+  }
+
+  let response: Response;
+  let base: string;
+  try {
+    const result = await safeFetch(
+      doFetch,
+      vouchUrl,
+      { method: "GET", headers: { accept: "text/html, */*" } },
+      {
+        logger,
+        metrics,
+        logEvent: WebmentionLogEvent.SsrfBlocked,
+        allowedHosts: options?.fetchAllowedHosts,
+      },
+    );
+    response = result.response;
+    base = result.url;
+  } catch {
+    return { verified: false };
+  }
+
+  if (!response.ok) {
+    return { verified: false };
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!isHtmlContentType(contentType)) {
+    return { verified: false };
+  }
+
+  const body = await readBodyCapped(response);
+  if (body === null) {
+    return { verified: false };
+  }
+
+  const links = await extractLinks(body, base);
+  const verified = links.some((link) => {
+    try {
+      return new URL(link).hostname.toLowerCase() === targetHost;
+    } catch {
+      return false;
+    }
+  });
+
+  const fields = {
+    vouchHost: hostFromUrl(vouchUrl),
+    targetHost: hostFromUrl(target),
+    verified,
+  };
+  logger.info(WebmentionLogEvent.VouchVerified, fields);
+  metrics.count(WebmentionLogEvent.VouchVerified, fields);
+  return { verified };
+}
+```
+
+In `packages/webmention/src/index.ts`, extend the re-export block:
+
+```ts
+export {
+  verifySource,
+  sourceLinksTo,
+  extractLinks,
+  verifyVouch,
+  type VerifyOptions,
+  type VerifyResult,
+  type VouchResult,
+} from "./verify.js";
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm test --project @dwk/webmention -- -t "verifyVouch"`
+Expected: PASS
+
+- [ ] **Step 5: Run the full package gate and commit**
+
+```bash
+pnpm --filter @dwk/webmention typecheck
+pnpm --filter @dwk/webmention build
+pnpm test --project @dwk/webmention
+git add packages/webmention/src/verify.ts packages/webmention/src/verify.test.ts \
+  packages/webmention/src/log.ts packages/webmention/src/index.ts
+git commit -m "feat(webmention): verify vouch URLs against the target's domain"
+```
+
+---
+
+### Task 4: wire vouch verification into the queue consumer
+
+**Files:**
+- Modify: `packages/webmention/src/index.ts` (`createWebmentionQueueConsumer`)
+- Test: `packages/webmention/src/index.test.ts`
+
+**Interfaces:**
+- Consumes: `WebmentionJob.vouch` (Task 1), `verifyVouch` (Task 3), `VerifiedMention.vouch` (Task 2).
+- Produces: a stored mention carries `vouch` exactly when `message.body.vouch` was present and the mention itself verified (`result.links === true`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/webmention/src/index.test.ts` (inside `describe("createWebmentionQueueConsumer", ...)`):
+
+```ts
+  it("verifies and stores a vouch when the job includes one and the mention verifies", async () => {
+    const inbox = new MemoryInbox();
+    const fetchImpl: FetchLike = vi.fn(async (input) => {
+      const url = String(input);
+      if (url === "https://vouches.example/for-me") {
+        return new Response(
+          '<a href="https://example.com/article">I trust this</a>',
+          { headers: { "content-type": "text/html" } },
+        );
+      }
+      return new Response('<a href="https://example.com/article">x</a>', {
+        headers: { "content-type": "text/html" },
+      });
+    });
+    const consumer = createWebmentionQueueConsumer({
+      ...config,
+      inbox,
+      fetch: fetchImpl,
+    });
+    const { batch } = batchOf([
+      {
+        source: "https://other.example/p",
+        target: "https://example.com/article",
+        vouch: "https://vouches.example/for-me",
+      },
+    ]);
+    await consumer(batch, {} as WebmentionEnv, ctx);
+
+    const [stored] = await inbox.list();
+    expect(stored?.vouch).toEqual({
+      url: "https://vouches.example/for-me",
+      verified: true,
+    });
+  });
+
+  it("stores a failed vouch outcome without affecting the mention itself", async () => {
+    const inbox = new MemoryInbox();
+    const fetchImpl: FetchLike = vi.fn(async (input) => {
+      const url = String(input);
+      if (url === "https://vouches.example/for-me") {
+        return new Response('<a href="https://elsewhere.example/">x</a>', {
+          headers: { "content-type": "text/html" },
+        });
+      }
+      return new Response('<a href="https://example.com/article">x</a>', {
+        headers: { "content-type": "text/html" },
+      });
+    });
+    const consumer = createWebmentionQueueConsumer({
+      ...config,
+      inbox,
+      fetch: fetchImpl,
+    });
+    const { batch } = batchOf([
+      {
+        source: "https://other.example/p",
+        target: "https://example.com/article",
+        vouch: "https://vouches.example/for-me",
+      },
+    ]);
+    await consumer(batch, {} as WebmentionEnv, ctx);
+
+    const [stored] = await inbox.list();
+    expect(stored?.vouch).toEqual({
+      url: "https://vouches.example/for-me",
+      verified: false,
+    });
+    expect(stored?.source).toBe("https://other.example/p");
+  });
+
+  it("stores no vouch field when the job carries none", async () => {
+    const inbox = new MemoryInbox();
+    const fetchImpl: FetchLike = vi.fn(
+      async () =>
+        new Response('<a href="https://example.com/article">x</a>', {
+          headers: { "content-type": "text/html" },
+        }),
+    );
+    const consumer = createWebmentionQueueConsumer({
+      ...config,
+      inbox,
+      fetch: fetchImpl,
+    });
+    const { batch } = batchOf([
+      {
+        source: "https://other.example/p",
+        target: "https://example.com/article",
+      },
+    ]);
+    await consumer(batch, {} as WebmentionEnv, ctx);
+
+    const [stored] = await inbox.list();
+    expect(stored?.vouch).toBeUndefined();
+  });
+
+  it("never fetches the vouch URL when the source itself does not verify", async () => {
+    const inbox = new MemoryInbox();
+    const fetchedUrls: string[] = [];
+    const fetchImpl: FetchLike = vi.fn(async (input) => {
+      fetchedUrls.push(String(input));
+      return new Response("<p>link removed</p>", {
+        headers: { "content-type": "text/html" },
+      });
+    });
+    const consumer = createWebmentionQueueConsumer({
+      ...config,
+      inbox,
+      fetch: fetchImpl,
+    });
+    const { batch } = batchOf([
+      {
+        source: "https://other.example/p",
+        target: "https://example.com/article",
+        vouch: "https://vouches.example/for-me",
+      },
+    ]);
+    await consumer(batch, {} as WebmentionEnv, ctx);
+
+    expect(fetchedUrls).toEqual(["https://other.example/p"]);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm test --project @dwk/webmention -- -t "vouch"`
+Expected: FAIL — the consumer never calls `verifyVouch` yet, so `stored?.vouch` is always `undefined` and the "never fetches" test's premise doesn't yet distinguish behavior.
+
+- [ ] **Step 3: Implement**
+
+In `packages/webmention/src/index.ts`, inside `createWebmentionQueueConsumer`'s loop, change:
+
+```ts
+      const { source, target } = message.body;
+```
+
+to:
+
+```ts
+      const { source, target, vouch } = message.body;
+```
+
+and change the `if (result.links) { ... }` block to:
+
+```ts
+        if (result.links) {
+          const verifiedAt = Date.now();
+          // `dt-published` when the entry declares (and we can parse) it,
+          // else the verification time — the field is always populated.
+          const publishedMs =
+            result.published !== undefined
+              ? Date.parse(result.published)
+              : Number.NaN;
+          // Vouch only runs once the mention itself has verified — it is a
+          // trust signal on top of a real mention, never a substitute for one.
+          const vouchResult =
+            vouch !== undefined
+              ? await verifyVouch(vouch, target, {
+                  fetch: config.fetch,
+                  logger,
+                  metrics,
+                  fetchAllowedHosts: config.fetchAllowedHosts,
+                })
+              : undefined;
+          await inbox.store({
+            source,
+            target,
+            verifiedAt,
+            interactionType: result.interactionType ?? "mention",
+            ...(result.author !== undefined ? { author: result.author } : {}),
+            ...(result.content !== undefined
+              ? { content: result.content }
+              : {}),
+            publishedAt: Number.isFinite(publishedMs)
+              ? publishedMs
+              : verifiedAt,
+            ...(result.rsvp !== undefined ? { rsvp: result.rsvp } : {}),
+            ...(vouchResult !== undefined
+              ? { vouch: { url: vouch, verified: vouchResult.verified } }
+              : {}),
+          });
+        } else {
+          await inbox.remove(source, target);
+        }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm test --project @dwk/webmention -- -t "vouch"`
+Expected: PASS
+
+- [ ] **Step 5: Run the full package gate and commit**
+
+```bash
+pnpm --filter @dwk/webmention typecheck
+pnpm --filter @dwk/webmention build
+pnpm test --project @dwk/webmention
+git add packages/webmention/src/index.ts packages/webmention/src/index.test.ts
+git commit -m "feat(webmention): verify vouch URLs during queue consumption"
+```
+
+---
+
+### Task 5: changeset, version bump, full repo gate, PR
+
+**Files:**
+- Create: `.changeset/webmention-vouch.md`
+- Modify: `packages/webmention/package.json` (version)
+
+- [ ] **Step 1: Add the changeset**
+
+```bash
+cat > .changeset/webmention-vouch.md <<'EOF'
+---
+"@dwk/webmention": minor
+---
+
+Recognize IndieWeb Vouch (indieweb.org/Vouch). A receiver may include an
+optional `vouch` form field alongside `source`/`target`; during asynchronous
+verification, once the mention itself verifies, the vouch URL is fetched and
+checked for a link back to the target's hostname. The outcome is persisted on
+the inbox record (`vouch: { url, verified }`, new nullable `vouch_url` /
+`vouch_verified` columns, migrated additively on existing inboxes) — a vouch
+that fails is stored distinctly from no vouch at all. Vouch never overrides
+the primary source-links-to-target gate; a failed or absent vouch does not
+reject the mention. Exports `verifyVouch` and `VouchResult`; `WebmentionJob`
+and `VerifiedMention` gain an optional `vouch`. Part of
+Anglesite/Anglesite#1597.
+EOF
+```
+
+- [ ] **Step 2: Bump the package version**
+
+Edit `packages/webmention/package.json`, changing `"version": "1.0.0-beta.1"` to `"version": "1.0.0-beta.2"`.
+
+- [ ] **Step 3: Run the full repo gate**
+
+```bash
+pnpm lint && pnpm format:check && pnpm typecheck && pnpm build && pnpm test
+```
+
+Expected: all green. Fix any failure before proceeding — do not skip a failing check.
+
+- [ ] **Step 4: Commit, push, open the PR**
+
+```bash
+git add .changeset/webmention-vouch.md packages/webmention/package.json
+git commit -m "feat(webmention): bump to 1.0.0-beta.2 for vouch support"
+git push -u origin feat/vouch-webmention
+```
+
+Confirm with the user before running `gh pr create` (pushing/opening a PR needs explicit confirmation per the standing safety rules — do not skip this even though the design was pre-approved). Once confirmed, open the PR against `davidwkeith/workers` main with a summary of the vouch feature and `part of Anglesite/Anglesite#1597` in the body (no closing keyword — see Global Constraints).
+
+**Do not proceed to Task 6 until this PR has merged and a tagged `1.0.0-beta.2` (or later) release of `@dwk/webmention` is published to npm** — Task 6 bumps Anglesite's dependency on that exact published version. Check with `npm view @dwk/webmention versions --json`.
+
+---
+
+## App side (Anglesite/Anglesite)
+
+### Task 6: bump `@dwk/webmention` and extend `WebmentionInboxD1Client`
+
+**Files:**
+- Modify: `Resources/Template/package.json`
+- Modify: `Sources/AnglesiteCore/WebmentionInboxD1Client.swift`
+- Test: `Tests/AnglesiteCoreTests/WebmentionInboxD1ClientTests.swift`
+
+**Interfaces:**
+- Produces: `WebmentionInboxD1Client.Mention.vouchURL: String? = nil`, `.vouchVerified: Bool? = nil` (defaulted so all 13 existing call sites keep compiling unchanged).
+
+- [ ] **Step 1: Bump the template's pinned version**
+
+In `Resources/Template/package.json`, change `"@dwk/webmention": "1.0.0-beta.1"` to `"@dwk/webmention": "1.0.0-beta.2"` (or whatever version Task 5 actually published — verify with `npm view @dwk/webmention versions --json` first).
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `Tests/AnglesiteCoreTests/WebmentionInboxD1ClientTests.swift`, after `listsVerifiedMentionsWithEnrichment`:
+
+```swift
+    @Test("decodes a vouched mention")
+    func decodesVouchedMention() async throws {
+        let body = Data("""
+        {"success": true, "result": [{"success": true, "results": [
+            {"id": "wm-abc123", "source": "https://alice.example/post", "target": "https://me.example/blog/hi",
+             "verified_at": 1753300000000, "interaction_type": "reply", "author_name": "Alice",
+             "author_url": "https://alice.example", "author_photo": "https://alice.example/photo.jpg",
+             "content": "Great post!", "published_at": 1753299000000,
+             "vouch_url": "https://trusted.example/", "vouch_verified": 1}
+        ]}]}
+        """.utf8)
+
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (body, Self.response(200)) })
+
+        let mentions = try await client.listVerifiedMentions()
+        let mention = try #require(mentions.first)
+        #expect(mention.vouchURL == "https://trusted.example/")
+        #expect(mention.vouchVerified == true)
+    }
+
+    @Test("decodes an unverified vouch attempt as verified == false, not nil")
+    func decodesUnverifiedVouch() async throws {
+        let body = Data("""
+        {"success": true, "result": [{"success": true, "results": [
+            {"id": "wm-ghi789", "source": "https://carol.example/post", "target": "https://me.example/blog/hi",
+             "verified_at": 1753300000000, "interaction_type": null, "author_name": null,
+             "author_url": null, "author_photo": null, "content": null, "published_at": null,
+             "vouch_url": "https://untrusted.example/", "vouch_verified": 0}
+        ]}]}
+        """.utf8)
+
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (body, Self.response(200)) })
+
+        let mentions = try await client.listVerifiedMentions()
+        let mention = try #require(mentions.first)
+        #expect(mention.vouchURL == "https://untrusted.example/")
+        #expect(mention.vouchVerified == false)
+    }
+
+```
+
+Do not add a third "no vouch columns present" test — the existing
+`decodesLegacyRowsWithNullEnrichmentColumns` test already covers it unmodified:
+its JSON has no `vouch_url`/`vouch_verified` keys at all, and Swift's
+synthesized `Decodable` treats a missing key on an `Optional` property as
+`nil`, so it exercises exactly that case once `Row` gains the two optional
+fields in Step 3.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter WebmentionInboxD1ClientTests`
+Expected: FAIL to compile — `Mention` has no `vouchURL`/`vouchVerified` members yet.
+
+- [ ] **Step 4: Implement**
+
+In `Sources/AnglesiteCore/WebmentionInboxD1Client.swift`, extend `Mention`:
+
+```swift
+        /// Source page's declared publication date in epoch milliseconds, when enrichment ran.
+        public let publishedAt: Int?
+        /// The sender's Vouch URL (indieweb.org/Vouch), when supplied and the mention verified.
+        /// `nil` when no vouch was sent, or the row predates vouch support upstream.
+        public let vouchURL: String? = nil
+        /// Whether `vouchURL` was confirmed to link to this mention's target domain. `nil` exactly
+        /// when `vouchURL` is `nil`; otherwise `true`/`false` — a failed vouch attempt is still
+        /// recorded (not collapsed into "no vouch"), since it's a stronger spam signal than silence.
+        public let vouchVerified: Bool? = nil
+    }
+```
+
+(The `= nil` defaults on `Mention`'s new stored properties keep its synthesized memberwise initializer backward-compatible — all 13 existing call sites across the codebase keep compiling with no vouch arguments.)
+
+Extend `Row`:
+
+```swift
+    private struct Row: Decodable {
+        let id: String?
+        let source: String
+        let target: String
+        let verified_at: Int
+        let interaction_type: String?
+        let author_name: String?
+        let author_url: String?
+        let author_photo: String?
+        let content: String?
+        let published_at: Int?
+        let vouch_url: String?
+        let vouch_verified: Int?
+    }
+```
+
+Extend `listVerifiedSQL`:
+
+```swift
+    private static let listVerifiedSQL = """
+    SELECT id, source, target, verified_at, interaction_type, author_name, author_url, \
+    author_photo, content, published_at, vouch_url, vouch_verified FROM webmentions ORDER BY verified_at DESC
+    """
+```
+
+Extend the mapping in `listVerifiedMentions()`:
+
+```swift
+        return rows.compactMap { row in
+            guard let id = row.id else { return nil }
+            return Mention(
+                id: id, source: row.source, target: row.target, verifiedAt: row.verified_at,
+                interactionType: row.interaction_type, authorName: row.author_name,
+                authorURL: row.author_url, authorPhoto: row.author_photo, content: row.content,
+                publishedAt: row.published_at, vouchURL: row.vouch_url,
+                vouchVerified: row.vouch_verified.map { $0 != 0 })
+        }
+```
+
+Also update the class-level doc comment's "tolerates the enrichment columns... being entirely `NULL`" note to mention `vouch_url`/`vouch_verified` alongside the existing list, since the same tolerance now applies to them too.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter WebmentionInboxD1ClientTests`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Resources/Template/package.json Sources/AnglesiteCore/WebmentionInboxD1Client.swift \
+  Tests/AnglesiteCoreTests/WebmentionInboxD1ClientTests.swift
+git commit -m "feat(#1597): bump @dwk/webmention, read vouch columns from D1"
+```
+
+---
+
+### Task 7: `ReceivedInteraction.Vouch`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ReceivedInteraction.swift`
+- Test: `Tests/AnglesiteCoreTests/ReceivedInteractionTests.swift`
+
+**Interfaces:**
+- Consumes: nothing from Task 6 (this is the pure data-model type).
+- Produces: `ReceivedInteraction.Vouch { url: URL; verified: Bool }`; `ReceivedInteraction.vouch: Vouch?`; `ReceivedInteraction.init(...)` gains a defaulted trailing parameter `vouch: Vouch? = nil` (all 13 existing call sites keep compiling unchanged).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/ReceivedInteractionTests.swift`, after `jsonRoundTrip`:
+
+```swift
+    @Test("round-trips a vouch through JSON encoding")
+    func vouchRoundTrips() throws {
+        let interaction = try ReceivedInteraction(
+            id: "wm-abc123",
+            type: .webmention,
+            source: URL(string: "https://other.example/post/42")!,
+            target: URL(string: "https://my.site/articles/hello-world")!,
+            interactionType: .reply,
+            author: nil,
+            content: "Great post!",
+            published: ISO8601DateFormatter().date(from: "2026-06-28T14:30:00Z")!,
+            verified: ISO8601DateFormatter().date(from: "2026-06-28T14:35:12Z")!,
+            verificationStatus: .verified,
+            vouch: ReceivedInteraction.Vouch(url: URL(string: "https://trusted.example/")!, verified: true)
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(interaction)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(ReceivedInteraction.self, from: data)
+        #expect(decoded == interaction)
+        #expect(decoded.vouch?.verified == true)
+    }
+
+    @Test("vouch defaults to nil when not supplied")
+    func vouchDefaultsToNil() throws {
+        let interaction = try ReceivedInteraction(
+            id: "wm-no-vouch",
+            type: .webmention,
+            source: URL(string: "https://other.example/post/42")!,
+            target: URL(string: "https://my.site/articles/hello-world")!,
+            interactionType: .mention,
+            author: nil,
+            content: nil,
+            published: Date(),
+            verified: Date(),
+            verificationStatus: .verified
+        )
+        #expect(interaction.vouch == nil)
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter ReceivedInteractionTests`
+Expected: FAIL to compile — no `Vouch` type, no `vouch` parameter/property.
+
+- [ ] **Step 3: Implement**
+
+In `Sources/AnglesiteCore/ReceivedInteraction.swift`, add the nested type after `Author`:
+
+```swift
+    /// A Vouch (indieweb.org/Vouch): the sender-supplied URL and whether the Worker confirmed it
+    /// links to this mention's target domain — an additional inbound-trust signal beyond ordinary
+    /// source→target link verification. A vouch that was sent but did NOT check out is still
+    /// represented here (`verified: false`), not collapsed into "no vouch" — see the type-level
+    /// design doc for why.
+    public struct Vouch: Codable, Sendable, Equatable {
+        /// The URL the sender supplied as their vouch.
+        public let url: URL
+        /// Whether `url` was confirmed to link to the target's domain.
+        public let verified: Bool
+
+        /// Creates a vouch outcome.
+        public init(url: URL, verified: Bool) {
+            self.url = url
+            self.verified = verified
+        }
+    }
+```
+
+Add the stored property (after `verificationStatus`):
+
+```swift
+    /// Current verification state of the interaction.
+    public let verificationStatus: VerificationStatus
+    /// The sender's Vouch outcome, when a vouch was supplied; `nil` when none was.
+    public let vouch: Vouch?
+```
+
+Update the initializer to accept it with a default:
+
+```swift
+    public init(
+        id: String,
+        type: ProtocolType,
+        source: URL,
+        target: URL,
+        interactionType: InteractionType,
+        author: Author?,
+        content: String?,
+        published: Date,
+        verified: Date,
+        verificationStatus: VerificationStatus,
+        vouch: Vouch? = nil
+    ) throws {
+        guard id.range(of: #"^[A-Za-z0-9_-]+$"#, options: .regularExpression) != nil else {
+            throw ValidationError.invalidID(id)
+        }
+        self.id = id
+        self.type = type
+        self.source = source
+        self.target = target
+        self.interactionType = interactionType
+        self.author = author
+        self.content = content
+        self.published = published
+        self.verified = verified
+        self.verificationStatus = verificationStatus
+        self.vouch = vouch
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter ReceivedInteractionTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ReceivedInteraction.swift Tests/AnglesiteCoreTests/ReceivedInteractionTests.swift
+git commit -m "feat(#1597): add ReceivedInteraction.Vouch"
+```
+
+---
+
+### Task 8: map vouch through `ReceivedInteractionSync`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ReceivedInteractionSync.swift`
+- Test: `Tests/AnglesiteCoreTests/ReceivedInteractionSyncTests.swift`
+
+**Interfaces:**
+- Consumes: `WebmentionInboxD1Client.Mention.vouchURL`/`.vouchVerified` (Task 6), `ReceivedInteraction.Vouch`/`.vouch` (Task 7).
+- Produces: `ReceivedInteractionSync.makeInteraction(from:)` populates `.vouch` from the mention's vouch columns.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/AnglesiteCoreTests/ReceivedInteractionSyncTests.swift`, after `makeInteractionDefaultsLegacyMention`:
+
+```swift
+    @Test("makeInteraction maps a vouched mention")
+    func makeInteractionMapsVouchedMention() throws {
+        let mention = WebmentionInboxD1Client.Mention(
+            id: "wm-abc123", source: "https://alice.example/post", target: "https://me.example/blog/hi",
+            verifiedAt: 1_753_300_000_000, interactionType: "reply", authorName: "Alice",
+            authorURL: "https://alice.example", authorPhoto: "https://alice.example/photo.jpg",
+            content: "Great post!", publishedAt: 1_753_299_000_000,
+            vouchURL: "https://trusted.example/", vouchVerified: true)
+
+        let interaction = try #require(ReceivedInteractionSync.makeInteraction(from: mention))
+        #expect(interaction.vouch?.url.absoluteString == "https://trusted.example/")
+        #expect(interaction.vouch?.verified == true)
+    }
+
+    @Test("makeInteraction maps a failed vouch attempt distinctly from no vouch")
+    func makeInteractionMapsFailedVouch() throws {
+        let mention = WebmentionInboxD1Client.Mention(
+            id: "wm-fail", source: "https://alice.example/post", target: "https://me.example/blog/hi",
+            verifiedAt: 1_753_300_000_000, interactionType: "reply", authorName: nil,
+            authorURL: nil, authorPhoto: nil, content: nil, publishedAt: nil,
+            vouchURL: "https://untrusted.example/", vouchVerified: false)
+
+        let interaction = try #require(ReceivedInteractionSync.makeInteraction(from: mention))
+        #expect(interaction.vouch?.url.absoluteString == "https://untrusted.example/")
+        #expect(interaction.vouch?.verified == false)
+    }
+
+    @Test("makeInteraction has no vouch when the mention carries none")
+    func makeInteractionHasNoVouchWhenAbsent() throws {
+        let mention = WebmentionInboxD1Client.Mention(
+            id: "wm-def456", source: "https://bob.example/post", target: "https://me.example/blog/hi",
+            verifiedAt: 1_753_300_000_000, interactionType: nil, authorName: nil,
+            authorURL: nil, authorPhoto: nil, content: nil, publishedAt: nil)
+
+        let interaction = try #require(ReceivedInteractionSync.makeInteraction(from: mention))
+        #expect(interaction.vouch == nil)
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter ReceivedInteractionSyncTests`
+Expected: FAIL — `interaction.vouch` is always `nil` (not wired up yet).
+
+- [ ] **Step 3: Implement**
+
+In `Sources/AnglesiteCore/ReceivedInteractionSync.swift`, extend `makeInteraction(from:)`:
+
+```swift
+    static func makeInteraction(from mention: WebmentionInboxD1Client.Mention) -> ReceivedInteraction? {
+        guard let source = URL(string: mention.source), let target = URL(string: mention.target) else { return nil }
+        let interactionType = mention.interactionType.flatMap(ReceivedInteraction.InteractionType.init(rawValue:)) ?? .mention
+        let author: ReceivedInteraction.Author? =
+            (mention.authorName != nil || mention.authorURL != nil || mention.authorPhoto != nil)
+            ? .init(
+                name: mention.authorName,
+                url: mention.authorURL.flatMap(URL.init(string:)),
+                photo: mention.authorPhoto.flatMap(URL.init(string:)))
+            : nil
+        // A vouch requires both the URL and the verified flag from the row — if either is missing
+        // (no vouch was sent, or a malformed vouchURL somehow made it through), there is no vouch.
+        let vouch: ReceivedInteraction.Vouch? = {
+            guard let vouchURLString = mention.vouchURL, let vouchVerified = mention.vouchVerified,
+                  let vouchURL = URL(string: vouchURLString)
+            else { return nil }
+            return ReceivedInteraction.Vouch(url: vouchURL, verified: vouchVerified)
+        }()
+        let verifiedAt = Double(mention.verifiedAt) / 1000
+        let publishedAt = Double(mention.publishedAt ?? mention.verifiedAt) / 1000
+        return try? ReceivedInteraction(
+            id: mention.id, type: .webmention, source: source, target: target,
+            interactionType: interactionType, author: author, content: mention.content,
+            published: Date(timeIntervalSince1970: publishedAt),
+            verified: Date(timeIntervalSince1970: verifiedAt), verificationStatus: .verified,
+            vouch: vouch)
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter ReceivedInteractionSyncTests`
+Expected: PASS
+
+- [ ] **Step 5: Run the full Swift suite and commit**
+
+```bash
+swift test --package-path .
+git add Sources/AnglesiteCore/ReceivedInteractionSync.swift Tests/AnglesiteCoreTests/ReceivedInteractionSyncTests.swift
+git commit -m "feat(#1597): map vouch outcome into ReceivedInteraction"
+```
+
+---
+
+### Task 9: `interactions.ts` Zod schema
+
+**Files:**
+- Modify: `Resources/Template/src/lib/interactions.ts`
+- Test: `Resources/Template/src/lib/interactions.test.ts`
+
+**Interfaces:**
+- Consumes: `httpUrl` (already defined in this file).
+- Produces: `ReceivedInteraction.vouch?: { url: string; verified: boolean }` (the TS type, inferred from the Zod schema — same name as the Swift type, different language/file).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Resources/Template/src/lib/interactions.test.ts`, after the "author and content are optional" test:
+
+```ts
+test("vouch is optional and round-trips when present", () => {
+  const all = parseInteractions(mods(raw({ vouch: { url: "https://trusted.example/", verified: true } })));
+  assert.equal(all.length, 1);
+  assert.deepEqual(all[0].vouch, { url: "https://trusted.example/", verified: true });
+});
+
+test("a failed vouch attempt round-trips distinctly from no vouch", () => {
+  const all = parseInteractions(mods(raw({ vouch: { url: "https://untrusted.example/", verified: false } })));
+  assert.equal(all[0].vouch?.verified, false);
+});
+
+test("vouch is undefined when absent", () => {
+  const all = parseInteractions(mods(raw()));
+  assert.equal(all[0].vouch, undefined);
+});
+
+test("rejects a non-http(s) vouch.url", () => {
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+  try {
+    const all = parseInteractions(
+      mods(raw({ vouch: { url: "javascript:alert(1)", verified: true } })),
+    );
+    assert.equal(all.length, 0);
+    assert.equal(warnings.length, 1);
+  } finally {
+    console.warn = origWarn;
+  }
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd Resources/Template && npx tsx --test src/lib/interactions.test.ts`
+Expected: FAIL — `vouch` is an unrecognized key that Zod silently strips (so `all[0].vouch` is `undefined` even in the "present" case) or, depending on the exact zod version's default object mode, is stripped without error either way the assertion on the round-tripped value fails.
+
+- [ ] **Step 3: Implement**
+
+In `Resources/Template/src/lib/interactions.ts`, add to `interactionSchema` (after `verificationStatus`):
+
+```ts
+  verificationStatus: z.enum(["verified", "pending", "failed"]),
+  /**
+   * The sender's Vouch outcome (indieweb.org/Vouch), when a vouch was supplied and the mention
+   * verified. `verified: false` means a vouch was attempted but didn't check out — distinct from
+   * no vouch at all, and worth surfacing since a failed vouch is a stronger spam signal than
+   * silence.
+   */
+  vouch: z
+    .object({
+      url: httpUrl,
+      verified: z.boolean(),
+    })
+    .optional(),
+});
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd Resources/Template && npx tsx --test src/lib/interactions.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Run the full template test suite and commit**
+
+```bash
+cd Resources/Template
+npm run test:scripts
+cd ../..
+git add Resources/Template/src/lib/interactions.ts Resources/Template/src/lib/interactions.test.ts
+git commit -m "feat(#1597): add vouch to the received-interaction schema"
+```
+
+---
+
+### Task 10: render the trust badge in `Interactions.astro`, final verification, PR
+
+**Files:**
+- Modify: `Resources/Template/src/components/Interactions.astro`
+
+**Interfaces:**
+- Consumes: `ReceivedInteraction.vouch` (Task 9's Zod type).
+
+- [ ] **Step 1: Add the badge to comments**
+
+In `Resources/Template/src/components/Interactions.astro`, inside the comments `<li>` template, add the badge right after the author byline and before the `dt-published` link:
+
+```astro
+                <div class="comment-body">
+                  <p class="comment-meta">
+                    {c.author?.url ? (
+                      <a class="u-author h-card" href={c.author.url} rel="nofollow ugc">
+                        {c.author?.name ?? new URL(c.author.url).hostname}
+                      </a>
+                    ) : (
+                      <span class="u-author h-card">{c.author?.name ?? new URL(c.source).hostname}</span>
+                    )}
+                    {c.vouch && (
+                      <span class={`trust-badge ${c.vouch.verified ? "trust-vouched" : "trust-unverified"}`}>
+                        {c.vouch.verified ? "Vouched" : "Unverified vouch"}
+                      </span>
+                    )}
+                    <a class="u-url" href={c.source} rel="nofollow ugc">
+                      <time class="dt-published" datetime={c.published}>
+                        {human(c.published)}
+                      </time>
+                    </a>
+                  </p>
+                  {c.content && <p class="p-content">{c.content}</p>}
+                </div>
+```
+
+- [ ] **Step 2: Add the badge to the "Mentioned by" list**
+
+Change the mentions block to:
+
+```astro
+      {g.mentions.length > 0 && (
+        <p class="mentions">
+          Mentioned by{" "}
+          {g.mentions.map((m, index) => (
+            <>
+              <a class="h-cite" href={m.source} rel="nofollow ugc">
+                {m.author?.name ?? new URL(m.source).hostname}
+              </a>
+              {m.vouch && (
+                <span class={`trust-badge ${m.vouch.verified ? "trust-vouched" : "trust-unverified"}`}>
+                  {m.vouch.verified ? "Vouched" : "Unverified vouch"}
+                </span>
+              )}
+              {index < g.mentions.length - 1 ? ", " : ""}
+            </>
+          ))}
+        </p>
+      )}
+```
+
+- [ ] **Step 3: Add the badge styles**
+
+In the `<style>` block, after `.mentions`:
+
+```css
+  .trust-badge {
+    display: inline-block;
+    margin-left: 0.4rem;
+    padding: 0.05rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    vertical-align: middle;
+  }
+  .trust-vouched {
+    background: var(--color-success-surface, #dcfce7);
+    color: var(--color-success-text, #166534);
+  }
+  .trust-unverified {
+    background: var(--color-warning-surface, #fef3c7);
+    color: var(--color-warning-text, #92400e);
+  }
+```
+
+- [ ] **Step 4: Manually verify the render in a browser**
+
+Astro components using `import.meta.glob` aren't unit-testable directly (per the existing `interactions.test.ts` design — pure logic lives in `interactions.ts`, glob lives in the `.astro` file), so this needs a real build. In a scratch site or the template's own dev checkout:
+
+1. Create three fixture files under `data/interactions/` in a test site (or temporarily in `Resources/Template/data/interactions/` if that directory is used for local preview — check first with `ls Resources/Template/data/interactions/`):
+   - one with `vouch: { url: "https://trusted.example/", verified: true }` targeting a real page on the site,
+   - one with `vouch: { url: "https://untrusted.example/", verified: false }`,
+   - one with no `vouch` key at all.
+2. Run `npm run dev` from `Resources/Template/` (or the equivalent scaffolded site) and open the page whose canonical URL matches those fixtures' `target`.
+3. Confirm: the vouched one shows a green "Vouched" badge, the failed one shows an amber "Unverified vouch" badge, the plain one shows no badge, and existing (no-vouch) interaction rendering is visually unchanged.
+4. Remove any fixture files you added that aren't meant to be committed.
+
+- [ ] **Step 5: Run `astro check` and the full test suites**
+
+```bash
+cd Resources/Template
+npx astro check
+npm run test:scripts
+cd ../..
+swift test --package-path .
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Resources/Template/src/components/Interactions.astro
+git commit -m "feat(#1597): render vouch trust badge on received interactions"
+```
+
+- [ ] **Step 7: Push and open the PR**
+
+Confirm with the user before pushing/opening the PR (per the standing safety rules on pushing code and creating PRs — the design being pre-approved doesn't cover this step).
+
+```bash
+git push -u origin claude/issue-1597-567179
+```
+
+Open the PR using `.github/PULL_REQUEST_TEMPLATE.md`'s exact headings (Summary, Paired PR check, Test plan — see `CONTRIBUTING.md` ▸ "Commits and pull requests"). The **Paired PR check** section should note the sidecar PR (`davidwkeith/workers`, Task 5) that shipped first. Body includes `Closes #1597`.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** every section of the design doc maps to a task — `WebmentionJob.vouch`/receive parsing (Task 1), D1 storage (Task 2), `verifyVouch` + log event (Task 3), queue-consumer wiring (Task 4), release (Task 5), D1 client (Task 6), Swift model (Task 7), sync mapping (Task 8), Zod schema (Task 9), Astro render + manual verification (Task 10). The "no moderation queue" non-goal has no task, correctly — it's an explicit absence, not a deliverable.
+- **Placeholder scan:** no TBD/TODO steps. Task 6 explicitly explains why a third "legacy row" test isn't needed (the existing `decodesLegacyRowsWithNullEnrichmentColumns` test already covers it) rather than silently omitting coverage.
+- **Type consistency:** `VouchResult { verified: boolean }` (Task 3) → consumed by the queue consumer (Task 4) → stored as `VerifiedMention.vouch: { url, verified }` (Task 2) → read as `Mention.vouchURL`/`.vouchVerified` (Task 6) → mapped to `ReceivedInteraction.Vouch { url: URL, verified: Bool }` (Task 7/8) → Zod `vouch: { url: httpUrl, verified: z.boolean() }` (Task 9) → rendered via `c.vouch`/`m.vouch` (Task 10). Names match at every hop.

--- a/docs/superpowers/plans/2026-08-20-vouch-webmention.md
+++ b/docs/superpowers/plans/2026-08-20-vouch-webmention.md
@@ -10,6 +10,13 @@
 
 Full design: [`docs/superpowers/specs/2026-08-20-vouch-webmention-design.md`](../specs/2026-08-20-vouch-webmention-design.md).
 
+**Status (2026-08-20): Tasks 1–5 (the sidecar half) are done and merged —
+[davidwkeith/workers#505](https://github.com/davidwkeith/workers/pull/505).** Do not re-run
+Task 1's worktree-creation step or re-open a PR for that work. **However, PR review on the
+Anglesite side (#1604) found the shipped `verifyVouch` semantics are inverted from the actual
+protocol — see the design spec's "Known issue" section before touching Task 6 or later.** A
+correctness fix to the already-merged sidecar code is pending a decision on trust-list scope.
+
 ## Global Constraints
 
 - Sidecar repo (`davidwkeith/workers`): Node.js >= 22, pnpm 10 (`corepack enable`). Before any PR: `pnpm lint && pnpm format:check && pnpm typecheck && pnpm build && pnpm test` must pass (CONTRIBUTING.md ▸ "Development workflow").
@@ -30,17 +37,17 @@ Do this work in a worktree off `origin/main` (the local `main` branch is behind 
 ### Task 1: `WebmentionJob.vouch` + receive-handler parsing
 
 **Files:**
-- Create worktree: `/Users/dwk/Developer/github.com/davidwkeith/workers/.claude/worktrees/vouch-1597/` on a new branch `feat/vouch-webmention` based on `origin/main`
+- Create worktree: `<davidwkeith/workers checkout>/.claude/worktrees/vouch-1597/` on a new branch `feat/vouch-webmention` based on `origin/main` — `davidwkeith/workers` isn't one of the two repos `AGENTS.md`'s `ANGLESITE_SIDECAR_SRC` convention covers, so there's no established env var for it; substitute wherever it's actually cloned (e.g. a sibling of this repo under the same `github.com/` root).
 - Modify: `packages/webmention/src/index.ts` (`WebmentionJob` interface, `createWebmention`)
 - Test: `packages/webmention/src/index.test.ts`
 
 **Interfaces:**
 - Produces: `WebmentionJob.vouch?: string` (raw form value, already validated as a syntactically valid `http(s)` URL — or absent).
 
-- [ ] **Step 1: Create the worktree**
+- [x] **Step 1: Create the worktree**
 
 ```bash
-cd /Users/dwk/Developer/github.com/davidwkeith/workers
+cd <davidwkeith/workers checkout>
 git fetch origin main
 git worktree add .claude/worktrees/vouch-1597 -b feat/vouch-webmention origin/main
 cd .claude/worktrees/vouch-1597
@@ -48,7 +55,7 @@ pnpm install
 pnpm build
 ```
 
-- [ ] **Step 2: Write the failing tests**
+- [x] **Step 2: Write the failing tests**
 
 In `packages/webmention/src/index.test.ts`, change the `formPost` helper to accept an optional third argument, and add two new `it` blocks inside `describe("createWebmention", ...)`:
 
@@ -111,12 +118,12 @@ function formPost(source?: string, target?: string, vouch?: string): Request {
   });
 ```
 
-- [ ] **Step 3: Run the tests to verify they fail**
+- [x] **Step 3: Run the tests to verify they fail**
 
 Run: `pnpm test --project @dwk/webmention -- -t "vouch"`
 Expected: FAIL — `sent[0]` has no `vouch` key yet (the job is still just `{ source, target }`).
 
-- [ ] **Step 4: Implement**
+- [x] **Step 4: Implement**
 
 In `packages/webmention/src/index.ts`, add `vouch` to `WebmentionJob`:
 
@@ -172,12 +179,12 @@ Then in `createWebmention`, read it and thread it into the enqueue call:
     });
 ```
 
-- [ ] **Step 5: Run the tests to verify they pass**
+- [x] **Step 5: Run the tests to verify they pass**
 
 Run: `pnpm test --project @dwk/webmention -- -t "vouch"`
 Expected: PASS
 
-- [ ] **Step 6: Run the full package gate and commit**
+- [x] **Step 6: Run the full package gate and commit**
 
 ```bash
 pnpm --filter @dwk/webmention typecheck
@@ -199,7 +206,7 @@ git commit -m "feat(webmention): accept an optional vouch URL on receive"
 - Consumes: nothing from Task 1.
 - Produces: `VerifiedMention.vouch?: { readonly url: string; readonly verified: boolean }`; `InboxStore.store()`/`list()` round-trip it via new `vouch_url TEXT` / `vouch_verified INTEGER` columns.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Add to `packages/webmention/src/inbox.test.ts` (inside `describe("createD1Inbox", ...)`):
 
@@ -288,12 +295,12 @@ Add to `packages/webmention/src/inbox.test.ts` (inside `describe("createD1Inbox"
   });
 ```
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [x] **Step 2: Run the tests to verify they fail**
 
 Run: `pnpm test --project @dwk/webmention -- -t "vouch"`
 Expected: FAIL — `vouch` is not a recognized field on `VerifiedMention`/not persisted.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `packages/webmention/src/inbox.ts`:
 
@@ -377,6 +384,17 @@ In `store()`, extend the `INSERT`:
     },
 ```
 
+**Note (raised in review):** `ON CONFLICT DO UPDATE` unconditionally overwrites `vouch_url`/
+`vouch_verified` with `excluded.*` — a re-sent webmention for the same `(source, target)` that
+arrives *without* a vouch will wipe a previously-verified one, and the badge silently
+disappears on a resend. This matches how the existing `rsvp`/enrichment columns already behave
+(same unconditional overwrite), so it's consistent with precedent, not a new gap — but it means
+`vouch` (like `rsvp`, `interactionType`, `author`, `content`) is a property of the *latest
+delivery*, not a permanent property of the mention. Documented here rather than changed:
+switching to `COALESCE(excluded.vouch_url, ${table}.vouch_url)` (sticky-until-explicitly-
+cleared) would be a real behavior change affecting every existing column this way, not just
+vouch, and is out of scope for this plan.
+
 In `list()`, extend the selected columns and the row mapping:
 
 ```ts
@@ -411,12 +429,12 @@ In `list()`, extend the selected columns and the row mapping:
         };
 ```
 
-- [ ] **Step 4: Run the tests to verify they pass**
+- [x] **Step 4: Run the tests to verify they pass**
 
 Run: `pnpm test --project @dwk/webmention -- -t "vouch"`
 Expected: PASS
 
-- [ ] **Step 5: Run the full package gate and commit**
+- [x] **Step 5: Run the full package gate and commit**
 
 ```bash
 pnpm --filter @dwk/webmention typecheck
@@ -440,7 +458,7 @@ git commit -m "feat(webmention): store vouch outcome on the inbox record"
 - Consumes: `safeFetch`, `readBodyCapped`, `FetchLike` (`@dwk/safe-fetch`); `isHtmlContentType` (`./html.js`); `extractLinks` (already local to `verify.ts`); `hostFromUrl`, `noopLogger`, `noopMetrics` (`@dwk/log`).
 - Produces: `verifyVouch(vouchUrl: string, target: string, options?: VerifyOptions): Promise<VouchResult>` where `VouchResult = { readonly verified: boolean }`. Never throws.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Add to `packages/webmention/src/verify.test.ts` (new top-level `describe`, after the existing `describe("verifySource", ...)` block):
 
@@ -520,17 +538,17 @@ And update the import line at the top of the file:
 import { extractLinks, sourceLinksTo, verifySource, verifyVouch } from "./verify.js";
 ```
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [x] **Step 2: Run the tests to verify they fail**
 
 Run: `pnpm test --project @dwk/webmention -- -t "verifyVouch"`
 Expected: FAIL — `verifyVouch` is not exported.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `packages/webmention/src/log.ts`, add a new event (after `VerifyFetchFailed`):
 
 ```ts
-  /** Vouch verification finished. Fields: `verified`. */
+  /** Vouch verification finished (every exit path, not just the success path). Fields: `verified`, `reason`. */
   VouchVerified: "webmention.vouch.verified",
 ```
 
@@ -559,6 +577,22 @@ export interface VouchResult {
  * non-2xx status, non-HTML response, or oversized/unreadable body yields
  * `{ verified: false }`; this function never throws.
  */
+```
+
+> **This function's target-matching semantics are under revision — see the design spec's
+> "Known issue" section.** The code below still shows the original (buggy) hostname-matching
+> logic pending that decision; the logging fix (emitting `VouchVerified` on every exit path,
+> not just the one that reaches the link check) applies regardless of which URL ends up being
+> matched, so it's written correctly below. Do not implement this task from the plan text alone
+> until the design spec's "Known issue" section shows a resolved status.
+
+Every early return below previously skipped the `VouchVerified` log/metric entirely — so the
+counter only ever fired for "page fetched fine, checked its links," and every other failure
+mode (SSRF block, fetch throw, non-2xx, wrong content type, oversized body) was invisible,
+making it impossible to tell "vouches are failing" from "nobody sends vouches" from the logs.
+Fix: a single exit point that always emits `VouchVerified` with a `reason` field:
+
+```typescript
 export async function verifyVouch(
   vouchUrl: string,
   target: string,
@@ -569,11 +603,32 @@ export async function verifyVouch(
   const logger = options?.logger ?? noopLogger;
   const metrics = options?.metrics ?? noopMetrics;
 
+  const record = (
+    verified: boolean,
+    reason:
+      | "ok"
+      | "invalid-target"
+      | "fetch-failed"
+      | "not-ok"
+      | "not-html"
+      | "body-unreadable",
+  ): VouchResult => {
+    const fields = {
+      vouchHost: hostFromUrl(vouchUrl),
+      targetHost: hostFromUrl(target),
+      verified,
+      reason,
+    };
+    logger.info(WebmentionLogEvent.VouchVerified, fields);
+    metrics.count(WebmentionLogEvent.VouchVerified, fields);
+    return { verified };
+  };
+
   let targetHost: string;
   try {
     targetHost = new URL(target).hostname.toLowerCase();
   } catch {
-    return { verified: false };
+    return record(false, "invalid-target");
   }
 
   let response: Response;
@@ -593,21 +648,21 @@ export async function verifyVouch(
     response = result.response;
     base = result.url;
   } catch {
-    return { verified: false };
+    return record(false, "fetch-failed");
   }
 
   if (!response.ok) {
-    return { verified: false };
+    return record(false, "not-ok");
   }
 
   const contentType = response.headers.get("content-type") ?? "";
   if (!isHtmlContentType(contentType)) {
-    return { verified: false };
+    return record(false, "not-html");
   }
 
   const body = await readBodyCapped(response);
   if (body === null) {
-    return { verified: false };
+    return record(false, "body-unreadable");
   }
 
   const links = await extractLinks(body, base);
@@ -619,14 +674,7 @@ export async function verifyVouch(
     }
   });
 
-  const fields = {
-    vouchHost: hostFromUrl(vouchUrl),
-    targetHost: hostFromUrl(target),
-    verified,
-  };
-  logger.info(WebmentionLogEvent.VouchVerified, fields);
-  metrics.count(WebmentionLogEvent.VouchVerified, fields);
-  return { verified };
+  return record(verified, "ok");
 }
 ```
 
@@ -644,12 +692,12 @@ export {
 } from "./verify.js";
 ```
 
-- [ ] **Step 4: Run the tests to verify they pass**
+- [x] **Step 4: Run the tests to verify they pass**
 
 Run: `pnpm test --project @dwk/webmention -- -t "verifyVouch"`
 Expected: PASS
 
-- [ ] **Step 5: Run the full package gate and commit**
+- [x] **Step 5: Run the full package gate and commit**
 
 ```bash
 pnpm --filter @dwk/webmention typecheck
@@ -672,7 +720,7 @@ git commit -m "feat(webmention): verify vouch URLs against the target's domain"
 - Consumes: `WebmentionJob.vouch` (Task 1), `verifyVouch` (Task 3), `VerifiedMention.vouch` (Task 2).
 - Produces: a stored mention carries `vouch` exactly when `message.body.vouch` was present and the mention itself verified (`result.links === true`).
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Add to `packages/webmention/src/index.test.ts` (inside `describe("createWebmentionQueueConsumer", ...)`):
 
@@ -799,12 +847,12 @@ Add to `packages/webmention/src/index.test.ts` (inside `describe("createWebmenti
   });
 ```
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [x] **Step 2: Run the tests to verify they fail**
 
 Run: `pnpm test --project @dwk/webmention -- -t "vouch"`
 Expected: FAIL — the consumer never calls `verifyVouch` yet, so `stored?.vouch` is always `undefined` and the "never fetches" test's premise doesn't yet distinguish behavior.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `packages/webmention/src/index.ts`, inside `createWebmentionQueueConsumer`'s loop, change:
 
@@ -862,12 +910,12 @@ and change the `if (result.links) { ... }` block to:
         }
 ```
 
-- [ ] **Step 4: Run the tests to verify they pass**
+- [x] **Step 4: Run the tests to verify they pass**
 
 Run: `pnpm test --project @dwk/webmention -- -t "vouch"`
 Expected: PASS
 
-- [ ] **Step 5: Run the full package gate and commit**
+- [x] **Step 5: Run the full package gate and commit**
 
 ```bash
 pnpm --filter @dwk/webmention typecheck
@@ -885,7 +933,7 @@ git commit -m "feat(webmention): verify vouch URLs during queue consumption"
 - Create: `.changeset/webmention-vouch.md`
 - Modify: `packages/webmention/package.json` (version)
 
-- [ ] **Step 1: Add the changeset**
+- [x] **Step 1: Add the changeset**
 
 ```bash
 cat > .changeset/webmention-vouch.md <<'EOF'
@@ -907,11 +955,11 @@ Anglesite/Anglesite#1597.
 EOF
 ```
 
-- [ ] **Step 2: Bump the package version**
+- [x] **Step 2: Bump the package version**
 
 Edit `packages/webmention/package.json`, changing `"version": "1.0.0-beta.1"` to `"version": "1.0.0-beta.2"`.
 
-- [ ] **Step 3: Run the full repo gate**
+- [x] **Step 3: Run the full repo gate**
 
 ```bash
 pnpm lint && pnpm format:check && pnpm typecheck && pnpm build && pnpm test
@@ -919,7 +967,7 @@ pnpm lint && pnpm format:check && pnpm typecheck && pnpm build && pnpm test
 
 Expected: all green. Fix any failure before proceeding — do not skip a failing check.
 
-- [ ] **Step 4: Commit, push, open the PR**
+- [x] **Step 4: Commit, push, open the PR**
 
 ```bash
 git add .changeset/webmention-vouch.md packages/webmention/package.json
@@ -929,7 +977,20 @@ git push -u origin feat/vouch-webmention
 
 Confirm with the user before running `gh pr create` (pushing/opening a PR needs explicit confirmation per the standing safety rules — do not skip this even though the design was pre-approved). Once confirmed, open the PR against `davidwkeith/workers` main with a summary of the vouch feature and `part of Anglesite/Anglesite#1597` in the body (no closing keyword — see Global Constraints).
 
-**Do not proceed to Task 6 until this PR has merged and a tagged `1.0.0-beta.2` (or later) release of `@dwk/webmention` is published to npm** — Task 6 bumps Anglesite's dependency on that exact published version. Check with `npm view @dwk/webmention versions --json`.
+**Status: done.** [davidwkeith/workers#505](https://github.com/davidwkeith/workers/pull/505)
+was opened, reviewed, and merged. One review finding required a follow-up commit: the manual
+`package.json` version bump in Step 2 above conflicts with `RELEASING.md`'s documented flow
+(version bumps come only from a dedicated `pnpm changeset version` run) — it was reverted back
+to `1.0.0-beta.1`, keeping the changeset file for that step to consume normally. **This means
+the actual next `@dwk/webmention` version is whatever the sidecar's real release run produces —
+not `1.0.0-beta.2`** as Step 2 above still literally says; treat that version number as
+illustrative, not exact.
+
+**Do not proceed to Task 6 until a tagged `@dwk/webmention` release containing this PR's commits
+is published to npm** — Task 6 bumps Anglesite's dependency on that exact published version.
+Check with `npm view @dwk/webmention versions --json` and cross-reference against
+[davidwkeith/workers#505](https://github.com/davidwkeith/workers/pull/505)'s merge commit to
+confirm the vouch commits are actually included in whatever version comes back.
 
 ---
 
@@ -943,7 +1004,7 @@ Confirm with the user before running `gh pr create` (pushing/opening a PR needs 
 - Test: `Tests/AnglesiteCoreTests/WebmentionInboxD1ClientTests.swift`
 
 **Interfaces:**
-- Produces: `WebmentionInboxD1Client.Mention.vouchURL: String? = nil`, `.vouchVerified: Bool? = nil` (defaulted so all 13 existing call sites keep compiling unchanged).
+- Produces: `WebmentionInboxD1Client.Mention.vouchURL: String?`, `.vouchVerified: Bool?`, via a new explicit `init` (defaulting both to `nil`) — see Step 4 for why a stored-property default alone doesn't work here. All 13 existing call sites keep compiling unchanged.
 
 - [ ] **Step 1: Bump the template's pinned version**
 
@@ -997,7 +1058,56 @@ Add to `Tests/AnglesiteCoreTests/WebmentionInboxD1ClientTests.swift`, after `lis
         #expect(mention.vouchVerified == false)
     }
 
+    @Test("falls back to the legacy column set when the site's worker hasn't migrated the vouch columns yet")
+    func fallsBackWhenVouchColumnsAreMissing() async throws {
+        let missingColumnBody = Data("""
+        {"success": false, "errors": [{"code": 7500, "message": "D1_ERROR: no such column: vouch_url: SQLITE_ERROR"}]}
+        """.utf8)
+        let legacyBody = Data("""
+        {"success": true, "result": [{"success": true, "results": [
+            {"id": "wm-abc123", "source": "https://alice.example/post", "target": "https://me.example/blog/hi",
+             "verified_at": 1753300000000, "interaction_type": "reply", "author_name": "Alice",
+             "author_url": "https://alice.example", "author_photo": "https://alice.example/photo.jpg",
+             "content": "Great post!", "published_at": 1753299000000}
+        ]}]}
+        """.utf8)
+
+        let attempts = ActorBox<Int>(0)
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in
+                let n = await attempts.get()
+                await attempts.set(n + 1)
+                return n == 0 ? (missingColumnBody, Self.response(200)) : (legacyBody, Self.response(200))
+            })
+
+        let mentions = try await client.listVerifiedMentions()
+        let mention = try #require(mentions.first)
+        #expect(mention.id == "wm-abc123")
+        #expect(mention.vouchURL == nil)
+        #expect(mention.vouchVerified == nil)
+        #expect(await attempts.get() == 2)
+    }
+
+    @Test("still throws when the D1 failure is unrelated to a missing column")
+    func doesNotFallBackOnUnrelatedError() async throws {
+        let body = Data("""
+        {"success": false, "errors": [{"code": 7500, "message": "D1_ERROR: database is locked"}]}
+        """.utf8)
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (body, Self.response(200)) })
+
+        await #expect(throws: CloudflareError.api(message: "D1_ERROR: database is locked")) {
+            _ = try await client.listVerifiedMentions()
+        }
+    }
+
 ```
+
+`fallsBackWhenVouchColumnsAreMissing` reuses the `ActorBox` helper already defined at the
+bottom of this test file (used by `WebmentionInboxD1ClientTests`'s
+`sendsPostToD1QueryEndpoint` test) as a simple mutable counter — no new helper needed.
 
 Do not add a third "no vouch columns present" test — the existing
 `decodesLegacyRowsWithNullEnrichmentColumns` test already covers it unmodified:
@@ -1013,22 +1123,57 @@ Expected: FAIL to compile — `Mention` has no `vouchURL`/`vouchVerified` member
 
 - [ ] **Step 4: Implement**
 
-In `Sources/AnglesiteCore/WebmentionInboxD1Client.swift`, extend `Mention`:
+In `Sources/AnglesiteCore/WebmentionInboxD1Client.swift`, extend `Mention`.
+
+**Important:** a `let` stored property *with* a default value (`= nil`) is excluded from
+Swift's synthesized memberwise initializer — it's already considered initialized and the
+compiler drops it from the generated `init` entirely. Giving the two new properties `= nil`
+at their declaration would silently make them permanently `nil`: `Mention`'s memberwise init
+would gain no `vouchURL:`/`vouchVerified:` parameters at all, so the mapping code below
+wouldn't compile (extra-argument error), and if it were adjusted to compile some other way,
+`mention.vouchURL` would never be anything but `nil`. The fix is an **explicit `init`** with
+the two new parameters defaulted — the same pattern `ReceivedInteraction.Author` (Task 7's
+`ReceivedInteraction.swift`) already uses for its own optional fields:
 
 ```swift
-        /// Source page's declared publication date in epoch milliseconds, when enrichment ran.
         public let publishedAt: Int?
         /// The sender's Vouch URL (indieweb.org/Vouch), when supplied and the mention verified.
         /// `nil` when no vouch was sent, or the row predates vouch support upstream.
-        public let vouchURL: String? = nil
+        public let vouchURL: String?
         /// Whether `vouchURL` was confirmed to link to this mention's target domain. `nil` exactly
         /// when `vouchURL` is `nil`; otherwise `true`/`false` — a failed vouch attempt is still
         /// recorded (not collapsed into "no vouch"), since it's a stronger spam signal than silence.
-        public let vouchVerified: Bool? = nil
+        public let vouchVerified: Bool?
+
+        /// Creates a mention row. `vouchURL`/`vouchVerified` default to `nil` so every existing
+        /// call site (production and test) that predates vouch support keeps compiling unchanged.
+        init(
+            id: String, source: String, target: String, verifiedAt: Int,
+            interactionType: String?, authorName: String?, authorURL: String?, authorPhoto: String?,
+            content: String?, publishedAt: Int?,
+            vouchURL: String? = nil, vouchVerified: Bool? = nil
+        ) {
+            self.id = id
+            self.source = source
+            self.target = target
+            self.verifiedAt = verifiedAt
+            self.interactionType = interactionType
+            self.authorName = authorName
+            self.authorURL = authorURL
+            self.authorPhoto = authorPhoto
+            self.content = content
+            self.publishedAt = publishedAt
+            self.vouchURL = vouchURL
+            self.vouchVerified = vouchVerified
+        }
     }
 ```
 
-(The `= nil` defaults on `Mention`'s new stored properties keep its synthesized memberwise initializer backward-compatible — all 13 existing call sites across the codebase keep compiling with no vouch arguments.)
+This gives `Mention` an explicit `init` for the first time — it previously relied on the
+synthesized memberwise one. All 13 existing call sites across the codebase (production and
+tests) omit `vouchURL`/`vouchVerified` and keep compiling unchanged via the new init's
+defaults, exactly as intended — verify this by running the full `WebmentionInboxD1ClientTests`
+and `ReceivedInteractionSyncTests` suites in Step 5, not just the new vouch-specific tests.
 
 Extend `Row`:
 
@@ -1049,30 +1194,105 @@ Extend `Row`:
     }
 ```
 
-Extend `listVerifiedSQL`:
+Add a second, legacy SQL constant, and extend `Envelope` to decode D1's error detail so a
+"missing column" failure can be recognized (rather than only ever throwing a generic
+`.malformedResponse`):
 
 ```swift
     private static let listVerifiedSQL = """
     SELECT id, source, target, verified_at, interaction_type, author_name, author_url, \
     author_photo, content, published_at, vouch_url, vouch_verified FROM webmentions ORDER BY verified_at DESC
     """
+
+    /// Column set from before vouch support existed. Used as a fallback when a site's D1
+    /// database hasn't been migrated yet — see `listVerifiedMentions()`'s deploy-ordering
+    /// handling below.
+    private static let listVerifiedSQLLegacy = """
+    SELECT id, source, target, verified_at, interaction_type, author_name, author_url, \
+    author_photo, content, published_at FROM webmentions ORDER BY verified_at DESC
+    """
 ```
 
-Extend the mapping in `listVerifiedMentions()`:
+```swift
+    private struct D1ErrorDetail: Decodable {
+        let message: String
+    }
+
+    private struct Envelope: Decodable {
+        let success: Bool
+        let result: [QueryResult]?
+        let errors: [D1ErrorDetail]?
+    }
+```
+
+**Deploy-ordering hazard this closes:** `Resources/Template/package.json`'s `@dwk/webmention`
+version bump (Step 1) only affects newly scaffolded or rebuilt sites — it does nothing to a
+worker already running in someone's Cloudflare account. Until that site's owner redeploys, its
+D1 database's `webmentions` table has no `vouch_url`/`vouch_verified` columns at all, and
+`SELECT`ing them is a hard SQLite error (`no such column`), not a `NULL` — unlike the existing
+"tolerates enrichment columns being entirely `NULL`" case, which only covers *values*, not
+*missing columns*. Left unhandled, `listVerifiedMentions()` would throw on every call for an
+un-redeployed site, and `ReceivedInteractionSync.pullAndCommit` already treats any thrown error
+as "sync did nothing this time" (`guard let mentions = try? await client.listVerifiedMentions()
+else { return 0 }`) — so **all** interaction syncing for that site would silently stop, not
+just vouch data, until the owner happens to redeploy.
+
+Fix: catch specifically a "no such column" failure and retry once with the legacy column set,
+so an un-redeployed site keeps syncing everything except vouch data (degrading gracefully,
+matching the intent of the existing NULL-tolerance note) rather than syncing nothing. Split the
+existing request/decode logic out of `listVerifiedMentions()` into a private `queryMentions`
+helper parameterized on which SQL/column set to use, and make `listVerifiedMentions()` itself
+the two-attempt wrapper:
 
 ```swift
+    public func listVerifiedMentions() async throws -> [Mention] {
+        do {
+            return try await queryMentions(sql: Self.listVerifiedSQL, includeVouch: true)
+        } catch CloudflareError.api(let message)
+        where message.localizedCaseInsensitiveContains("no such column") {
+            return try await queryMentions(sql: Self.listVerifiedSQLLegacy, includeVouch: false)
+        }
+    }
+
+    private func queryMentions(sql: String, includeVouch: Bool) async throws -> [Mention] {
+        let url = URL(string: "\(baseURL)/accounts/\(accountID)/d1/database/\(databaseID)/query")
+        guard let url else { throw CloudflareError.malformedResponse }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(QueryBody(sql: sql))
+
+        let (data, http) = try await transport(request)
+        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
+        guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
+        guard let envelope = try? JSONDecoder().decode(Envelope.self, from: data) else {
+            throw CloudflareError.malformedResponse
+        }
+        guard envelope.success, let rows = envelope.result?.first?.results else {
+            throw CloudflareError.api(message: envelope.errors?.first?.message ?? "unknown D1 error")
+        }
+
         return rows.compactMap { row in
             guard let id = row.id else { return nil }
             return Mention(
                 id: id, source: row.source, target: row.target, verifiedAt: row.verified_at,
                 interactionType: row.interaction_type, authorName: row.author_name,
                 authorURL: row.author_url, authorPhoto: row.author_photo, content: row.content,
-                publishedAt: row.published_at, vouchURL: row.vouch_url,
-                vouchVerified: row.vouch_verified.map { $0 != 0 })
+                publishedAt: row.published_at,
+                vouchURL: includeVouch ? row.vouch_url : nil,
+                vouchVerified: includeVouch ? row.vouch_verified.map { $0 != 0 } : nil)
         }
+    }
 ```
 
-Also update the class-level doc comment's "tolerates the enrichment columns... being entirely `NULL`" note to mention `vouch_url`/`vouch_verified` alongside the existing list, since the same tolerance now applies to them too.
+(`CloudflareError.api(message:)` already exists in `CloudflareReading.swift` — this reuses it
+rather than adding a new error case.)
+
+Also update the class-level doc comment's "tolerates the enrichment columns... being entirely
+`NULL`" note to mention `vouch_url`/`vouch_verified` alongside the existing list, and add a
+sentence noting that a *missing* vouch column (not just a null value) is handled separately by
+the fallback above.
 
 - [ ] **Step 5: Run the tests to verify they pass**
 
@@ -1388,10 +1608,22 @@ test("rejects a non-http(s) vouch.url", () => {
 });
 ```
 
+`warnings.length === 1` for a single rejected file matches this same test file's existing
+convention — not a new assumption: the "skips malformed files with a warning instead of
+throwing" test asserts `warnings.length === 3` for 3 bad files among 4 inputs, and "rejects
+non-http(s) URL schemes on source/target/author fields" asserts `warnings.length === 4` for 4
+bad inputs — both confirm `parseInteractions` logs exactly one warning per rejected file, never
+more, in this codebase today.
+
 - [ ] **Step 2: Run the tests to verify they fail**
 
 Run: `cd Resources/Template && npx tsx --test src/lib/interactions.test.ts`
-Expected: FAIL — `vouch` is an unrecognized key that Zod silently strips (so `all[0].vouch` is `undefined` even in the "present" case) or, depending on the exact zod version's default object mode, is stripped without error either way the assertion on the round-tripped value fails.
+Expected: FAIL — `interactionSchema` is a plain `z.object()` (Zod's default mode strips unknown
+keys rather than rejecting them), so `vouch` is silently dropped: the "round-trips when present"
+test's `assert.deepEqual(all[0].vouch, {...})` fails because `all[0].vouch` is `undefined`, and
+the "rejects a non-http(s) vouch.url" test fails because the malformed `vouch.url` never reaches
+validation at all (it's stripped, so the file parses as "valid" with `all.length === 1`, not
+`0`).
 
 - [ ] **Step 3: Implement**
 
@@ -1439,6 +1671,24 @@ git commit -m "feat(#1597): add vouch to the received-interaction schema"
 **Interfaces:**
 - Consumes: `ReceivedInteraction.vouch` (Task 9's Zod type).
 
+**Two fixes from review, applied below:**
+1. `--color-success-surface`/`--color-success-text`/`--color-warning-surface`/`--color-warning-text`
+   don't exist anywhere in `Resources/Template/` — every one of them silently fell through to
+   its hardcoded hex fallback. Those hexes are light-mode pastels, and the template *does*
+   theme (`src/styles/global.css` has a `prefers-color-scheme: dark` block redefining
+   `--color-surface`/`--color-text-muted`/etc.), so a dark-themed site would have rendered a
+   bright mint/amber chip against a slate page. Fixed below by building the badge entirely out
+   of tokens that already exist (`--color-primary`, `--color-surface`, `--color-text-muted`) —
+   no `global.css` change needed.
+2. An `Unverified vouch` badge is only reachable when a sender *bothered to send* a vouch that
+   then failed — a spammer who omits the field entirely renders clean, so this badge would only
+   ever land on an honest sender whose vouch page moved or errored, punishing exactly the wrong
+   party. Fixed below by rendering a badge only for `verified === true`; a failed vouch is still
+   stored (Task 2) for the owner to see in the raw data, just not rendered as a claim on the
+   page. This is independent of the open Vouch-semantics question in the design spec (which
+   affects what `verified: true` *means*, not whether a false one should be shown) — revisit
+   once that's resolved.
+
 - [ ] **Step 1: Add the badge to comments**
 
 In `Resources/Template/src/components/Interactions.astro`, inside the comments `<li>` template, add the badge right after the author byline and before the `dt-published` link:
@@ -1453,10 +1703,8 @@ In `Resources/Template/src/components/Interactions.astro`, inside the comments `
                     ) : (
                       <span class="u-author h-card">{c.author?.name ?? new URL(c.source).hostname}</span>
                     )}
-                    {c.vouch && (
-                      <span class={`trust-badge ${c.vouch.verified ? "trust-vouched" : "trust-unverified"}`}>
-                        {c.vouch.verified ? "Vouched" : "Unverified vouch"}
-                      </span>
+                    {c.vouch?.verified && (
+                      <span class="trust-badge" title="This sender named a page that links back to this post">Vouched</span>
                     )}
                     <a class="u-url" href={c.source} rel="nofollow ugc">
                       <time class="dt-published" datetime={c.published}>
@@ -1481,10 +1729,8 @@ Change the mentions block to:
               <a class="h-cite" href={m.source} rel="nofollow ugc">
                 {m.author?.name ?? new URL(m.source).hostname}
               </a>
-              {m.vouch && (
-                <span class={`trust-badge ${m.vouch.verified ? "trust-vouched" : "trust-unverified"}`}>
-                  {m.vouch.verified ? "Vouched" : "Unverified vouch"}
-                </span>
+              {m.vouch?.verified && (
+                <span class="trust-badge" title="This sender named a page that links back to this post">Vouched</span>
               )}
               {index < g.mentions.length - 1 ? ", " : ""}
             </>
@@ -1506,16 +1752,15 @@ In the `<style>` block, after `.mentions`:
     font-size: 0.75rem;
     font-weight: 600;
     vertical-align: middle;
-  }
-  .trust-vouched {
-    background: var(--color-success-surface, #dcfce7);
-    color: var(--color-success-text, #166534);
-  }
-  .trust-unverified {
-    background: var(--color-warning-surface, #fef3c7);
-    color: var(--color-warning-text, #92400e);
+    background: var(--color-surface, #f8fafc);
+    color: var(--color-primary, #2563eb);
+    border: 1px solid var(--color-primary, #2563eb);
   }
 ```
+
+Every token here (`--color-surface`, `--color-primary`) is already defined under both `:root`
+and the `prefers-color-scheme: dark` block in `src/styles/global.css`, so this badge follows
+the site's theme automatically with no new tokens to add.
 
 - [ ] **Step 4: Manually verify the render in a browser**
 
@@ -1526,7 +1771,7 @@ Astro components using `import.meta.glob` aren't unit-testable directly (per the
    - one with `vouch: { url: "https://untrusted.example/", verified: false }`,
    - one with no `vouch` key at all.
 2. Run `npm run dev` from `Resources/Template/` (or the equivalent scaffolded site) and open the page whose canonical URL matches those fixtures' `target`.
-3. Confirm: the vouched one shows a green "Vouched" badge, the failed one shows an amber "Unverified vouch" badge, the plain one shows no badge, and existing (no-vouch) interaction rendering is visually unchanged.
+3. Confirm: the vouched one shows the "Vouched" badge (using the site's `--color-primary`, so check it also looks right in dark mode — resize or toggle `prefers-color-scheme`), the failed one shows **no** badge (per Step 3's fix: a failed vouch is stored but not rendered as a claim), and the plain one is visually identical to interaction rendering before this task.
 4. Remove any fixture files you added that aren't meant to be committed.
 
 - [ ] **Step 5: Run `astro check` and the full test suites**

--- a/docs/superpowers/specs/2026-08-20-vouch-webmention-design.md
+++ b/docs/superpowers/specs/2026-08-20-vouch-webmention-design.md
@@ -1,7 +1,23 @@
 # Vouch protocol for webmention spam mitigation (#1597)
 
-Status: approved for implementation
+Status: **known bug found in PR review, fix in progress** — see "Known issue" below
 Repos touched: `davidwkeith/workers` (`@dwk/webmention`), `Anglesite/Anglesite` (this repo)
+
+## Known issue (found in review of Anglesite/Anglesite#1604, 2026-08-20)
+
+The `verifyVouch` design below (and the shipped implementation in
+[davidwkeith/workers#505](https://github.com/davidwkeith/workers/pull/505), already merged)
+checks that the vouch page links to the **target's** domain. Per
+[indieweb.org/Vouch](https://indieweb.org/Vouch) and this issue's own "Gap" wording ("a URL
+that the target already links to"), the receiver should instead check that the vouch page
+links to the **source's** domain, *and* that the vouch domain is one the receiver already
+trusts (a list, not an open-ended link check) — the trust chain is "someone I already trust
+vouches for this stranger." As designed and shipped, the check is backwards and has no trust
+list, so `vouch=<the source URL itself>` verifies unconditionally once `verifySource` has
+already proven that link exists — a spammer gets a "Vouched" badge for free. The rest of this
+document (and the implementation plan) is being corrected; sections below marked with the
+original (buggy) semantics are being updated in place, not left as historical record, since
+that would leave a live design doc describing a real vulnerability as intended behavior.
 
 ## Problem
 
@@ -27,8 +43,11 @@ ships first in a tagged release, then the app PR consumes it.
 
 Current pinned version in `Resources/Template/package.json` is `@dwk/webmention@1.0.0-beta.1`
 (confirmed against `origin/main` of `davidwkeith/workers`, which is 5 commits ahead of the
-locally checked-out branch). The sidecar change ships as the next prerelease,
-`1.0.0-beta.2`.
+locally checked-out branch). The sidecar change shipped in
+[davidwkeith/workers#505](https://github.com/davidwkeith/workers/pull/505) without a manual
+version bump (review feedback: version bumps come only from a dedicated `pnpm changeset
+version` run per `RELEASING.md`, never hand-edited alongside feature work) — the actual next
+published version is whatever that run produces, not a number this doc can predict.
 
 ## Sidecar: `@dwk/webmention` (davidwkeith/workers)
 
@@ -92,7 +111,10 @@ readonly vouch?: { readonly url: string; readonly verified: boolean };
 Two new D1 columns via the existing `ADDED_COLUMNS` additive-migration list (same mechanism
 already used for `rsvp`, `id`, the mf2 columns): `vouch_url TEXT`, `vouch_verified INTEGER`
 (0/1, nullable). `store()`/`list()` extended to round-trip the nested shape to/from the two flat
-columns.
+columns. `vouch` is a property of the *latest delivery* like every other enrichment column here
+(`rsvp`, `interactionType`, `author`, `content`) — the upsert's `ON CONFLICT DO UPDATE`
+unconditionally overwrites it, so a re-sent mention without a vouch clears a previously-verified
+one. Consistent with existing precedent, not a new gap.
 
 ### Observability
 
@@ -109,7 +131,8 @@ Add `VouchVerified` to `WebmentionLogEvent`, logged/counted the same way
   vouch-verification failure does not affect whether the mention itself is stored/removed;
   malformed `vouch` form field is dropped, not rejected (still enqueues without `vouch`).
 
-Release as `1.0.0-beta.2` via the existing `.changeset/` flow.
+Release via the existing `.changeset/` flow (`pnpm changeset` → later, a dedicated `pnpm
+changeset version` release run) — see the version note above.
 
 ## App side (Anglesite)
 
@@ -152,9 +175,17 @@ A small trust badge next to the author byline in comments (`.comments li`) and i
 "Mentioned by" list — text, not an icon, consistent with the component's current no-emoji
 style:
 
-- `vouch` absent → no badge (unchanged rendering).
-- `vouch.verified === true` → `Vouched` badge.
-- `vouch.verified === false` → `Unverified vouch` badge.
+- `vouch.verified === true` → `Vouched` badge (with a `title` gloss, since "Vouched" is
+  IndieWeb jargon a visitor has never heard of).
+- `vouch` absent, or `vouch.verified === false` → no badge. A failed vouch attempt is still
+  stored (§ inbox schema above) for the owner to see in the raw data, just not rendered as a
+  trust claim on the page — a spammer who omits the vouch parameter entirely renders exactly as
+  clean as one whose vouch failed, so a visible "Unverified vouch" badge would only ever land
+  on an honest sender whose vouch page moved or errored, which is the wrong party to flag.
+
+Badge styling uses only CSS custom properties that already exist in
+`src/styles/global.css` (`--color-primary`, `--color-surface`) — no new tokens, so it follows
+the site's light/dark theme automatically.
 
 Not added to the facepile (likes/reposts render as bare avatars with no room for accompanying
 text; the `title` tooltip already carries author name and isn't extended for this).
@@ -179,10 +210,12 @@ deleting the snapshot file, same as any other unwanted interaction today.
 ## Sequencing
 
 1. Sidecar PR in `davidwkeith/workers`: `verifyVouch`, `WebmentionJob.vouch`, queue-consumer
-   wiring, `inbox.ts` columns, tests. Merge, tag, publish `1.0.0-beta.2`.
-2. Anglesite PR: bump `@dwk/webmention` to `1.0.0-beta.2` in
-   `Resources/Template/package.json`, then the five app-side changes above (D1 client, Swift
-   model, sync, Zod schema, Astro render) with their tests. `Closes #1597`.
+   wiring, `inbox.ts` columns, tests. **Done:**
+   [davidwkeith/workers#505](https://github.com/davidwkeith/workers/pull/505), merged. A
+   correctness follow-up is pending — see "Known issue" above — before step 2 starts.
+2. Anglesite PR: bump `@dwk/webmention` to whatever version the sidecar's release run actually
+   publishes in `Resources/Template/package.json`, then the five app-side changes above (D1
+   client, Swift model, sync, Zod schema, Astro render) with their tests. `Closes #1597`.
 
 ## Non-goals
 

--- a/docs/superpowers/specs/2026-08-20-vouch-webmention-design.md
+++ b/docs/superpowers/specs/2026-08-20-vouch-webmention-design.md
@@ -1,30 +1,70 @@
 # Vouch protocol for webmention spam mitigation (#1597)
 
-Status: **known bug found in PR review, fix in progress** — see "Known issue" below
+Status: sidecar Tasks 1–5 shipped and merged
+([davidwkeith/workers#505](https://github.com/davidwkeith/workers/pull/505)) with an inverted,
+forgeable verification bug found in PR review; the fix design below (source-domain match + a
+real trust list) is approved and awaiting a follow-up sidecar commit before app-side work
+(Task 6+) starts.
 Repos touched: `davidwkeith/workers` (`@dwk/webmention`), `Anglesite/Anglesite` (this repo)
 
-## Known issue (found in review of Anglesite/Anglesite#1604, 2026-08-20)
+## Bug found in review, and its fix (found in review of Anglesite/Anglesite#1604, 2026-08-20)
 
-The `verifyVouch` design below (and the shipped implementation in
-[davidwkeith/workers#505](https://github.com/davidwkeith/workers/pull/505), already merged)
-checks that the vouch page links to the **target's** domain. Per
-[indieweb.org/Vouch](https://indieweb.org/Vouch) and this issue's own "Gap" wording ("a URL
-that the target already links to"), the receiver should instead check that the vouch page
-links to the **source's** domain, *and* that the vouch domain is one the receiver already
-trusts (a list, not an open-ended link check) — the trust chain is "someone I already trust
-vouches for this stranger." As designed and shipped, the check is backwards and has no trust
-list, so `vouch=<the source URL itself>` verifies unconditionally once `verifySource` has
-already proven that link exists — a spammer gets a "Vouched" badge for free. The rest of this
-document (and the implementation plan) is being corrected; sections below marked with the
-original (buggy) semantics are being updated in place, not left as historical record, since
-that would leave a live design doc describing a real vulnerability as intended behavior.
+The originally-shipped `verifyVouch` checked that the vouch page links to the **target's**
+domain, with no trust list at all. Per [indieweb.org/Vouch](https://indieweb.org/Vouch) and
+this issue's own "Gap" wording ("a URL that the target already links to"), the receiver should
+instead check that the vouch page links to the **source's** domain, *and* that the vouch
+domain is one the receiver already trusts — the trust chain is "someone I already trust
+vouches for this stranger." As shipped, the check was backwards and had no trust list, so
+`vouch=<the source URL itself>` verified unconditionally once `verifySource` had already
+proven that link exists — a spammer got a "Vouched" badge for free. **Every section below
+describes the corrected design**, not the originally-shipped one; the corrected algorithm and
+the trust-list source are covered in their own sections right after "Where the logic belongs."
+
+### The trust list: reuse the existing blogroll
+
+The template already has a blogroll content collection (`src/content/blogroll/*.md`, OPML
+export at `/blogroll.opml`) — exactly what Vouch means by "domains the target already links
+to." No new content type or UI: the owner already maintains this list for an unrelated reason
+(their public reading list), and it happens to be precisely the right trust source.
+
+Reaching the Worker mirrors the pattern `#1567` already built for the contacts allowlist
+(`ContactsAllowlistSync` → `ContactsAllowlistKVClient` → `SOCIAL_KV` key `contacts:allowlist`
+→ `reader-identity.ts`'s `isAllowedReader`) — same `SOCIAL_KV` namespace, a new key:
+
+- **New Swift pair**, `BlogrollTrustSync`/`BlogrollTrustKVClient`, structurally identical to
+  `ContactsAllowlistSync`/`ContactsAllowlistKVClient`: reads every `src/content/blogroll/*.md`
+  entry's `url` frontmatter field, extracts `new URL(url).hostname` for each, and `PUT`s the
+  sorted, deduplicated set as a JSON array to `SOCIAL_KV` under key `vouch:trusted-domains` —
+  same whole-set-replace, self-healing, never-throws design as the contacts sync (frontmatter
+  parsing already exists broadly in `AnglesiteCore` — no new capability needed there).
+- **Trigger:** deploy-time only, mirroring `DeployModel`'s post-deploy `ContactsAllowlistSync`
+  call. The trust list doesn't need real-time freshness the way reader-auth's allowlist does,
+  and this avoids hunting down every blogroll-editing code path for an immediate-push trigger.
+- **Read side:** a new `worker/vouch-trust.ts`, structurally identical to
+  `reader-identity.ts`'s `readAllowlist`/`isAllowedReader` — missing `SOCIAL_KV`, missing key,
+  or malformed JSON all degrade to an empty set ("nothing trusted yet"), never a hard failure.
+  A site with an empty or unprovisioned blogroll has no trust list, which correctly means every
+  vouch is unverified — not that everything is trusted.
+
+### The corrected algorithm
+
+1. **Check the trust list first, before any fetch:** `hostname(vouchUrl)` must be in the
+   trusted-domains set. Untrusted → `verified: false`, **no outbound fetch happens at all** —
+   this also closes a fetch-amplification concern raised in review (every verified mention
+   would otherwise trigger a second outbound fetch to an attacker-named URL).
+2. Only if the vouch domain is trusted, fetch the vouch URL (same SSRF-safe `safeFetch` as
+   `verifySource`) and check whether it links anywhere under the **source's** hostname — not
+   the target's, and not an exact-URL match, matching the spec's "contains a hyperlink to the
+   domain used in source" wording.
+3. `verified: true` only when both hold.
 
 ## Problem
 
 Anglesite receives and verifies inbound Webmentions (`Resources/Template/worker/worker.ts`
 → `@dwk/webmention`), but link-verification (source really links to target) is the only
 trust signal. There's no [Vouch](https://indieweb.org/Vouch) support: an optional sender-supplied
-URL that, when it also links to the target's domain, raises confidence the mention isn't spam.
+URL — from a domain the site owner already trusts — that also links to the *source's* domain,
+raising confidence the mention isn't spam.
 
 ## Where the logic belongs
 
@@ -74,33 +114,47 @@ export interface VouchResult {
 
 export async function verifyVouch(
   vouchUrl: string,
-  target: string,
+  source: string,
+  isTrustedDomain: (hostname: string) => boolean | Promise<boolean>,
   options?: VerifyOptions,
 ): Promise<VouchResult>
 ```
 
-Fetches `vouchUrl` through the same `safeFetch` wrapper `verifySource` uses (SSRF-safe host
-checks, capped redirects, timeout). Extracts links the same way `extractLinks`/`sourceLinksTo`
-already do, but the match is **hostname equality** against `new URL(target).hostname`, not
-full-URL equality — i.e. any link on the vouch page pointing anywhere under the target's host
-counts ("links to the domain of the target," per the Vouch spec). Any fetch failure, non-2xx
+`isTrustedDomain` is required (not optional) at this function's level — a caller with no trust
+list should pass `() => false` explicitly, making "nothing is trusted" a decision the caller
+states rather than a default this function silently falls back to. Checks
+`isTrustedDomain(new URL(vouchUrl).hostname.toLowerCase())` **first, before any network
+access** — an untrusted vouch domain returns `{ verified: false }` immediately, no fetch. Only
+for a trusted domain does it fetch `vouchUrl` through the same `safeFetch` wrapper
+`verifySource` uses (SSRF-safe host checks, capped redirects, timeout) and check — via
+`extractLinks`, hostname equality against `new URL(source).hostname`, not full-URL equality —
+whether the fetched page links anywhere under the **source's** host. Any fetch failure, non-2xx
 status, or oversized/unreadable body yields `{ verified: false }`; the function never throws.
+
+### `WebmentionConfig` (`index.ts`)
+
+Add `isTrustedVouchDomain?: (hostname: string) => boolean | Promise<boolean>`. Omitted →
+`createWebmentionQueueConsumer` passes `() => false` into `verifyVouch` (see above) — no
+config, no trust, matching "an empty or unprovisioned trust list means nothing is trusted
+yet," not "everything is."
 
 ### Queue consumer (`index.ts` — `createWebmentionQueueConsumer`)
 
 Vouch verification only runs when the *primary* `verifySource` check already succeeded — vouch
 never overrides or substitutes for the source→target link check, which remains the hard gate.
-When `job.vouch` is present and the mention verifies, call `verifyVouch(job.vouch, target, …)`
-and store the outcome as `vouch: { url: job.vouch, verified }` on the mention passed to
-`inbox.store()`.
+When `job.vouch` is present and the mention verifies, call
+`verifyVouch(job.vouch, source, config.isTrustedVouchDomain ?? (() => false), …)` and store the
+outcome as `vouch: { url: job.vouch, verified }` on the mention passed to `inbox.store()`.
 
 Three resulting states on a stored mention:
 
 - `vouch` absent — no signal sent (today's behavior, unchanged).
-- `vouch.verified === true` — vouched: the vouch URL really does link to the target's domain.
-- `vouch.verified === false` — vouch attempted but didn't check out (unreachable, or doesn't
-  link to the domain). Arguably a *stronger* spam signal than no vouch at all — a forged vouch
-  attempt — so it's tracked distinctly rather than collapsed into "absent."
+- `vouch.verified === true` — vouched: the vouch domain is trusted, and the vouch page really
+  does link to the source's domain.
+- `vouch.verified === false` — vouch attempted but didn't check out (untrusted domain,
+  unreachable, or doesn't link to the source). Arguably a *stronger* spam signal than no vouch
+  at all — a forged vouch attempt — so it's tracked distinctly rather than collapsed into
+  "absent."
 
 ### `VerifiedMention` / `inbox.ts`
 
@@ -124,17 +178,48 @@ Add `VouchVerified` to `WebmentionLogEvent`, logged/counted the same way
 ### Testing (sidecar)
 
 - `verify.test.ts`: `verifyVouch` — verified true/false cases, unreachable URL, non-HTML body,
-  hostname-vs-exact-URL matching (subdomain/path variations under the target host all count).
+  hostname-vs-exact-URL matching against the **source** (subdomain/path variations under the
+  source host all count); an untrusted vouch domain returns `verified: false` **without any
+  fetch call** (assert the fetch mock is never invoked); a trusted domain whose page doesn't
+  link back to the source still returns `verified: false`.
 - `inbox.test.ts`: additive migration creates the two columns on a pre-existing table; round-trip
   of `vouch` through `store()`/`list()`; absence of `vouch` on `store()` leaves both columns null.
 - `index.test.ts`: queue consumer only calls `verifyVouch` when `verifySource` succeeded; a
   vouch-verification failure does not affect whether the mention itself is stored/removed;
-  malformed `vouch` form field is dropped, not rejected (still enqueues without `vouch`).
+  malformed `vouch` form field is dropped, not rejected (still enqueues without `vouch`);
+  `config.isTrustedVouchDomain` is threaded through to `verifyVouch`, and its absence defaults
+  to always-untrusted (not always-trusted).
 
 Release via the existing `.changeset/` flow (`pnpm changeset` → later, a dedicated `pnpm
-changeset version` release run) — see the version note above.
+changeset version` release run) — see the version note above. This trust-list fix is a
+**follow-up commit on top of the already-merged [#505](https://github.com/davidwkeith/workers/pull/505)**,
+not a further edit to that PR — its own changeset, its own review.
 
 ## App side (Anglesite)
+
+### `BlogrollTrustSync.swift` / `BlogrollTrustKVClient.swift` (new)
+
+Structurally identical to `ContactsAllowlistSync.swift`/`ContactsAllowlistKVClient.swift`
+(#1567): `BlogrollTrustSync.push(entries:client:)` reads every `blogroll` content-collection
+entry's `url`, extracts `URL(string: url)!.host` for each, and calls
+`BlogrollTrustKVClient.putTrustedDomains(_:)` — a whole-set-replace `PUT` of the sorted array
+to `SOCIAL_KV` under key `vouch:trusted-domains`, same namespace `#1567` already provisions.
+`BlogrollTrustSync.pushIfConfigured(...)` mirrors `ContactsAllowlistSync.pushIfConfigured`'s
+no-op-unless-provisioned guard. Called once, from `DeployModel`, alongside the existing
+`ContactsAllowlistSync.pushIfConfigured` call — deploy-time only, self-healing on every deploy
+like its precedent, no immediate-on-edit trigger needed for a list this loosely time-sensitive.
+
+### `worker/vouch-trust.ts` (new)
+
+Structurally identical to `reader-identity.ts`'s `readAllowlist`/`isAllowedReader`: reads
+`SOCIAL_KV` key `vouch:trusted-domains` (JSON array of hostnames), returns an empty
+`ReadonlySet<string>` for a missing binding, missing key, or malformed JSON — never throws.
+Exports `isTrustedVouchDomain(env, hostname): Promise<boolean>`. `worker.ts`'s
+`handleWebmentionQueue` passes `(hostname) => isTrustedVouchDomain(env, hostname)` as
+`WebmentionConfig.isTrustedVouchDomain` when building the queue consumer — `env` is already in
+scope there (unlike `createWebmentionQueueConsumer`'s module-level call sites elsewhere, this
+one is built per-invocation inside the handler function, so the real per-request `SOCIAL_KV`
+binding is available to close over).
 
 ### `WebmentionInboxD1Client.swift`
 
@@ -204,18 +289,27 @@ deleting the snapshot file, same as any other unwanted interaction today.
   rejects a non-http(s) `vouch.url` (same `httpUrl` guard as `source`/`target`).
 - Swift: extend `ReceivedInteractionSync` test coverage (wherever `makeInteraction(from:)` is
   currently exercised) with vouched / unverified-vouch / no-vouch D1 rows.
-- Manual: build the template locally, confirm the badge renders correctly for all three states
-  and that existing snapshots (no `vouch` key) still render unchanged.
+- Swift: `BlogrollTrustSyncTests`/`BlogrollTrustKVClientTests` mirroring the existing
+  `ContactsAllowlistSync`/`ContactsAllowlistKVClient` test suites — empty blogroll pushes an
+  empty array (not a no-op skip), duplicate hostnames across entries dedupe, an unprovisioned
+  `SOCIAL_KV` no-ops without a network call.
+- `worker/vouch-trust.test.ts` mirroring `reader-identity.ts`'s existing allowlist tests:
+  missing binding, missing key, malformed JSON all return `false`/empty set, never throw.
+- Manual: build the template locally, confirm the badge renders correctly for a
+  trust-list-verified vouch and that existing snapshots (no `vouch` key) still render unchanged.
 
 ## Sequencing
 
 1. Sidecar PR in `davidwkeith/workers`: `verifyVouch`, `WebmentionJob.vouch`, queue-consumer
    wiring, `inbox.ts` columns, tests. **Done:**
-   [davidwkeith/workers#505](https://github.com/davidwkeith/workers/pull/505), merged. A
-   correctness follow-up is pending — see "Known issue" above — before step 2 starts.
-2. Anglesite PR: bump `@dwk/webmention` to whatever version the sidecar's release run actually
-   publishes in `Resources/Template/package.json`, then the five app-side changes above (D1
-   client, Swift model, sync, Zod schema, Astro render) with their tests. `Closes #1597`.
+   [davidwkeith/workers#505](https://github.com/davidwkeith/workers/pull/505), merged.
+2. Sidecar follow-up PR: the trust-list fix above (`isTrustedDomain` parameter, source-domain
+   match, `WebmentionConfig.isTrustedVouchDomain`) — a new commit/PR on top of #505, not a
+   further edit to it. Must merge and publish before step 3.
+3. Anglesite PR: bump `@dwk/webmention` to whatever version the sidecar's release run actually
+   publishes in `Resources/Template/package.json`, then the seven app-side changes above (D1
+   client, Swift model, sync, Zod schema, Astro render, `BlogrollTrustSync`/`KVClient`,
+   `worker/vouch-trust.ts`) with their tests. `Closes #1597`.
 
 ## Non-goals
 
@@ -224,3 +318,6 @@ deleting the snapshot file, same as any other unwanted interaction today.
 - No interaction with #963's audience-limited posting — that controls who can *see* restricted
   posts; Vouch is about trust-scoring *inbound* mentions on otherwise-public content (per the
   issue's own "Not in scope" note).
+- No dedicated vouch-trust UI or separate curated list — reuses the blogroll as-is. An owner who
+  wants a different trust set than their public reading list can't get one without also changing
+  their blogroll; revisit only if that turns out to matter in practice.

--- a/docs/superpowers/specs/2026-08-20-vouch-webmention-design.md
+++ b/docs/superpowers/specs/2026-08-20-vouch-webmention-design.md
@@ -1,0 +1,193 @@
+# Vouch protocol for webmention spam mitigation (#1597)
+
+Status: approved for implementation
+Repos touched: `davidwkeith/workers` (`@dwk/webmention`), `Anglesite/Anglesite` (this repo)
+
+## Problem
+
+Anglesite receives and verifies inbound Webmentions (`Resources/Template/worker/worker.ts`
+→ `@dwk/webmention`), but link-verification (source really links to target) is the only
+trust signal. There's no [Vouch](https://indieweb.org/Vouch) support: an optional sender-supplied
+URL that, when it also links to the target's domain, raises confidence the mention isn't spam.
+
+## Where the logic belongs
+
+The fetch-and-verify pipeline — receive → enqueue → `verifySource` → inbox store — lives
+entirely in `@dwk/webmention` (published from the sibling `davidwkeith/workers` monorepo).
+`Resources/Template/worker/worker.ts` only composes it (`createWebmention`,
+`createWebmentionQueueConsumer`, `createD1Inbox`). Vouch verification (fetch a URL, check it
+links to a domain) is structurally identical to the existing `verifySource` check, so it
+belongs in the same package, following the same pattern already used for RSVP
+(`rsvp.ts`) and mf2 enrichment (`enrich.ts`): an optional signal added to the job → checked
+in the queue consumer → stored on `VerifiedMention` → additive D1 column.
+
+This ships as a paired change across both repos — the same shape as the existing
+anglesite-skills MCP pairing documented in `AGENTS.md` ▸ "Two-repo coordination": sidecar
+ships first in a tagged release, then the app PR consumes it.
+
+Current pinned version in `Resources/Template/package.json` is `@dwk/webmention@1.0.0-beta.1`
+(confirmed against `origin/main` of `davidwkeith/workers`, which is 5 commits ahead of the
+locally checked-out branch). The sidecar change ships as the next prerelease,
+`1.0.0-beta.2`.
+
+## Sidecar: `@dwk/webmention` (davidwkeith/workers)
+
+### `WebmentionJob`
+
+Add `readonly vouch?: string` — the raw vouch URL from the form POST. Optional field on a
+Queue message body is backward-compatible (older/newer consumers both tolerate its absence).
+
+### Receive handler (`index.ts` — `createWebmention`)
+
+Read the `vouch` form field alongside `source`/`target`. If present but not a syntactically
+valid `http(s)` URL (same check `validateWebmentionParams` already applies to
+`source`/`target`), **drop it silently** — proceed as if no vouch was supplied. Vouch is a
+supplementary trust signal per spec, not a hard requirement; a malformed vouch parameter must
+never turn into a whole-mention rejection. This mirrors the issue's own framing ("flag it...
+rather than rejecting outright").
+
+### `verifyVouch` (new, `verify.ts`)
+
+```ts
+export interface VouchResult {
+  readonly verified: boolean;
+}
+
+export async function verifyVouch(
+  vouchUrl: string,
+  target: string,
+  options?: VerifyOptions,
+): Promise<VouchResult>
+```
+
+Fetches `vouchUrl` through the same `safeFetch` wrapper `verifySource` uses (SSRF-safe host
+checks, capped redirects, timeout). Extracts links the same way `extractLinks`/`sourceLinksTo`
+already do, but the match is **hostname equality** against `new URL(target).hostname`, not
+full-URL equality — i.e. any link on the vouch page pointing anywhere under the target's host
+counts ("links to the domain of the target," per the Vouch spec). Any fetch failure, non-2xx
+status, or oversized/unreadable body yields `{ verified: false }`; the function never throws.
+
+### Queue consumer (`index.ts` — `createWebmentionQueueConsumer`)
+
+Vouch verification only runs when the *primary* `verifySource` check already succeeded — vouch
+never overrides or substitutes for the source→target link check, which remains the hard gate.
+When `job.vouch` is present and the mention verifies, call `verifyVouch(job.vouch, target, …)`
+and store the outcome as `vouch: { url: job.vouch, verified }` on the mention passed to
+`inbox.store()`.
+
+Three resulting states on a stored mention:
+
+- `vouch` absent — no signal sent (today's behavior, unchanged).
+- `vouch.verified === true` — vouched: the vouch URL really does link to the target's domain.
+- `vouch.verified === false` — vouch attempted but didn't check out (unreachable, or doesn't
+  link to the domain). Arguably a *stronger* spam signal than no vouch at all — a forged vouch
+  attempt — so it's tracked distinctly rather than collapsed into "absent."
+
+### `VerifiedMention` / `inbox.ts`
+
+```ts
+readonly vouch?: { readonly url: string; readonly verified: boolean };
+```
+
+Two new D1 columns via the existing `ADDED_COLUMNS` additive-migration list (same mechanism
+already used for `rsvp`, `id`, the mf2 columns): `vouch_url TEXT`, `vouch_verified INTEGER`
+(0/1, nullable). `store()`/`list()` extended to round-trip the nested shape to/from the two flat
+columns.
+
+### Observability
+
+Add `VouchVerified` to `WebmentionLogEvent`, logged/counted the same way
+`VerifyCompleted` is today (sanitized host fields only).
+
+### Testing (sidecar)
+
+- `verify.test.ts`: `verifyVouch` — verified true/false cases, unreachable URL, non-HTML body,
+  hostname-vs-exact-URL matching (subdomain/path variations under the target host all count).
+- `inbox.test.ts`: additive migration creates the two columns on a pre-existing table; round-trip
+  of `vouch` through `store()`/`list()`; absence of `vouch` on `store()` leaves both columns null.
+- `index.test.ts`: queue consumer only calls `verifyVouch` when `verifySource` succeeded; a
+  vouch-verification failure does not affect whether the mention itself is stored/removed;
+  malformed `vouch` form field is dropped, not rejected (still enqueues without `vouch`).
+
+Release as `1.0.0-beta.2` via the existing `.changeset/` flow.
+
+## App side (Anglesite)
+
+### `WebmentionInboxD1Client.swift`
+
+Extend the `SELECT` (`WebmentionInboxD1Client.swift:81`) and `Mention` struct with
+`vouch_url`/`vouch_verified`, following the existing pattern for the mf2-enrichment columns
+(nullable, tolerated on rows written by older `@dwk/webmention` versions that predate these
+columns).
+
+### `ReceivedInteraction.swift`
+
+```swift
+public struct Vouch: Codable, Sendable, Equatable {
+    public let url: URL
+    public let verified: Bool
+}
+public let vouch: Vouch?
+```
+
+Threaded through `init`; no change to the sanitisation/validation contract (`id` regex,
+`gitPath`).
+
+### `ReceivedInteractionSync.swift`
+
+`makeInteraction(from:)` maps `mention.vouchURL`/`mention.vouchVerified` into
+`ReceivedInteraction.vouch` (both present → `Vouch`; either absent → `nil`).
+
+### `interactions.ts` (Zod schema)
+
+```ts
+vouch: z.object({ url: httpUrl, verified: z.boolean() }).optional(),
+```
+
+added to `interactionSchema`. `httpUrl` (the existing http(s)-only scheme guard) reused as-is.
+
+### `Interactions.astro`
+
+A small trust badge next to the author byline in comments (`.comments li`) and in the
+"Mentioned by" list — text, not an icon, consistent with the component's current no-emoji
+style:
+
+- `vouch` absent → no badge (unchanged rendering).
+- `vouch.verified === true` → `Vouched` badge.
+- `vouch.verified === false` → `Unverified vouch` badge.
+
+Not added to the facepile (likes/reposts render as bare avatars with no room for accompanying
+text; the `title` tooltip already carries author name and isn't extended for this).
+
+### No moderation queue
+
+The mention still flows through the exact same pipeline it does today — vouch state is a
+rendered signal only, not a gate. This matches the issue's own proposal and the existing
+`interactions.ts` doc comment ("moderation = delete the file"): an owner who sees an
+`Unverified vouch` badge (or wants to distrust unvouched mentions generally) moderates by
+deleting the snapshot file, same as any other unwanted interaction today.
+
+### Testing (app side)
+
+- `interactions.test.ts`: `parseInteractions` accepts/round-trips the optional `vouch` field;
+  rejects a non-http(s) `vouch.url` (same `httpUrl` guard as `source`/`target`).
+- Swift: extend `ReceivedInteractionSync` test coverage (wherever `makeInteraction(from:)` is
+  currently exercised) with vouched / unverified-vouch / no-vouch D1 rows.
+- Manual: build the template locally, confirm the badge renders correctly for all three states
+  and that existing snapshots (no `vouch` key) still render unchanged.
+
+## Sequencing
+
+1. Sidecar PR in `davidwkeith/workers`: `verifyVouch`, `WebmentionJob.vouch`, queue-consumer
+   wiring, `inbox.ts` columns, tests. Merge, tag, publish `1.0.0-beta.2`.
+2. Anglesite PR: bump `@dwk/webmention` to `1.0.0-beta.2` in
+   `Resources/Template/package.json`, then the five app-side changes above (D1 client, Swift
+   model, sync, Zod schema, Astro render) with their tests. `Closes #1597`.
+
+## Non-goals
+
+- No change to how `source`/`target` verification works — vouch is additive only.
+- No moderation queue / hold state — out of scope, see "No moderation queue" above.
+- No interaction with #963's audience-limited posting — that controls who can *see* restricted
+  posts; Vouch is about trust-scoring *inbound* mentions on otherwise-public content (per the
+  issue's own "Not in scope" note).


### PR DESCRIPTION
Part of #1597 — not closing it yet. This is the planning half only; the app-side implementation (Swift D1 client, ReceivedInteraction model, Zod schema, Astro render) is a follow-up PR blocked on a sidecar release (see below).

## Summary

- Design spec for IndieWeb Vouch support on inbound webmentions (`docs/superpowers/specs/2026-08-20-vouch-webmention-design.md`): where the verification logic belongs (the sidecar `@dwk/webmention` package, not this repo), the three-state trust model, and how it threads through to the rendered interaction.
- 10-task TDD implementation plan (`docs/superpowers/plans/2026-08-20-vouch-webmention.md`) split across the sidecar repo (`davidwkeith/workers`) and this one.
- Tasks 1–5 (the sidecar half) are already implemented and reviewed: [davidwkeith/workers#505](https://github.com/davidwkeith/workers/pull/505). Tasks 6–10 (this repo's D1 client, Swift model, sync, Zod schema, Astro badge) start once that PR merges and a tagged `@dwk/webmention` release publishes.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`. (The docs in this PR don't consume anything from a sidecar. The *future* app-side implementation PR this plan describes does depend on [davidwkeith/workers#505](https://github.com/davidwkeith/workers/pull/505) — a different sidecar than `anglesite-skills`, so neither checkbox here describes that relationship precisely; noted for the record rather than mis-checked.)
- [ ] This change **needs a paired PR** in `Anglesite/anglesite-skills` (MCP sidecar server).

## Test plan

- [ ] `swift test --package-path .` — N/A, docs-only change, no Swift/template code touched.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — N/A, same reason.
- [ ] Manual smoke — N/A, no runtime behavior in this PR.