### PR TITLE
fix(#1222): insertBlock silently dropped props on the real transport

### DIFF
--- a/Sources/AnglesiteCore/EditRouter.swift
+++ b/Sources/AnglesiteCore/EditRouter.swift
@@ -45,6 +45,23 @@ public struct EditReply: Sendable, Equatable, Encodable {
     /// routine refusal) should switch on this instead of substring-matching `message`, which is
     /// free-form prose the plugin is free to reword.
     public let reason: String?
+    /// Decoded from the apply_edit reply's `inverse.component.nodeId` — used ONLY to learn a
+    /// newly-inserted node's real (server-assigned) id, so a same-op attribute follow-up can
+    /// address it (see `SidecarWYSIWYGHostTransport.sendOp`, which issues `setAttr` calls for an
+    /// `insertBlock` op's dropped `props` because the sidecar's `insertBlock`/`insert-node` wire
+    /// schema has no attributes field at all). This is a narrow, explicitly-scoped exception, NOT
+    /// an adoption of the sidecar's general inverse-for-undo mechanism — that remains explicitly
+    /// out of scope (see
+    /// `docs/superpowers/plans/2026-08-19-wysiwyg-sidecar-backed-transport.md`'s "Design
+    /// decisions" section, decision 1). `nil` when the reply carries no `inverse` (most ops), or
+    /// its `component` sub-object has no `nodeId` (non-insert ops).
+    public let inverseNodeId: String?
+    /// Decoded from the apply_edit reply's `inverse.component.baseVersion` — the fresh
+    /// post-write content hash, present so a same-op attribute follow-up (see ``inverseNodeId``)
+    /// can chain a valid `baseVersion` into its own request without a second round-trip to
+    /// re-fetch the model. Same narrow-exception scope as ``inverseNodeId`` — not part of
+    /// general inverse-for-undo. `nil` under the same conditions as ``inverseNodeId``.
+    public let postWriteVersion: String?
 
     /// `replace-image-src` metadata: the final asset URLs the plugin wrote, which the overlay
     /// swaps into the live `<img>` so the page reflects the edit without a full reload.
@@ -91,7 +108,9 @@ public struct EditReply: Sendable, Equatable, Encodable {
         op: String? = nil,
         model: ComponentModel? = nil,
         reason: String? = nil,
-        newFile: String? = nil
+        newFile: String? = nil,
+        inverseNodeId: String? = nil,
+        postWriteVersion: String? = nil
     ) {
         self.id = id
         self.status = status
@@ -105,6 +124,8 @@ public struct EditReply: Sendable, Equatable, Encodable {
         self.model = model
         self.reason = reason
         self.newFile = newFile
+        self.inverseNodeId = inverseNodeId
+        self.postWriteVersion = postWriteVersion
     }
 }
 

--- a/Sources/AnglesiteCore/MCPApplyEditRouter.swift
+++ b/Sources/AnglesiteCore/MCPApplyEditRouter.swift
@@ -115,7 +115,9 @@ public struct MCPApplyEditRouter: EditRouter {
                 commit: parsed?.commit,
                 result: parsed?.result,
                 model: parsed?.model,
-                newFile: parsed?.newFile
+                newFile: parsed?.newFile,
+                inverseNodeId: parsed?.inverseNodeId,
+                postWriteVersion: parsed?.postWriteVersion
             )
             if let persistEdit {
                 do {
@@ -211,8 +213,24 @@ public struct MCPApplyEditRouter: EditRouter {
         // Present on `anglesite:edit-failed` bodies (e.g. "stale", "no-match", "invalid-input") —
         // the machine-readable counterpart to the free-form `detail` prose folded into `message`.
         let reason = json["reason"] as? String
-        if file == nil && commit == nil && image == nil && newFile == nil && model == nil && reason == nil { return nil }
-        return Parsed(file: file, commit: commit, result: image, newFile: newFile, model: model, reason: reason)
+        // `inverse.component.{nodeId, baseVersion}` — a narrow, explicitly-scoped decode (see
+        // `EditReply.inverseNodeId`/`postWriteVersion`'s doc comments): NOT general
+        // inverse-for-undo support, only enough to learn a freshly-inserted node's real id +
+        // fresh version for `SidecarWYSIWYGHostTransport`'s attribute follow-up. `inverse` is
+        // absent for ops that don't compute one, and its `component` sub-object may lack either
+        // key — decode defensively, `nil` on any shape mismatch, never throw.
+        var inverseNodeId: String?
+        var postWriteVersion: String?
+        if let inverse = json["inverse"] as? [String: Any],
+           let inverseComponent = inverse["component"] as? [String: Any] {
+            inverseNodeId = inverseComponent["nodeId"] as? String
+            postWriteVersion = inverseComponent["baseVersion"] as? String
+        }
+        if file == nil && commit == nil && image == nil && newFile == nil && model == nil && reason == nil
+            && inverseNodeId == nil && postWriteVersion == nil { return nil }
+        return Parsed(
+            file: file, commit: commit, result: image, newFile: newFile, model: model, reason: reason,
+            inverseNodeId: inverseNodeId, postWriteVersion: postWriteVersion)
     }
 
     struct Parsed: Equatable {
@@ -222,5 +240,7 @@ public struct MCPApplyEditRouter: EditRouter {
         let newFile: String?
         let model: ComponentModel?
         let reason: String?
+        let inverseNodeId: String?
+        let postWriteVersion: String?
     }
 }

--- a/Sources/AnglesiteCore/WYSIWYG/SidecarWYSIWYGHostTransport.swift
+++ b/Sources/AnglesiteCore/WYSIWYG/SidecarWYSIWYGHostTransport.swift
@@ -81,7 +81,32 @@ public actor SidecarWYSIWYGHostTransport: WYSIWYGHostTransport {
     ///
     /// `props` is a `[String: PropValue]` dictionary — iteration order isn't guaranteed, but each
     /// `setAttr` call targets a distinct attribute name independently, so that's harmless here.
+    ///
+    /// `.null`-valued props (`PropValue.null` — `PageModelBlockAdapter` maps every valueless HTML
+    /// attribute, e.g. `disabled`/`required`/`open`/`checked`, to this case) are skipped entirely
+    /// rather than sent as a `setAttr`: `WYSIWYGOpTranslator.stringValue(.null)` is `nil`, and
+    /// `setAttr`'s `value: nil` means "remove this attribute" (its own doc comment) — but the
+    /// node was JUST inserted with no attributes at all, so the sidecar refuses that as
+    /// `no-match` (nothing to remove), which would otherwise fail the whole insert. There is no
+    /// wire-level way to *add* a valueless/boolean attribute through `insertBlock` or `setAttr`
+    /// (`setAttr`'s `value: nil` only ever means "remove," never "add present-with-no-value"), so
+    /// this is the same lossy-but-non-destructive tradeoff `stringValue`'s own doc comment already
+    /// applies to `.object`/`.array` — the attribute is silently dropped for this op family, not
+    /// destructively mishandled. (`stringValue` itself must keep mapping `.null` → `nil` — it's
+    /// shared with `WYSIWYGOpTranslator.translate`'s `setProp` case, where `.null` legitimately
+    /// means "remove this EXISTING attribute" and has to keep working; the skip belongs here, at
+    /// the insert-follow-up call site, not inside `stringValue`.)
     private func applyPropsFollowUp(_ props: [String: PropValue], insertReply: EditReply, requestId: String) async -> OpResult? {
+        // Drop `.null` props BEFORE the nodeId/version guard below — a block whose props are all
+        // `.null` (e.g. duplicating `<button disabled>`, which carries only the one boolean
+        // attribute) needs no follow-up `setAttr` calls at all, so it must not fail just because
+        // the insert reply happened not to carry an `inverseNodeId`/`postWriteVersion` that
+        // nothing here would actually use.
+        let attributeProps = props.filter { _, value in
+            if case .null = value { return false }
+            return true
+        }
+        guard !attributeProps.isEmpty else { return nil }
         guard let nodeId = insertReply.inverseNodeId, let initialVersion = insertReply.postWriteVersion else {
             return .rejected(
                 reason: .hostError,
@@ -92,7 +117,7 @@ public actor SidecarWYSIWYGHostTransport: WYSIWYGHostTransport {
             )
         }
         var baseVersion = initialVersion
-        for (index, (name, value)) in props.enumerated() {
+        for (index, (name, value)) in attributeProps.enumerated() {
             let setMessage = ComponentStructureEditBuilder.setAttr(
                 id: "\(requestId)-attr-\(index)", path: path, baseVersion: baseVersion,
                 nodeId: nodeId, name: name, value: WYSIWYGOpTranslator.stringValue(value))

--- a/Sources/AnglesiteCore/WYSIWYG/SidecarWYSIWYGHostTransport.swift
+++ b/Sources/AnglesiteCore/WYSIWYG/SidecarWYSIWYGHostTransport.swift
@@ -30,6 +30,11 @@ public actor SidecarWYSIWYGHostTransport: WYSIWYGHostTransport {
         let reply = await editRouter.apply(message)
         switch reply.status {
         case .applied:
+            if case .insertBlock(_, _, _, _, let block) = envelope.op, !block.props.isEmpty {
+                if let rejection = await applyPropsFollowUp(block.props, insertReply: reply, requestId: envelope.id) {
+                    return rejection
+                }
+            }
             do {
                 let fresh = try await pageModelClient.fetch(path: path)
                 rootId = fresh.tree.id
@@ -53,6 +58,59 @@ public actor SidecarWYSIWYGHostTransport: WYSIWYGHostTransport {
             // path). Treat defensively as a host error rather than force-unwrapping an assumption.
             return .rejected(reason: .hostError, message: "unexpected reply status: \(reply.status)", freshModel: nil)
         }
+    }
+
+    /// The sidecar's `insertBlock`/`insert-node` wire schema has NO attributes field at all
+    /// (`apply-edit-schema.mjs`'s `componentEditSchema`, confirmed against
+    /// `server/component-structure-edit.mjs`'s `applyInsertNode`) — so a `.insertBlock` op whose
+    /// `block.props` is non-empty can't carry those attributes in the insert call itself. This
+    /// issues one `setAttr` follow-up per prop instead, addressed at the newly-inserted node's
+    /// REAL (server-assigned) id — learned from `insertReply.inverseNodeId`, a narrow,
+    /// explicitly-scoped decode of the insert reply's `inverse.component.nodeId` (see
+    /// `EditReply`'s doc comments — this is NOT an adoption of the sidecar's general
+    /// inverse-for-undo mechanism, which stays out of scope per the plan doc's design decision
+    /// 1). `baseVersion` chains forward from each successive reply's own `postWriteVersion`
+    /// (`inverse.component.baseVersion`, stamped by the sidecar's dispatcher with the file's
+    /// POST-write hash) so each follow-up targets the file's actual current version rather than
+    /// the now-stale version the insert itself was sent with.
+    ///
+    /// Returns a `.rejected` result — honest about exactly what did and didn't land — the moment
+    /// anything about the follow-up can't proceed: the insert reply didn't carry enough
+    /// information to address the new node, or a `setAttr` call itself failed. Returns `nil` when
+    /// every prop's `setAttr` landed, so the caller proceeds to its normal re-fetch+adapt path.
+    ///
+    /// `props` is a `[String: PropValue]` dictionary — iteration order isn't guaranteed, but each
+    /// `setAttr` call targets a distinct attribute name independently, so that's harmless here.
+    private func applyPropsFollowUp(_ props: [String: PropValue], insertReply: EditReply, requestId: String) async -> OpResult? {
+        guard let nodeId = insertReply.inverseNodeId, let initialVersion = insertReply.postWriteVersion else {
+            return .rejected(
+                reason: .hostError,
+                message: "The block was inserted, but its attributes could not be set — the "
+                    + "preview server's reply didn't include enough information to address the "
+                    + "new block.",
+                freshModel: nil
+            )
+        }
+        var baseVersion = initialVersion
+        for (index, (name, value)) in props.enumerated() {
+            let setMessage = ComponentStructureEditBuilder.setAttr(
+                id: "\(requestId)-attr-\(index)", path: path, baseVersion: baseVersion,
+                nodeId: nodeId, name: name, value: WYSIWYGOpTranslator.stringValue(value))
+            let setReply = await editRouter.apply(setMessage)
+            guard setReply.status == .applied else {
+                return .rejected(
+                    reason: .hostError,
+                    message: "The block was inserted, but setting its \"\(name)\" attribute "
+                        + "failed: \(setReply.message ?? "unknown error"). The block now exists "
+                        + "with only the attributes applied before this failure.",
+                    freshModel: nil
+                )
+            }
+            if let nextVersion = setReply.postWriteVersion {
+                baseVersion = nextVersion
+            }
+        }
+        return nil
     }
 
     public func onModelUpdate(_ listener: @escaping @Sendable (BlockModel) -> Void) async -> () -> Void {

--- a/Sources/AnglesiteCore/WYSIWYG/WYSIWYGOpTranslator.swift
+++ b/Sources/AnglesiteCore/WYSIWYG/WYSIWYGOpTranslator.swift
@@ -89,7 +89,11 @@ public enum WYSIWYGOpTranslator {
     /// into a string rather than dropping to `nil`: lossy (the wire has no structured-value
     /// slot for this op family) but non-destructive, and round-trippable by re-parsing the JSON
     /// text back out on read.
-    private static func stringValue(_ value: PropValue) -> String? {
+    ///
+    /// Package-visible (not `private`) so `SidecarWYSIWYGHostTransport` can reuse the same
+    /// `PropValue` → wire-string mapping for its `insertBlock`-props `setAttr` follow-up calls
+    /// (see that type's `sendOp`) instead of duplicating this logic.
+    static func stringValue(_ value: PropValue) -> String? {
         switch value {
         case .string(let s): return s
         case .number(let n):

--- a/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
@@ -126,6 +126,43 @@ struct MCPApplyEditRouterTests {
         #expect(reply.result == nil)
     }
 
+    @Test("Structured reply with inverse exposes inverseNodeId and postWriteVersion")
+    func structuredReplyWithInverseExposesInverseFields() async {
+        // insertBlock's reply carries a computed `inverse: {op: "deleteBlock", component: {path,
+        // nodeId, baseVersion}}` — `baseVersion` here is the POST-write hash the dispatcher
+        // stamps in (see server/apply-edit-dispatcher.mjs). The router must decode just
+        // `nodeId`/`baseVersion` out of it, narrowly, without adopting the rest of `inverse` as a
+        // general mechanism (see EditRouter.swift's EditReply doc comments).
+        let body = #"{"type":"anglesite:edit-applied","id":"e-1","file":"src/pages/about.astro","range":{"start":12,"end":25},"commit":"abc1234567890abcdef1234567890abcdef12345","inverse":{"op":"deleteBlock","component":{"path":"src/pages/about.astro","nodeId":"n42","baseVersion":"sha256:postwrite111"}}}"#
+        let recorder = ToolCallRecorder(result: .success(MCPClient.ToolCallResult(
+            content: [.init(type: "text", text: body)],
+            isError: false
+        )))
+        let router = MCPApplyEditRouter(toolCaller: { try await recorder.call(name: $0, arguments: $1) })
+        let reply = await router.apply(sampleMessage)
+        #expect(reply.status == .applied)
+        #expect(reply.inverseNodeId == "n42")
+        #expect(reply.postWriteVersion == "sha256:postwrite111")
+    }
+
+    @Test("Structured reply with no inverse key decodes nil inverseNodeId/postWriteVersion")
+    func structuredReplyWithNoInverseDecodesNilInverseFields() async {
+        // Most ops' replies (and this one, a plain edit-applied body) carry no `inverse` key at
+        // all — the decode must not throw or misbehave, and the reply's other structured fields
+        // (`commit` here) must still decode normally alongside the nil inverse fields.
+        let body = #"{"type":"anglesite:edit-applied","id":"e-1","file":"src/pages/about.astro","range":{"start":12,"end":25},"commit":"abc1234567890abcdef1234567890abcdef12345"}"#
+        let recorder = ToolCallRecorder(result: .success(MCPClient.ToolCallResult(
+            content: [.init(type: "text", text: body)],
+            isError: false
+        )))
+        let router = MCPApplyEditRouter(toolCaller: { try await recorder.call(name: $0, arguments: $1) })
+        let reply = await router.apply(sampleMessage)
+        #expect(reply.status == .applied)
+        #expect(reply.commit == "abc1234567890abcdef1234567890abcdef12345")
+        #expect(reply.inverseNodeId == nil)
+        #expect(reply.postWriteVersion == nil)
+    }
+
     @Test("Malformed reply text falls back to message string") func malformedReplyTextFallsBackToMessageString() async {
         let recorder = ToolCallRecorder(result: .success(MCPClient.ToolCallResult(
             content: [.init(type: "text", text: "not valid json {")],

--- a/Tests/AnglesiteCoreTests/SidecarWYSIWYGHostTransportTests.swift
+++ b/Tests/AnglesiteCoreTests/SidecarWYSIWYGHostTransportTests.swift
@@ -210,6 +210,60 @@ struct SidecarWYSIWYGHostTransportTests {
         #expect(editRouter.messages.count == 2)
     }
 
+    // Review finding (Important): PageModelBlockAdapter maps every valueless HTML attribute
+    // (disabled/required/open/checked/...) to PropValue.null, and duplicateSelectedBlock — the
+    // motivating caller for this whole fix — copies props verbatim. Sending a setAttr for a
+    // .null prop would ask to REMOVE an attribute that was never on the just-inserted node,
+    // which the sidecar refuses as no-match — wrongly failing the whole insert. .null props must
+    // be skipped, not sent, while non-null props in the same insert still go through normally.
+    @Test func insertBlockSkipsNullValuedPropsButSendsOthers() async {
+        let pageModelClient = PageModelClient(toolCaller: { _, _ in
+            let data = try! JSONEncoder().encode(emptyPageModel(version: "sha256:fresh333333"))
+            return MCPClient.ToolCallResult(content: [.init(type: "text", text: String(data: data, encoding: .utf8))], isError: false)
+        })
+        let insertReply = EditReply(id: "req-9", status: .applied, message: nil, inverseNodeId: "n42", postWriteVersion: "sha256:postwrite1")
+        let classReply = EditReply(id: "req-9-attr-0", status: .applied, message: nil, postWriteVersion: "sha256:postwrite2")
+        let editRouter = SequencedEditRouter(replies: [insertReply, classReply])
+        let transport = SidecarWYSIWYGHostTransport(path: "src/pages/index.astro", pageModelClient: pageModelClient, editRouter: editRouter, rootId: "n0")
+
+        // A duplicated `<button class="cta" disabled>` — `disabled` decodes as PropValue.null.
+        let content = BlockNodeContent(
+            kind: .element, componentName: "button", props: ["class": .string("cta"), "disabled": .null],
+            slots: [:], sourceSpan: [0, 0], richText: nil)
+        let op = Op.insertBlock(parentId: rootParentID, slot: "default", index: 0, newId: "n9", block: content)
+        let result = await transport.sendOp(OpEnvelope(id: "req-9", targetVersion: "sha256:stale000000", op: op))
+
+        guard case .applied(let model) = result else { Issue.record("expected .applied, got \(result)"); return }
+        #expect(model.version == "sha256:fresh333333")
+        // Insert + exactly ONE follow-up (for "class") — "disabled" must never generate a setAttr.
+        #expect(editRouter.messages.count == 2)
+        let followUp = editRouter.messages[1]
+        #expect(followUp.op == EditMessage.Op.setAttr)
+        #expect(attrValue(followUp, "name") == .string("class"))
+    }
+
+    // A block whose props are ALL .null (e.g. duplicating an element with only boolean
+    // attributes, like `<hr hidden>`) needs no setAttr follow-up at all — it must succeed even
+    // though the insert reply below carries no inverseNodeId/postWriteVersion, proving the
+    // nodeId/version guard is only enforced when a follow-up would actually be sent.
+    @Test func insertBlockWithOnlyNullPropsIssuesNoFollowUpAndSucceeds() async {
+        let pageModelClient = PageModelClient(toolCaller: { _, _ in
+            let data = try! JSONEncoder().encode(emptyPageModel(version: "sha256:fresh444444"))
+            return MCPClient.ToolCallResult(content: [.init(type: "text", text: String(data: data, encoding: .utf8))], isError: false)
+        })
+        let insertReply = EditReply(id: "req-10", status: .applied, message: nil) // no inverseNodeId/postWriteVersion
+        let editRouter = SequencedEditRouter(replies: [insertReply])
+        let transport = SidecarWYSIWYGHostTransport(path: "src/pages/index.astro", pageModelClient: pageModelClient, editRouter: editRouter, rootId: "n0")
+
+        let content = BlockNodeContent(kind: .element, componentName: "hr", props: ["hidden": .null], slots: [:], sourceSpan: [0, 0], richText: nil)
+        let op = Op.insertBlock(parentId: rootParentID, slot: "default", index: 0, newId: "n9", block: content)
+        let result = await transport.sendOp(OpEnvelope(id: "req-10", targetVersion: "sha256:stale000000", op: op))
+
+        guard case .applied(let model) = result else { Issue.record("expected .applied, got \(result)"); return }
+        #expect(model.version == "sha256:fresh444444")
+        #expect(editRouter.messages.count == 1)
+    }
+
     // Regression guard: an insertBlock with EMPTY props must behave exactly as before this fix —
     // a single insert call, no setAttr follow-ups, straight through to the re-fetch.
     @Test func insertBlockWithEmptyPropsIssuesNoFollowUp() async {

--- a/Tests/AnglesiteCoreTests/SidecarWYSIWYGHostTransportTests.swift
+++ b/Tests/AnglesiteCoreTests/SidecarWYSIWYGHostTransportTests.swift
@@ -21,9 +21,30 @@ struct SidecarWYSIWYGHostTransportTests {
         }
     }
 
+    /// Returns a canned reply for each successive `apply` call, in order, and records every
+    /// message it was asked to apply — lets a test drive a multi-call sequence (insert, then N
+    /// `setAttr` follow-ups) and inspect each wire payload in turn.
+    final class SequencedEditRouter: EditRouter, @unchecked Sendable {
+        private var replies: [EditReply]
+        private(set) var messages: [EditMessage] = []
+        init(replies: [EditReply]) { self.replies = replies }
+        func apply(_ message: EditMessage) async -> EditReply {
+            messages.append(message)
+            guard !replies.isEmpty else {
+                return EditReply(id: message.id, status: .failed, message: "SequencedEditRouter ran out of canned replies")
+            }
+            return replies.removeFirst()
+        }
+    }
+
     private func emptyPageModel(version: String) -> PageModel {
         PageModel(version: version, path: "src/pages/index.astro",
             tree: .init(id: "n0", kind: .fragment, tag: nil, attrs: [], span: .init(start: 0, end: 0), loc: nil, text: nil, children: [], block: nil))
+    }
+
+    private func attrValue(_ message: EditMessage, _ key: String) -> JSONValue? {
+        guard case .object(let component)? = message.component else { return nil }
+        return component[key]
     }
 
     @Test func appliedOpRefetchesAndAdaptsFreshModel() async {
@@ -89,5 +110,124 @@ struct SidecarWYSIWYGHostTransportTests {
         }
         #expect(component["parentId"] == .string("n0"))
         #expect(component["parentId"] != .string(rootParentID))
+    }
+
+    // Confirmed bug (WYSIWYGOpTranslator.swift line 114 review comment): `ComponentStructureEditBuilder.NodeSpec`
+    // carries no attributes field, so an insertBlock's `block.props` was silently dropped on the
+    // wire. The sidecar's insert schema has no attributes field either (server/apply-edit-schema.mjs's
+    // componentEditSchema) — the only fix is a `setAttr` follow-up per prop, addressed at the real
+    // node id the insert reply's `inverse.component.nodeId` reveals.
+    @Test func insertBlockWithPropsIssuesOneSetAttrFollowUpPerProp() async {
+        let pageModelClient = PageModelClient(toolCaller: { _, _ in
+            let data = try! JSONEncoder().encode(emptyPageModel(version: "sha256:fresh999999"))
+            return MCPClient.ToolCallResult(content: [.init(type: "text", text: String(data: data, encoding: .utf8))], isError: false)
+        })
+        let insertReply = EditReply(id: "req-5", status: .applied, message: nil, inverseNodeId: "n42", postWriteVersion: "sha256:postwrite1")
+        let classReply = EditReply(id: "req-5-attr-0", status: .applied, message: nil, postWriteVersion: "sha256:postwrite2")
+        let idReply = EditReply(id: "req-5-attr-1", status: .applied, message: nil, postWriteVersion: "sha256:postwrite3")
+        let editRouter = SequencedEditRouter(replies: [insertReply, classReply, idReply])
+        let transport = SidecarWYSIWYGHostTransport(path: "src/pages/index.astro", pageModelClient: pageModelClient, editRouter: editRouter, rootId: "n0")
+
+        let content = BlockNodeContent(
+            kind: .element, componentName: "section", props: ["class": .string("hero"), "id": .string("top")],
+            slots: [:], sourceSpan: [0, 0], richText: nil)
+        let op = Op.insertBlock(parentId: rootParentID, slot: "default", index: 0, newId: "n9", block: content)
+        let result = await transport.sendOp(OpEnvelope(id: "req-5", targetVersion: "sha256:stale000000", op: op))
+
+        guard case .applied = result else { Issue.record("expected .applied, got \(result)"); return }
+        #expect(editRouter.messages.count == 3)
+        #expect(editRouter.messages[0].op == EditMessage.Op.insertBlock)
+
+        let followUps = Array(editRouter.messages.dropFirst())
+        #expect(followUps.allSatisfy { $0.op == EditMessage.Op.setAttr })
+        // Every follow-up targets the REAL node id from the insert reply's inverse, not the
+        // app-side `newId` sentinel from the op.
+        #expect(followUps.allSatisfy { attrValue($0, "nodeId") == .string("n42") })
+
+        let names = Set(followUps.compactMap { message -> String? in
+            if case .string(let name)? = attrValue(message, "name") { return name }
+            return nil
+        })
+        #expect(names == ["class", "id"])
+
+        // baseVersion chains forward through each successive reply's own postWriteVersion rather
+        // than reusing the insert's version for every follow-up.
+        let versions = followUps.compactMap { message -> String? in
+            if case .string(let v)? = attrValue(message, "baseVersion") { return v }
+            return nil
+        }
+        #expect(versions.first == "sha256:postwrite1")
+        #expect(versions.last == "sha256:postwrite2")
+    }
+
+    @Test func insertBlockAppliedButMissingInverseNodeIdRejectsWithoutFollowUp() async {
+        let pageModelClient = PageModelClient(toolCaller: { _, _ in
+            Issue.record("should not re-fetch when attribute follow-up cannot proceed")
+            return MCPClient.ToolCallResult(content: [], isError: false)
+        })
+        // Applied, but no inverseNodeId/postWriteVersion — the sidecar didn't give us enough to
+        // address the new node.
+        let insertReply = EditReply(id: "req-6", status: .applied, message: nil)
+        let editRouter = SequencedEditRouter(replies: [insertReply])
+        let transport = SidecarWYSIWYGHostTransport(path: "src/pages/index.astro", pageModelClient: pageModelClient, editRouter: editRouter, rootId: "n0")
+
+        let content = BlockNodeContent(kind: .element, componentName: "section", props: ["class": .string("hero")], slots: [:], sourceSpan: [0, 0], richText: nil)
+        let op = Op.insertBlock(parentId: rootParentID, slot: "default", index: 0, newId: "n9", block: content)
+        let result = await transport.sendOp(OpEnvelope(id: "req-6", targetVersion: "sha256:stale000000", op: op))
+
+        guard case .rejected(let reason, let message, let freshModel) = result else { Issue.record("expected .rejected, got \(result)"); return }
+        #expect(reason == .hostError)
+        #expect(message?.isEmpty == false)
+        #expect(freshModel == nil)
+        // Only the insert call happened — no follow-up was attempted with a missing node id.
+        #expect(editRouter.messages.count == 1)
+    }
+
+    @Test func insertBlockFollowUpSetAttrFailureRejectsAndStopsImmediately() async {
+        let pageModelClient = PageModelClient(toolCaller: { _, _ in
+            Issue.record("should not re-fetch when a follow-up setAttr fails")
+            return MCPClient.ToolCallResult(content: [], isError: false)
+        })
+        let insertReply = EditReply(id: "req-7", status: .applied, message: nil, inverseNodeId: "n42", postWriteVersion: "sha256:postwrite1")
+        let failedSetAttr = EditReply(id: "req-7-attr-0", status: .failed, message: "stale")
+        // A second canned reply that must NEVER be consumed if the transport really stops
+        // immediately after the first follow-up fails.
+        let neverReached = EditReply(id: "req-7-attr-1", status: .applied, message: nil, postWriteVersion: "sha256:unreached")
+        let editRouter = SequencedEditRouter(replies: [insertReply, failedSetAttr, neverReached])
+        let transport = SidecarWYSIWYGHostTransport(path: "src/pages/index.astro", pageModelClient: pageModelClient, editRouter: editRouter, rootId: "n0")
+
+        let content = BlockNodeContent(
+            kind: .element, componentName: "section", props: ["only-prop": .string("value")],
+            slots: [:], sourceSpan: [0, 0], richText: nil)
+        let op = Op.insertBlock(parentId: rootParentID, slot: "default", index: 0, newId: "n9", block: content)
+        let result = await transport.sendOp(OpEnvelope(id: "req-7", targetVersion: "sha256:stale000000", op: op))
+
+        guard case .rejected(let reason, let message, let freshModel) = result else { Issue.record("expected .rejected, got \(result)"); return }
+        #expect(reason == .hostError)
+        #expect(message?.contains("only-prop") == true)
+        #expect(freshModel == nil)
+        // Insert + the one failed follow-up — the second prop's setAttr must never be sent.
+        #expect(editRouter.messages.count == 2)
+    }
+
+    // Regression guard: an insertBlock with EMPTY props must behave exactly as before this fix —
+    // a single insert call, no setAttr follow-ups, straight through to the re-fetch.
+    @Test func insertBlockWithEmptyPropsIssuesNoFollowUp() async {
+        let pageModelClient = PageModelClient(toolCaller: { _, _ in
+            let data = try! JSONEncoder().encode(emptyPageModel(version: "sha256:fresh222222"))
+            return MCPClient.ToolCallResult(content: [.init(type: "text", text: String(data: data, encoding: .utf8))], isError: false)
+        })
+        let insertReply = EditReply(id: "req-8", status: .applied, message: nil)
+        let editRouter = SequencedEditRouter(replies: [insertReply])
+        let transport = SidecarWYSIWYGHostTransport(path: "src/pages/index.astro", pageModelClient: pageModelClient, editRouter: editRouter, rootId: "n0")
+
+        let content = BlockNodeContent(kind: .text, componentName: "p", props: [:], slots: [:], sourceSpan: [0, 0], richText: nil)
+        let op = Op.insertBlock(parentId: rootParentID, slot: "default", index: 0, newId: "n9", block: content)
+        let result = await transport.sendOp(OpEnvelope(id: "req-8", targetVersion: "sha256:stale000000", op: op))
+
+        guard case .applied(let model) = result else { Issue.record("expected .applied, got \(result)"); return }
+        #expect(model.version == "sha256:fresh222222")
+        #expect(editRouter.messages.count == 1)
+        #expect(editRouter.messages[0].op == EditMessage.Op.insertBlock)
     }
 }


### PR DESCRIPTION
Follow-up to #1603 (merged) — that PR's own review found this bug, but a fix and one subsequent fix-round landed on the PR branch *after* it had already been merged (GitHub's PR head-SHA tracking got stuck and silently stopped picking up pushes — confirmed via the commits API showing the branch's real tip while the PR object stayed on an older SHA). Neither of these two commits ever reached `main`. Cherry-picked cleanly onto current `main`; no other changes.

## Summary

- `WYSIWYGOpTranslator.nodeSpec(for:)` translated an `Op.insertBlock`'s props into a `ComponentStructureEditBuilder.NodeSpec` that has no attributes field at all — the sidecar's `insertBlock`/`insert-node` wire schema genuinely can't carry attributes on insert (verified directly against `anglesite-skills/server/component-structure-edit.mjs`). Attributes silently vanished on every real insert with props — most visibly on `WYSIWYGCanvasController.duplicateSelectedBlock()` (⌘D), which explicitly copies `node.props` expecting the duplicate to keep them.
- Fixed by threading `inverse.component.nodeId`/`baseVersion` through `EditReply` (a narrow, explicitly-scoped exception to the plan's "don't consume server-computed inverse" decision — used only to learn a newly-inserted node's real id/fresh version, not for undo) and having `SidecarWYSIWYGHostTransport` issue one follow-up `setAttr` per prop after a successful insert. Fails loudly, never silently, if the follow-up info is missing or a prop fails to apply.
- A second review round caught a regression in that fix: boolean/valueless HTML attributes (`disabled`, `required`, etc. — `PropValue.null`) were sent as "remove this attribute" on a node that was never given one, hard-failing the whole insert. Fixed by skipping `.null`-valued props in the follow-up (no wire-level way to add a valueless attribute here anyway — same lossy-but-non-destructive tradeoff already applied to `.object`/`.array` props).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills):

## Test plan

- [x] `swift test --package-path .` (on top of current `main`, not the stale PR branch) — 664/664 passing, exit 0.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not yet run in this environment; these two commits already passed the app build once as part of #1603's own review before the PR-sync issue, and touch only `AnglesiteCore`.
- [ ] Manual smoke — not performed in this environment. Recommend: duplicate (⌘D) a block with a plain attribute (e.g. `class`) and confirm it survives; duplicate one with a boolean attribute (e.g. `disabled`) and confirm the insert still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)