### PR TITLE
fix(#714): dismiss website inspector before pane switch

### DIFF
--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -94,8 +94,18 @@ struct SiteWindow: View {
                 // alone would leave Dock ▸ New Site a silent no-op on such launches (#522 review).
                 let openWindow = openWindow
                 WindowRouter.shared.openSitesWindow = { openWindow(id: "sites") }
+                // The model's seam back into this view's presentation state — see
+                // `SiteWindowModel.dismissWebsiteInspector`. Stored once, like the router closure
+                // above: `@State`/`@SceneStorage` read and write through storage that outlives any
+                // single `body` evaluation, so a closure captured here stays bound to this
+                // window's live state for its whole lifetime.
+                model.dismissWebsiteInspector = { hideWebsiteInspectorForPaneSwitch() }
             }
             .onDisappear {
+                // Break the seam before teardown: the closure captures this view value, which
+                // holds `_model`'s storage, so leaving it installed would keep the whole
+                // `SiteWindowModel` (and its preview/runtime graph) alive past window close.
+                model.dismissWebsiteInspector = nil
                 let terminationLease = unsavedEditsTerminationLease
                 unsavedEditsTerminationLease = nil
                 model.close(suddenTerminationLease: terminationLease)
@@ -250,6 +260,27 @@ struct SiteWindow: View {
         activeInspector = outcome.active
         inspectorShown = outcome.shown
         syncWebsiteInspectorPresented()
+    }
+
+    /// Hides the website inspector ahead of a main-pane swap — the implementation behind
+    /// `SiteWindowModel.dismissWebsiteInspector` (#714 v2 slice 1 fix round 5).
+    ///
+    /// Goes through `activateInspector` rather than writing `inspectorShown` directly, so this
+    /// dismissal is indistinguishable from a second ⌥⌘J press: `InspectorActivationPolicy`
+    /// resolves target == current + shown to a plain hide, `syncWebsiteInspectorPresented()` runs
+    /// in the same transaction, and the panel comes straight back on the next ⌥⌘J because
+    /// `activeInspector` stays `.website`.
+    ///
+    /// Deliberately does *not* arm `suppressNextInspectorWriteBack`: that flag exists to swallow a
+    /// write-back queued under an activation the user has since switched *away* from, and this is
+    /// not a kind switch. The write-back SwiftUI posts for this collapse re-reads
+    /// `activeInspector == .website` — still true — and writes `inspectorShown = false`, which is
+    /// the value this method just wrote. Suppressing it would change nothing; arming the flag for
+    /// an idempotent write-back would only risk swallowing a genuine one.
+    @MainActor
+    private func hideWebsiteInspectorForPaneSwitch() {
+        guard inspectorShown, activeInspector == .website else { return }
+        activateInspector(.website)
     }
 
     /// Sets `suppressNextInspectorWriteBack` for one run-loop turn — see its doc comment. Called
@@ -1238,7 +1269,30 @@ struct SiteWindow: View {
             }
         case .website:
             Group {
-                if let websiteModel = model.websiteInspector {
+                if !inspectorShown {
+                    // Render nothing while the panel is hidden or collapsing — a leaf, not an empty
+                    // branch, so the `.task(id:)` below still attaches (fix round 4, Important 3).
+                    //
+                    // The selection branch above gets this for free: its content is
+                    // `inspectorContext`, which the dismissal path clears synchronously, so its
+                    // column always animates closed over an empty subtree. The website panel's
+                    // model deliberately outlives its presentation (it holds unsaved edits), so
+                    // without this gate the whole `Form` stays mounted inside a column animating to
+                    // zero width — and a `Form` on macOS is bridged through an
+                    // `AppKitPlatformViewHost`, which invalidates layout from inside the display
+                    // cycle's commit phase. `-[NSWindow _postWindowNeedsUpdateConstraints]` then
+                    // raises, and the rethrown ObjC exception aborts the process (#1126 class).
+                    //
+                    // Verified live, both directions (#714 v2 slice 1 fix round 5): with the
+                    // dismissal seam below but *without* this gate, six ⌘3/⌘1 pane switches
+                    // survived but Metadata ▸ More Settings… still aborted — the heavier `.plist`
+                    // editor rebuild lands while the collapse is still animating past the 300 ms
+                    // settle (crash report Anglesite-2026-08-20-131656.ips, faulting frames
+                    // `AppKitPlatformViewHost.invalidateLayout()` →
+                    // `-[NSView setNeedsUpdateConstraints:]` → `_postWindowNeedsUpdateConstraints`).
+                    // With the gate, the same sequence is clean.
+                    Color.clear.frame(width: 0, height: 0)
+                } else if let websiteModel = model.websiteInspector {
                     WebsiteInspectorView(
                         model: websiteModel,
                         openStylesheet: { model.openFile($0) },

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -41,6 +41,25 @@ struct SiteWindow: View {
     /// workaround — long enough for an already-queued stale write-back to land and be swallowed,
     /// short enough that a later, genuine write-back for the NEW activation isn't suppressed too.
     @State private var suppressNextInspectorWriteBack = false
+    /// Temporarily withholds the website inspector from the panel across a main-pane swap (#714 v2
+    /// slice 1 fix round 6) — the state behind `SiteWindowModel.setWebsiteInspectorSuspended`.
+    ///
+    /// Deliberately `@State`, not `@SceneStorage`: this is a transient, app-initiated *withholding*
+    /// of a panel the user still wants, not a change of their mind about it. Fix round 5 implemented
+    /// the same dismissal by routing through `activateInspector(.website)`, which wrote
+    /// `inspectorShown = false` into scene storage — so Metadata ▸ More Settings… (a button *inside*
+    /// the panel, whose `openFile` goes through `clearInspectorThenSwitchPane`) permanently closed
+    /// the panel and the closure survived relaunch, with no way back except ⌥⌘J. Suspension keeps
+    /// `inspectorShown`/`activeInspector` untouched, so the preference is preserved and the panel
+    /// returns on its own once the swap has settled.
+    ///
+    /// Set true by `suspendWebsiteInspector(_:)` before the pane swap and false by the same seam
+    /// after it — `SiteWindowModel.clearInspectorThenSwitchPane` owns both edges, because it is the
+    /// only place that knows when the swap actually completed. A `.onChange(of: model.mainPaneMode)`
+    /// here would have been the alternative signal, but it silently never fires when the swap
+    /// target equals the current mode (re-opening the already-open `Info.plist` editor is exactly
+    /// that case), which would strand the panel suspended until the next ⌥⌘J.
+    @State private var websiteInspectorSuspended = false
     /// The title shown in the content-delete confirmation dialog. Held separately from
     /// `model.deleteConfirmation` so the title stays stable through the dismiss animation —
     /// mirrors `SiteNavigatorView`'s `candidateToDeleteTitle` for the same reason.
@@ -95,17 +114,17 @@ struct SiteWindow: View {
                 let openWindow = openWindow
                 WindowRouter.shared.openSitesWindow = { openWindow(id: "sites") }
                 // The model's seam back into this view's presentation state — see
-                // `SiteWindowModel.dismissWebsiteInspector`. Stored once, like the router closure
-                // above: `@State`/`@SceneStorage` read and write through storage that outlives any
-                // single `body` evaluation, so a closure captured here stays bound to this
-                // window's live state for its whole lifetime.
-                model.dismissWebsiteInspector = { hideWebsiteInspectorForPaneSwitch() }
+                // `SiteWindowModel.setWebsiteInspectorSuspended`. Stored once, like the router
+                // closure above: `@State`/`@SceneStorage` read and write through storage that
+                // outlives any single `body` evaluation, so a closure captured here stays bound to
+                // this window's live state for its whole lifetime.
+                model.setWebsiteInspectorSuspended = { suspendWebsiteInspector($0) }
             }
             .onDisappear {
                 // Break the seam before teardown: the closure captures this view value, which
                 // holds `_model`'s storage, so leaving it installed would keep the whole
                 // `SiteWindowModel` (and its preview/runtime graph) alive past window close.
-                model.dismissWebsiteInspector = nil
+                model.setWebsiteInspectorSuspended = nil
                 let terminationLease = unsavedEditsTerminationLease
                 unsavedEditsTerminationLease = nil
                 model.close(suddenTerminationLease: terminationLease)
@@ -155,6 +174,9 @@ struct SiteWindow: View {
         // restoration landing `activeInspector == .website` before either toggle func ever runs.
         .onChange(of: inspectorShown, initial: true) { _, _ in syncWebsiteInspectorPresented() }
         .onChange(of: activeInspector, initial: true) { _, _ in syncWebsiteInspectorPresented() }
+        // The third input to `websiteInspectorVisible`. `suspendWebsiteInspector(_:)` already syncs
+        // in its own transaction; this is the same catch-all backstop as the two above.
+        .onChange(of: websiteInspectorSuspended) { _, _ in syncWebsiteInspectorPresented() }
         .onChange(of: model.preview.state) { _, newState in
             model.previewStateChanged(newState)
         }
@@ -262,25 +284,34 @@ struct SiteWindow: View {
         syncWebsiteInspectorPresented()
     }
 
-    /// Hides the website inspector ahead of a main-pane swap — the implementation behind
-    /// `SiteWindowModel.dismissWebsiteInspector` (#714 v2 slice 1 fix round 5).
+    /// Withholds the website inspector across a main-pane swap, then puts it back — the
+    /// implementation behind `SiteWindowModel.setWebsiteInspectorSuspended` (#714 v2 slice 1 fix
+    /// round 6, replacing round 5's hide).
     ///
-    /// Goes through `activateInspector` rather than writing `inspectorShown` directly, so this
-    /// dismissal is indistinguishable from a second ⌥⌘J press: `InspectorActivationPolicy`
-    /// resolves target == current + shown to a plain hide, `syncWebsiteInspectorPresented()` runs
-    /// in the same transaction, and the panel comes straight back on the next ⌥⌘J because
-    /// `activeInspector` stays `.website`.
+    /// Writes only `websiteInspectorSuspended`, never `inspectorShown`/`activeInspector`: the
+    /// user's persisted choice to have this panel open is not what the pane swap is trying to
+    /// change (see `websiteInspectorSuspended`'s doc comment for the regression that motivated
+    /// the distinction). Because the preference is untouched, resuming is the whole restore — the
+    /// panel returns to exactly the state it was in, which is also why the answer to "does it come
+    /// back?" is *yes, automatically*: More Settings… and ⌘3 should not silently close a panel the
+    /// user opened, and re-opening it by hand every time would be worse UX than the brief blink.
     ///
-    /// Deliberately does *not* arm `suppressNextInspectorWriteBack`: that flag exists to swallow a
+    /// Suspending is idempotent and only meaningful while the panel is actually up; resuming is
+    /// unconditional, so a stray resume can never leave the flag stuck true.
+    ///
+    /// Deliberately does *not* arm `suppressNextInspectorWriteBack`. That flag swallows a
     /// write-back queued under an activation the user has since switched *away* from, and this is
-    /// not a kind switch. The write-back SwiftUI posts for this collapse re-reads
-    /// `activeInspector == .website` — still true — and writes `inspectorShown = false`, which is
-    /// the value this method just wrote. Suppressing it would change nothing; arming the flag for
-    /// an idempotent write-back would only risk swallowing a genuine one.
+    /// not a kind switch. The collapse SwiftUI posts here is handled instead by the
+    /// `websiteInspectorSuspended` guard in `inspectorPresented`'s setter, which covers the whole
+    /// suspension window rather than a single run-loop turn — the suspension outlives one turn by
+    /// design (it spans the pane swap plus a settle).
     @MainActor
-    private func hideWebsiteInspectorForPaneSwitch() {
-        guard inspectorShown, activeInspector == .website else { return }
-        activateInspector(.website)
+    private func suspendWebsiteInspector(_ suspended: Bool) {
+        if suspended {
+            guard inspectorShown, activeInspector == .website else { return }
+        }
+        websiteInspectorSuspended = suspended
+        syncWebsiteInspectorPresented()
     }
 
     /// Sets `suppressNextInspectorWriteBack` for one run-loop turn — see its doc comment. Called
@@ -292,14 +323,27 @@ struct SiteWindow: View {
         DispatchQueue.main.async { suppressNextInspectorWriteBack = false }
     }
 
+    /// Whether the website inspector is on screen right now: the user's persisted activation, minus
+    /// any transient pane-swap suspension. The single source the `.inspector(isPresented:)`
+    /// binding, the model mirror, and `inspectorContent`'s panel gate all read, so those three
+    /// can't drift apart (they must agree, or the panel renders content into a collapsing column —
+    /// the #1126-class abort the gate exists to prevent).
+    ///
+    /// Not what the View menu's Show/Hide Website Inspector state reads: that reflects the
+    /// *preference* (`inspectorShown && activeInspector == .website`), which a sub-second
+    /// suspension shouldn't flicker.
+    private var websiteInspectorVisible: Bool {
+        inspectorShown && activeInspector == .website && !websiteInspectorSuspended
+    }
+
     /// Mirrors the website inspector's actual presented state onto the model — see
     /// `SiteWindowModel.websiteInspectorPresented`'s doc comment. Called synchronously by both
-    /// toggle funcs above and by `coreBody`'s `.onChange` (for the other paths that can flip
-    /// `inspectorShown`/`activeInspector`: `SiteSearchFieldModifier`'s programmatic dismiss,
-    /// scene restoration).
+    /// toggle funcs above, by `suspendWebsiteInspector(_:)`, and by `coreBody`'s `.onChange` (for
+    /// the other paths that can flip `inspectorShown`/`activeInspector`:
+    /// `SiteSearchFieldModifier`'s programmatic dismiss, scene restoration).
     @MainActor
     private func syncWebsiteInspectorPresented() {
-        model.websiteInspectorPresented = inspectorShown && activeInspector == .website
+        model.websiteInspectorPresented = websiteInspectorVisible
     }
 
     @ViewBuilder
@@ -313,16 +357,24 @@ struct SiteWindow: View {
         // uses, not a copy that could drift out of sync.
         let inspectorPresented = Binding(
             get: {
-                inspectorShown && (activeInspector == .website || model.inspectorSelection != nil)
+                websiteInspectorVisible
+                    || (inspectorShown && activeInspector == .selection && model.inspectorSelection != nil)
             },
             set: { newValue in
                 // Swallow a write-back scheduled under an activation that's since been switched
                 // away from — see `suppressNextInspectorWriteBack`'s doc comment (#714 v2 slice 1
                 // fix round 1, Important 1).
                 guard !suppressNextInspectorWriteBack else { return }
-                // Website inspector always has content, so its show/hide is always an explicit
-                // user choice. Selection keeps the #968 guard: never persist an auto-hide
-                // caused by a transient-nil selection.
+                // Same idea, for the collapse that a pane-swap suspension triggers: the panel goes
+                // away because the app withheld it for one transaction, not because the user closed
+                // it, so persisting the resulting `isPresented = false` would turn a temporary
+                // suspension into a permanent preference change — precisely the regression fix
+                // round 5 shipped by routing the dismissal through `activateInspector` (#714 v2
+                // slice 1 fix round 6, Important 1).
+                guard !websiteInspectorSuspended else { return }
+                // The website inspector always has content, so while it's the active panel a
+                // write-back really is the user's own show/hide. Selection keeps the #968 guard:
+                // never persist an auto-hide caused by a transient-nil selection.
                 if activeInspector == .website || model.inspectorSelection != nil {
                     inspectorShown = newValue
                 }
@@ -1269,9 +1321,10 @@ struct SiteWindow: View {
             }
         case .website:
             Group {
-                if !inspectorShown {
-                    // Render nothing while the panel is hidden or collapsing — a leaf, not an empty
-                    // branch, so the `.task(id:)` below still attaches (fix round 4, Important 3).
+                if !websiteInspectorVisible {
+                    // Render nothing while the panel is hidden, suspended, or collapsing — a leaf,
+                    // not an empty branch, so the `.task(id:)` below still attaches (fix round 4,
+                    // Important 3).
                     //
                     // The selection branch above gets this for free: its content is
                     // `inspectorContext`, which the dismissal path clears synchronously, so its
@@ -1291,6 +1344,22 @@ struct SiteWindow: View {
                     // `AppKitPlatformViewHost.invalidateLayout()` →
                     // `-[NSView setNeedsUpdateConstraints:]` → `_postWindowNeedsUpdateConstraints`).
                     // With the gate, the same sequence is clean.
+                    //
+                    // The gate cuts both ways in principle — leaving it *remounts* the `Form`, which
+                    // is #1139's own crash shape (a fresh inspector subtree mounting into a column
+                    // that's expanding) — but measurement says that half is not what bites here
+                    // (#714 v2 slice 1 fix round 6, Important 2). Holding the content back behind
+                    // its own settle was implemented and then reverted: with the mount deliberately
+                    // delayed to 4 s, the app was already pinned at 92% CPU in AppKit's
+                    // update-constraints cycle 0.5 s after the panel opened, i.e. the storm belongs
+                    // to the *column opening* over a heavy main pane, and the mount is a bystander.
+                    // See `SiteWindowModel.setWebsiteInspectorSuspended` for what that residual
+                    // (⌥⌘J with the Graph pane up, reproduced identically on this branch's parent)
+                    // does and does not have to do with this round.
+                    //
+                    // `clearInspectorThenSwitchPane` still resumes a suspension only after the pane
+                    // rebuild has settled, so the remount never lands in the same transaction as
+                    // the swap.
                     Color.clear.frame(width: 0, height: 0)
                 } else if let websiteModel = model.websiteInspector {
                     WebsiteInspectorView(

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -323,23 +323,48 @@ final class SiteWindowModel {
     /// main-pane swap, not just the selection one `inspectorSelection` already covers.
     var websiteInspectorPresented = false
 
-    /// Hides the website inspector panel, wired by `SiteWindow` to its own activation machinery.
+    /// Withholds the website inspector panel (`true`) and puts it back (`false`), wired by
+    /// `SiteWindow` to its own presentation state.
     ///
     /// Mirrors the existing `dismissSiteWindow` closure seam: presentation of the *website*
     /// inspector lives entirely in `SiteWindow`'s `@SceneStorage` (`inspectorShown` +
     /// `activeInspector`), which this model cannot reach — `websiteInspectorPresented` above is a
     /// read-only mirror, so before this seam existed the model could observe that panel but never
-    /// dismiss it. `clearInspectorThenSwitchPane` needs exactly that: its #1126 settle only helps
+    /// take it down. `clearInspectorThenSwitchPane` needs exactly that: its #1126 settle only helps
     /// if a dismissal has actually been started before it waits, and for the website panel there
     /// was none, so the main pane swapped underneath a still-presented inspector and re-entered
     /// AppKit's update-constraints pass (`_postWindowNeedsUpdateConstraints` abort, #714 v2 slice
     /// 1 fix round 5).
     ///
-    /// `SiteWindow` routes it through `InspectorActivationPolicy` (the same path as a second ⌥⌘J
-    /// press) so `websiteInspectorPresented` and the stale-write-back suppression flag stay
-    /// consistent with every other activation change.
+    /// Two-edged rather than one-shot (fix round 6). Round 5 hid the panel by routing through
+    /// `InspectorActivationPolicy`, which wrote the user's persisted `inspectorShown` preference to
+    /// false — so an in-panel button like Metadata ▸ More Settings… closed the panel for good,
+    /// across relaunches. The panel is now *suspended*: `SiteWindow` withholds it without touching
+    /// the preference, and this model — the only place that knows when the swap finished — resumes
+    /// it. Both edges therefore belong to one call site, `clearInspectorThenSwitchPane`.
+    ///
+    /// **Known residual, not introduced here.** Opening this panel's column while the *Graph* pane
+    /// is showing sends AppKit into the same runaway update-constraints cycle (100% CPU, then an
+    /// `__NSWindowGetDisplayCycleObserverForUpdateConstraints_block_invoke` →
+    /// `objc_exception_rethrow` abort — crash report `Anglesite-2026-08-20-152412.ips`). A/B
+    /// confirmed against this branch's parent commit, where a plain ⌥⌘J on the Graph pane aborts
+    /// identically, so it is the same #1126-class residual the round-5 notes already record for
+    /// the panel over the `.plist` settings editor, not a consequence of the suspension. It is
+    /// *reachable* through the restore above, though: round 5 hid the panel by writing the
+    /// preference off, which left nothing to reopen, and this round correctly puts it back. Six
+    /// ⌥⌘J toggles over the Preview pane never raise the CPU at all, so the trigger is the weight
+    /// of the main pane being relaid out beside the opening column. Fixing that belongs with the
+    /// Graph pane's own layout, not here.
+    ///
+    /// Only that method drives this seam. Other `mainPaneMode` writes (`applyNavigatorSelection`'s
+    /// `.route`/`.directory` returns to Preview, `openFile`'s "already the active editor" fast
+    /// path, `deleteCleanupCandidate`) swap the pane without it, so a presented website panel rides
+    /// those transitions live. They are left alone deliberately: they are synchronous, non-`async`
+    /// paths that would each need their own dismiss/settle/swap/resume sequence, which is a larger
+    /// change than this fix round takes on. If the #1126 class resurfaces on one of them, route it
+    /// through `clearInspectorThenSwitchPane` rather than growing a second seam.
     @ObservationIgnored
-    var dismissWebsiteInspector: (() -> Void)?
+    var setWebsiteInspectorSuspended: ((Bool) -> Void)?
 
     /// What the window inspector is inspecting, in precedence order. Component and collection are
     /// gated on the pane mode they belong to, so a stale value from an earlier selection can never
@@ -585,9 +610,27 @@ final class SiteWindowModel {
         // `websiteInspectorPresented` so this predicate still matches actual presentation
         // (fix round 1, Important 3).
         let wasInspecting = inspectorSelection != nil || websiteInspectorPresented
+        let suspendingWebsitePanel = websiteInspectorPresented
+        // Commit the website inspector's in-flight edit before its panel leaves the view tree.
+        // Its `TextField`s save on focus loss, and suspension unmounts them without ever
+        // delivering one, so a Title/Language typed-but-not-committed edit would be silently
+        // dropped by the pane switch (#714 v2 slice 1 fix round 6, Important 3). This is the same
+        // flush-before-leaving contract `leaveCurrentEditor()`/`leaveCurrentInspector()` give the
+        // other two dirty-able surfaces — done here rather than in `leaveCurrentInspector()`
+        // because the trigger is the *unmount*, which happens only on this path (the navigator's
+        // direct `mainPaneMode` writes leave the panel presented, so its fields keep their focus
+        // and their normal commit-on-blur).
+        //
+        // The result is deliberately ignored, unlike `leaveCurrentInspector()`'s: this model has
+        // no conflict-resolution flow (that belongs to `PlistEditorModel`, the deep editor), so a
+        // failed write surfaces as `saveError` inside the panel instead of vetoing a pane switch
+        // the user asked for — matching how `close()`/`handleSiteChanged()` already treat it.
+        if suspendingWebsitePanel, let websiteInspector, websiteInspector.isDirty {
+            await websiteInspector.saveAll()
+        }
         // Clearing `inspectorContext`/`collectionInspection` starts the *selection* inspector's
         // dismissal; the website inspector's presentation is scene state this model doesn't own,
-        // so it needs an explicit dismissal through `SiteWindow`'s seam — otherwise `settle()`
+        // so it needs an explicit suspension through `SiteWindow`'s seam — otherwise `settle()`
         // below waited out a dismissal that never began and the pane swapped under a genuinely
         // presented panel, which is the actual `_postWindowNeedsUpdateConstraints` abort (#1126
         // class) the smoke test hit via ⌥⌘J → ⌘3/⌘1 and via Metadata ▸ More Settings… (whose
@@ -599,13 +642,29 @@ final class SiteWindowModel {
         // ⌘3 still aborts in the same class (crash reports `Anglesite-2026-08-20-132733.ips`,
         // `-133259.ips`). The same switches with no website inspector presented survive, so the
         // remaining trigger is on this panel's side, not a general pane-switch defect.
-        if websiteInspectorPresented { dismissWebsiteInspector?() }
+        if suspendingWebsitePanel { setWebsiteInspectorSuspended?(true) }
         inspectorContext = nil
         collectionInspection = nil
         if wasInspecting {
             await AppKitConstraintStormMitigation.settle()
         }
         mainPaneMode = mode
+        // Put the panel back. The suspension is a temporary withholding, not a dismissal — the
+        // user's activation preference was never touched — so leaving it withheld would be the
+        // very regression this round fixes, only transient instead of persisted.
+        //
+        // Behind a second settle, and awaited rather than fired-and-forgotten: resuming remounts
+        // the panel's `Form` (`SiteWindow.inspectorContent`'s gate renders a zero-size leaf while
+        // suspended), and a fresh inspector subtree mounting into an expanding column *is* #1139's
+        // crash shape. Coalescing that remount with the pane rebuild above is the mirror image of
+        // the dismissal case this whole method exists for, and gets the same treatment `openFile`
+        // gives the Component Editor's inspector presentation: its own transaction, one settle
+        // later. Callers are already in a `Task`, so the extra 300 ms delays nothing on screen —
+        // the new pane is up and interactive throughout.
+        if suspendingWebsitePanel {
+            await AppKitConstraintStormMitigation.settle()
+            setWebsiteInspectorSuspended?(false)
+        }
     }
 
     /// Resolves a chat citation's file path to a Site Graph Explorer node and reveals it there
@@ -1448,6 +1507,12 @@ final class SiteWindowModel {
     @MainActor
     func openFile(_ file: FileRef) {
         if activeEditorFile?.id == file.id {
+            // Bypasses `clearInspectorThenSwitchPane`, so a presented website inspector is neither
+            // flushed nor suspended across this swap (see `setWebsiteInspectorSuspended`'s doc
+            // comment for the full list of such paths and why they're left as-is). Reachable via
+            // More Settings… when `Info.plist` is already the active editor but the pane has since
+            // returned to Preview. Left synchronous deliberately: routing it through the async
+            // sequence would also have to join `inFlightOpenFile`'s bookkeeping.
             mainPaneMode = .editor(file)
             return
         }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -323,6 +323,24 @@ final class SiteWindowModel {
     /// main-pane swap, not just the selection one `inspectorSelection` already covers.
     var websiteInspectorPresented = false
 
+    /// Hides the website inspector panel, wired by `SiteWindow` to its own activation machinery.
+    ///
+    /// Mirrors the existing `dismissSiteWindow` closure seam: presentation of the *website*
+    /// inspector lives entirely in `SiteWindow`'s `@SceneStorage` (`inspectorShown` +
+    /// `activeInspector`), which this model cannot reach — `websiteInspectorPresented` above is a
+    /// read-only mirror, so before this seam existed the model could observe that panel but never
+    /// dismiss it. `clearInspectorThenSwitchPane` needs exactly that: its #1126 settle only helps
+    /// if a dismissal has actually been started before it waits, and for the website panel there
+    /// was none, so the main pane swapped underneath a still-presented inspector and re-entered
+    /// AppKit's update-constraints pass (`_postWindowNeedsUpdateConstraints` abort, #714 v2 slice
+    /// 1 fix round 5).
+    ///
+    /// `SiteWindow` routes it through `InspectorActivationPolicy` (the same path as a second ⌥⌘J
+    /// press) so `websiteInspectorPresented` and the stale-write-back suppression flag stay
+    /// consistent with every other activation change.
+    @ObservationIgnored
+    var dismissWebsiteInspector: (() -> Void)?
+
     /// What the window inspector is inspecting, in precedence order. Component and collection are
     /// gated on the pane mode they belong to, so a stale value from an earlier selection can never
     /// shadow the current one after a pane toggle.
@@ -567,6 +585,21 @@ final class SiteWindowModel {
         // `websiteInspectorPresented` so this predicate still matches actual presentation
         // (fix round 1, Important 3).
         let wasInspecting = inspectorSelection != nil || websiteInspectorPresented
+        // Clearing `inspectorContext`/`collectionInspection` starts the *selection* inspector's
+        // dismissal; the website inspector's presentation is scene state this model doesn't own,
+        // so it needs an explicit dismissal through `SiteWindow`'s seam — otherwise `settle()`
+        // below waited out a dismissal that never began and the pane swapped under a genuinely
+        // presented panel, which is the actual `_postWindowNeedsUpdateConstraints` abort (#1126
+        // class) the smoke test hit via ⌥⌘J → ⌘3/⌘1 and via Metadata ▸ More Settings… (whose
+        // `openFile` on `Info.plist` routes here too, rebuilding the whole detail view as the
+        // heavyweight `.plist` settings editor). Both clears run before the single `settle()`, so
+        // the two dismissals share one SwiftUI transaction rather than stacking two waits.
+        //
+        // Not yet the whole story: with the panel presented *over* the `.plist` settings editor,
+        // ⌘3 still aborts in the same class (crash reports `Anglesite-2026-08-20-132733.ips`,
+        // `-133259.ips`). The same switches with no website inspector presented survive, so the
+        // remaining trigger is on this panel's side, not a general pane-switch defect.
+        if websiteInspectorPresented { dismissWebsiteInspector?() }
         inspectorContext = nil
         collectionInspection = nil
         if wasInspecting {

--- a/Tests/AnglesiteAppTests/InspectorActivationPolicyTests.swift
+++ b/Tests/AnglesiteAppTests/InspectorActivationPolicyTests.swift
@@ -81,12 +81,16 @@ struct InspectorActivationPolicyTests {
             current: .website, shown: false, target: .website).armSuppress)
     }
 
-    /// `SiteWindow.hideWebsiteInspectorForPaneSwitch()` (fix round 5) reuses this policy to dismiss
-    /// the website panel before a main-pane swap, so the pre-swap dismissal is exactly a
-    /// second-press hide. Pinned here because three things about that outcome are load-bearing:
-    /// it must hide (not switch kind), it must leave `active == .website` so the next ⌥⌘J brings
-    /// the same panel straight back, and it must not request a model for a panel that is going
-    /// away.
+    /// A second ⌥⌘J on the presented website panel. Pinned because three things about the outcome
+    /// are load-bearing: it must hide (not switch kind), it must leave `active == .website` so the
+    /// next ⌥⌘J brings the same panel straight back, and it must not request a model for a panel
+    /// that is going away.
+    ///
+    /// Note what does *not* come through here any more: fix round 5 dismissed the panel ahead of a
+    /// main-pane swap by reusing this policy, which meant an app-initiated, temporary withholding
+    /// wrote the user's persisted `inspectorShown` preference to false — More Settings… closed the
+    /// panel for good. Round 6 moved that to `SiteWindow.suspendWebsiteInspector(_:)`, which is
+    /// deliberately *not* an activation change and so has no business in this policy.
     @Test("dismissing the presented website panel is a plain hide that keeps it the active kind")
     func websiteDismissalIsAPlainHide() {
         let outcome = InspectorActivationPolicy.apply(

--- a/Tests/AnglesiteAppTests/InspectorActivationPolicyTests.swift
+++ b/Tests/AnglesiteAppTests/InspectorActivationPolicyTests.swift
@@ -80,4 +80,20 @@ struct InspectorActivationPolicyTests {
         #expect(!InspectorActivationPolicy.apply(
             current: .website, shown: false, target: .website).armSuppress)
     }
+
+    /// `SiteWindow.hideWebsiteInspectorForPaneSwitch()` (fix round 5) reuses this policy to dismiss
+    /// the website panel before a main-pane swap, so the pre-swap dismissal is exactly a
+    /// second-press hide. Pinned here because three things about that outcome are load-bearing:
+    /// it must hide (not switch kind), it must leave `active == .website` so the next ⌥⌘J brings
+    /// the same panel straight back, and it must not request a model for a panel that is going
+    /// away.
+    @Test("dismissing the presented website panel is a plain hide that keeps it the active kind")
+    func websiteDismissalIsAPlainHide() {
+        let outcome = InspectorActivationPolicy.apply(
+            current: .website, shown: true, target: .website)
+        #expect(outcome.shown == false)
+        #expect(outcome.active == .website)
+        #expect(!outcome.armSuppress)
+        #expect(!outcome.needsWebsiteModel)
+    }
 }

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -1602,6 +1602,49 @@ extension SiteWindowModelTests {
         #expect(onDiskAfter.entries == onDiskBefore.entries)
     }
 
+    /// The model half of File ▸ Save / Revert To ▸ Revert to Saved *enablement*, which the two
+    /// command structs spell as `hasUnsavedEdits != true || editCommandInFlight == true`
+    /// (`SaveCommands.swift`, `FileItemCommands.swift`). The sibling tests above cover what the
+    /// commands *do* once invoked; this pins that they are reachable at all when the website
+    /// inspector is the only dirty surface — including `requestRevertToSaved()`'s own guard, which
+    /// re-checks the same pair and would silently swallow the click if they disagreed.
+    ///
+    /// A GUI smoke reported this menu item as permanently disabled for a dirty inspector Title.
+    /// Re-running it live disproved that: the failing observation was made with no key window (in
+    /// the same screenshot, File ▸ Close, Save, Rename…, and Reveal in Finder were all disabled
+    /// too), so `@FocusedValue(\.siteWindowModel)` was nil and *every* window-scoped File item was
+    /// off — nothing to do with dirtiness. Kept as a regression pin for the enablement inputs,
+    /// which no test covered before.
+    @Test("File ▸ Save / Revert to Saved are enabled and reachable for a website-inspector-only dirty field")
+    func editCommandGateOpensForDirtyWebsiteInspector() async throws {
+        let (root, packageURL, _) = try makeSitePackage()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let model = makeModel()
+        model.site = SiteStore.Site(
+            id: "site-a", name: "Test", packageURL: packageURL,
+            isValid: true, missingSentinels: [], lastSeen: Date(), bookmarkData: nil
+        )
+        model.ensureWebsiteInspectorLoaded()
+        let inspector = try #require(model.websiteInspector)
+        await waitForWebsiteInspectorLoad(inspector)
+
+        // Clean: both items disabled, and the action is inert if a stale menu item fires anyway.
+        #expect(!model.hasUnsavedEdits)
+        model.requestRevertToSaved()
+        #expect(!model.revertConfirmationPresented)
+
+        // Dirty, with no main-pane editor and no selection inspector — the exact state the smoke
+        // exercised: the website inspector alone must open the gate.
+        inspector.title = "Dirty title, nothing else open"
+        #expect(model.activeEditor == nil)
+        #expect(model.inspectorContext == nil)
+        #expect(model.hasUnsavedEdits)
+        #expect(!model.editCommandInFlight)
+
+        model.requestRevertToSaved()
+        #expect(model.revertConfirmationPresented, "Revert to Saved must reach its confirmation")
+    }
+
     /// One half of the ordering contract every caller of `ensureWebsiteInspectorLoaded()` depends
     /// on: the model is non-nil the instant the call returns, with no suspension point in
     /// between, so a caller can flip `activeInspector`/`inspectorShown` in the very next statement
@@ -1713,5 +1756,48 @@ extension SiteWindowModelTests {
         #expect(!model.websiteInspectorPresented)
         model.handleSiteChanged()
         #expect(model.websiteInspector == nil)
+    }
+
+    /// Fix round 5, Critical: the #1126 settle in `clearInspectorThenSwitchPane` only buys a
+    /// separate SwiftUI transaction for a dismissal that has actually *started*. The website
+    /// inspector's presentation lives in `SiteWindow`'s scene storage, so nothing this model did
+    /// began one — the pane swapped under a presented panel and AppKit aborted in
+    /// `_postWindowNeedsUpdateConstraints`. This pins the ordering the fix restores: dismiss,
+    /// then settle, then swap.
+    @Test("a main-pane switch dismisses a presented website inspector before swapping the pane (fix round 5)")
+    func paneSwitchDismissesPresentedWebsiteInspectorFirst() async {
+        let model = makeModel()
+        model.websiteInspectorPresented = true
+
+        var dismissals = 0
+        var paneModeWhenDismissed: MainPaneMode?
+        model.dismissWebsiteInspector = { [unowned model] in
+            dismissals += 1
+            paneModeWhenDismissed = model.mainPaneMode
+            // What `SiteWindow.hideWebsiteInspectorForPaneSwitch()` mirrors back synchronously.
+            model.websiteInspectorPresented = false
+        }
+
+        #expect(await model.showGraph())
+
+        #expect(dismissals == 1)
+        #expect(paneModeWhenDismissed == .preview, "dismissal must precede the pane swap")
+        #expect(model.mainPaneMode == .graph)
+        #expect(!model.websiteInspectorPresented)
+    }
+
+    /// The complement: with the website panel hidden there is nothing to dismiss, so the seam
+    /// must stay untouched (calling it would *show* the panel — `activateInspector(.website)` on a
+    /// hidden panel is a show, which is why `SiteWindow`'s implementation guards too).
+    @Test("a main-pane switch leaves the website-inspector dismissal seam alone when it isn't presented (fix round 5)")
+    func paneSwitchSkipsDismissalWhenWebsiteInspectorHidden() async {
+        let model = makeModel()
+        var dismissals = 0
+        model.dismissWebsiteInspector = { dismissals += 1 }
+
+        #expect(await model.showGraph())
+
+        #expect(dismissals == 0)
+        #expect(model.mainPaneMode == .graph)
     }
 }

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -1762,42 +1762,86 @@ extension SiteWindowModelTests {
     /// separate SwiftUI transaction for a dismissal that has actually *started*. The website
     /// inspector's presentation lives in `SiteWindow`'s scene storage, so nothing this model did
     /// began one — the pane swapped under a presented panel and AppKit aborted in
-    /// `_postWindowNeedsUpdateConstraints`. This pins the ordering the fix restores: dismiss,
-    /// then settle, then swap.
-    @Test("a main-pane switch dismisses a presented website inspector before swapping the pane (fix round 5)")
-    func paneSwitchDismissesPresentedWebsiteInspectorFirst() async {
+    /// `_postWindowNeedsUpdateConstraints`. This pins the ordering the fix restores: suspend,
+    /// then settle, then swap — and (fix round 6) resume once the swap is done, so the panel the
+    /// user opened comes back on its own.
+    @Test("a main-pane switch suspends a presented website inspector, then restores it after the swap (fix round 6)")
+    func paneSwitchSuspendsPresentedWebsiteInspectorThenRestoresIt() async {
         let model = makeModel()
         model.websiteInspectorPresented = true
 
-        var dismissals = 0
-        var paneModeWhenDismissed: MainPaneMode?
-        model.dismissWebsiteInspector = { [unowned model] in
-            dismissals += 1
-            paneModeWhenDismissed = model.mainPaneMode
-            // What `SiteWindow.hideWebsiteInspectorForPaneSwitch()` mirrors back synchronously.
-            model.websiteInspectorPresented = false
+        var edges: [Bool] = []
+        var paneModeAtEdge: [MainPaneMode] = []
+        model.setWebsiteInspectorSuspended = { [unowned model] suspended in
+            edges.append(suspended)
+            paneModeAtEdge.append(model.mainPaneMode)
+            // What `SiteWindow.suspendWebsiteInspector(_:)` mirrors back synchronously.
+            model.websiteInspectorPresented = !suspended
         }
 
         #expect(await model.showGraph())
 
-        #expect(dismissals == 1)
-        #expect(paneModeWhenDismissed == .preview, "dismissal must precede the pane swap")
+        #expect(edges == [true, false], "the panel must be suspended and then put back")
+        #expect(paneModeAtEdge.first == .preview, "suspension must precede the pane swap")
+        #expect(paneModeAtEdge.last == .graph, "the restore must follow it")
         #expect(model.mainPaneMode == .graph)
-        #expect(!model.websiteInspectorPresented)
+        #expect(model.websiteInspectorPresented, "the user's panel must not be left withheld")
     }
 
-    /// The complement: with the website panel hidden there is nothing to dismiss, so the seam
-    /// must stay untouched (calling it would *show* the panel — `activateInspector(.website)` on a
-    /// hidden panel is a show, which is why `SiteWindow`'s implementation guards too).
-    @Test("a main-pane switch leaves the website-inspector dismissal seam alone when it isn't presented (fix round 5)")
-    func paneSwitchSkipsDismissalWhenWebsiteInspectorHidden() async {
+    /// The complement: with the website panel hidden there is nothing to withhold, so the seam
+    /// must stay untouched — including its restoring edge, which would otherwise clear a
+    /// suspension this switch never armed.
+    @Test("a main-pane switch leaves the website-inspector suspension seam alone when it isn't presented (fix round 5)")
+    func paneSwitchSkipsSuspensionWhenWebsiteInspectorHidden() async {
         let model = makeModel()
-        var dismissals = 0
-        model.dismissWebsiteInspector = { dismissals += 1 }
+        var edges: [Bool] = []
+        model.setWebsiteInspectorSuspended = { edges.append($0) }
 
         #expect(await model.showGraph())
 
-        #expect(dismissals == 0)
+        #expect(edges.isEmpty)
         #expect(model.mainPaneMode == .graph)
+    }
+
+    /// Fix round 6, Important 3: suspending the panel unmounts its `Form`, and a `TextField`
+    /// that never loses focus never commits — so a Title typed but not tabbed out of was silently
+    /// dropped by the pane switch. The flush has to land *before* the suspension, which the
+    /// `isDirty` reading taken inside the seam pins; the on-disk assertion (a second model loaded
+    /// from the same package) proves the flush was a real write, not just a state reset.
+    @Test("a main-pane switch flushes a dirty website inspector to disk before suspending it (fix round 6)")
+    func paneSwitchFlushesDirtyWebsiteInspector() async throws {
+        let (root, packageURL, _) = try makeSitePackage(named: "Flush")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let model = makeModel()
+        model.site = SiteStore.Site(
+            id: "site-a", name: "Flush", packageURL: packageURL,
+            isValid: true, missingSentinels: [], lastSeen: Date(), bookmarkData: nil
+        )
+        model.websiteInspectorPresented = true
+        model.ensureWebsiteInspectorLoaded()
+        let inspector = try #require(model.websiteInspector)
+        // `ensureWebsiteInspectorLoaded()` is synchronous by design and kicks its load off in a
+        // detached task; typing into the fields before that lands would just be overwritten.
+        while inspector.title != "Flush" { await Task.yield() }
+
+        // The unflushed edit: the field's binding is updated, its commit-on-blur never runs.
+        inspector.title = "Flushed By Pane Switch"
+        #expect(inspector.isDirty)
+
+        var dirtyWhenSuspended: Bool?
+        model.setWebsiteInspectorSuspended = { [unowned model] suspended in
+            if suspended, dirtyWhenSuspended == nil { dirtyWhenSuspended = inspector.isDirty }
+            model.websiteInspectorPresented = !suspended
+        }
+
+        #expect(await model.showGraph())
+
+        #expect(dirtyWhenSuspended == false, "the flush must precede the panel's unmount")
+        #expect(!inspector.isDirty)
+
+        let reloaded = WebsiteInspectorModel(packageURL: packageURL)
+        await reloaded.load()
+        #expect(reloaded.title == "Flushed By Pane Switch", "the edit never reached Info.plist")
     }
 }


### PR DESCRIPTION
Part of #714 (follow-up to #1595 — does not close the issue; v2 slices 2–4 remain).

## Summary

- Fixes the #1126-class crash (`_postWindowNeedsUpdateConstraints` abort) when the main pane switches while the Website inspector (⌥⌘J, shipped in #1595) is presented: `clearInspectorThenSwitchPane` awaited the constraint-storm settle but never started an actual dismissal — the panel's presentation lives in `@SceneStorage` on `SiteWindow`, unreachable from the model. Root cause independently traced by a peer session and corroborated by GUI smoke (repro: ⌥⌘J then ⌘3/⌘1, or Metadata ▸ More Settings…).
- The panel is now **suspended, not hidden**, across the swap: a `setWebsiteInspectorSuspended` model→view seam withholds it (transient `@State`, both edges owned by `clearInspectorThenSwitchPane`), a content gate avoids the teardown/remount storms in both directions, a dirty Title/Language is flushed to disk before leaving (matching the neighbouring surfaces' auto-save contract), and the panel returns on its own after the swap with the user's `@SceneStorage` preference intact.
- Adds policy/model tests (91 green in the touched suites) including dismiss-before-swap ordering, plain-hide policy semantics, pane-switch flush, and a revert-enablement pin.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> No MCP message-schema changes; template untouched.

## Test plan

- [x] `swift test --filter "SiteWindowModel|InspectorActivationPolicy"` — 91/91
- [x] `swift build` clean; Debug app build via `scripts/build-app.sh` clean
- [x] Manual smoke: ⌥⌘J → ⌘3/⌘1 alternation and More Settings… no longer crash; panel visibly suspends and returns; dirty title flushed to `Info.plist` before the swap; Revert to Saved verified end-to-end (the earlier "never enables" report was a false positive — the File menu had been read with no key window)

## Known-open (documented, out of scope here)

- Residual same-class crash on a narrower path: panel presented **over the `.plist` Settings editor** + ⌘3. Separable second ingredient (heavyweight main-pane teardown); tracked in the workspace ledger for a follow-up.
- A few direct `mainPaneMode` writes (e.g. `setPaneSelection` ⌘1/⌘2 fast paths) bypass the suspend seam; commented in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)